### PR TITLE
Add build and test badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Raid - Distributed Development Orchestration
+[![Build and Test](https://github.com/8bitAlex/raid/actions/workflows/build.yml/badge.svg)](https://github.com/8bitAlex/raid/actions/workflows/build.yml)
 [![codecov](https://codecov.io/github/8bitAlex/raid/graph/badge.svg?token=Z75V7I2TLW)](https://codecov.io/github/8bitAlex/raid)
 
 `Raid` is a configurable command-line application that orchestrates common development tasks, environments, and dependencies across distributed code repositories.


### PR DESCRIPTION
This pull request adds a build and test status badge to the top of the `README.md` file, making it easier for contributors to see the current build status directly from the project page.