### PR TITLE
Release prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,8 @@ brew install raid  # macOS — Linux and Windows coming soon
 First, create a profile file (see [Configuration](#configuration) below), then:
 
 ```bash
-raid profile add my-project.raid.yaml  # register and activate a profile
+raid profile add ~/my-project.raid.yaml  # register and activate a profile
 raid install                           # clone repos and run install tasks
-raid env dev                           # apply the dev environment
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ brew install raid  # macOS — Linux and Windows coming soon
 
 ### Quickstart
 
-First, create a profile file (see [Configuration](#configuration) below), then:
-
 ```bash
-raid profile add ~/my-project.raid.yaml  # register and activate a profile
-raid install                           # clone repos and run install tasks
+raid profile create   # interactive wizard: name your profile and add repositories
+raid install          # clone repos and run install tasks
 ```
+
+You can also write a profile file manually (see [Configuration](#configuration)) and register it with `raid profile add <file>`.
 
 ---
 
@@ -54,7 +54,8 @@ raid install                           # clone repos and run install tasks
 
 Manage profiles. A profile is a named collection of repositories and environments.
 
-- `raid profile add <file>` — register profiles from a YAML or JSON file; the first added profile is set as active automatically
+- `raid profile create` — interactive wizard to create and register a new profile
+- `raid profile add <file>` — register profiles from a YAML or JSON file
 - `raid profile list` — list all registered profiles
 - `raid profile <name>` — switch the active profile
 - `raid profile remove <name>` — remove a profile
@@ -68,6 +69,10 @@ Clone all repositories in the active profile and run any configured install task
 - `raid env <name>` — apply a named environment: writes `.env` files into each repo and runs environment tasks
 - `raid env` — show the currently active environment
 - `raid env list` — list available environments
+
+### `raid doctor`
+
+Check the current configuration for issues and get suggestions for fixing them. Useful after initial setup or when something isn't working as expected.
 
 ### `raid <command>`
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Custom commands appear alongside built-in commands in `raid --help`. Commands de
 
 ### Profile (`*.raid.yaml`)
 
-A profile defines the repositories, environments, and tasks for a project — tasks can be organized into install steps, reusable groups, and custom commands. The `$schema` annotation enables autocomplete and validation in editors like VS Code.
+A profile defines the repositories, environments, and tasks for a project. The `$schema` annotation enables autocomplete and validation in editors like VS Code. See [Tasks](#tasks) for available task types.
 
 Supported formats: `.yaml`, `.yml`, `.json`
 
@@ -183,6 +183,21 @@ commands:
 
 ## Tasks
 
+Tasks are the unit of work in raid. They appear in environments, install steps, commands, and task groups. Each task has a `type` and type-specific fields.
+
+| Type | Description |
+|------|-------------|
+| `Shell` | Run a shell command |
+| `Script` | Execute a script file |
+| `Git` | Run a git operation (`pull`, `clone`, etc.) |
+| `HTTP` | Download a file from a URL |
+| `Wait` | Poll a URL or address until it responds |
+| `Template` | Render a template file |
+| `Print` | Print a message to the console |
+| `Prompt` | Prompt the user for input and store it in a variable |
+| `Confirm` | Prompt the user for a yes/no confirmation |
+| `Group` | Execute a named task group by `ref` |
+
 All task types support two optional modifiers:
 
 ```yaml
@@ -247,20 +262,14 @@ Render a file by substituting `$VAR` and `${VAR}` references with environment va
 
 ### Group
 
-Execute a named group of tasks defined in the profile's top-level `groups` map.
+Execute a named task group defined in the profile's `task_groups`. Supports optional parallel and retry modifiers.
 
 ```yaml
 - type: Group
   ref: verify-services
-```
-
-### Parallel
-
-Like `Group`, but forces all tasks in the group to run concurrently, then waits for all to finish before continuing.
-
-```yaml
-- type: Parallel
-  ref: start-services
+  parallel: true   # optional: run all tasks in the group concurrently
+  attempts: 3      # optional: retry the group on failure
+  delay: 5s        # optional: delay between retries (default: 1s)
 ```
 
 ### Git
@@ -303,17 +312,6 @@ Pause and require explicit confirmation (`y` or `yes`) before continuing. Useful
 ```yaml
 - type: Confirm
   message: "This will reset the production database. Continue?"
-```
-
-### Retry
-
-Re-run a group of tasks on failure, up to a configurable number of attempts.
-
-```yaml
-- type: Retry
-  ref: run-migrations
-  attempts: 3      # optional, default: 3
-  delay: 5s        # optional, default: 1s
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Supported formats: `.yaml`, `.yml`, `.json`
 
 Example `my-project.raid.yaml`:
 ```yaml
-# yaml-language-server: $schema=schemas/raid-profile.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-profile.schema.json
 
 name: my-project
 
@@ -158,7 +158,7 @@ Multiple profiles can be defined in a single file using YAML document separators
 Individual repositories can carry their own `raid.yaml` at their root to define repo-specific environments and tasks. These are merged with the profile configuration at load time. Committing this file to each repo is the recommended way to share knowledge with your team.
 
 ```yaml
-# yaml-language-server: $schema=schemas/raid-repo.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-repo.schema.json
 
 name: my-service
 branch: main

--- a/README.md
+++ b/README.md
@@ -84,12 +84,13 @@ Custom commands appear alongside built-in commands in `raid --help`. Commands de
 
 ## Configuration
 
-Tasks can be defined under `install`, within any environment, or in named `groups` — in both profile and repo configs.
-
 ### Profile (`*.raid.yaml`)
 
-A profile defines the repositories, environments, and reusable task groups for a project. The `$schema` annotation enables autocomplete and validation in editors like VS Code.
+A profile defines the repositories, environments, and tasks for a project — tasks can be organized into install steps, reusable groups, and custom commands. The `$schema` annotation enables autocomplete and validation in editors like VS Code.
 
+Supported formats: `.yaml`, `.yml`, `.json`
+
+Example `my-project.raid.yaml`:
 ```yaml
 # yaml-language-server: $schema=schemas/raid-profile.schema.json
 
@@ -125,7 +126,7 @@ install:
     - type: Shell
       cmd: brew install node
 
-groups:
+task_groups:
   verify-services:
     - type: Wait
       url: http://localhost:3000
@@ -146,13 +147,15 @@ commands:
         path: ~/Developer/backend
       - type: Shell
         cmd: docker compose restart
+      - type: Group
+        ref: verify-services
 ```
 
 Multiple profiles can be defined in a single file using YAML document separators (`---`) or a JSON array.
 
 ### Repository (`raid.yaml`)
 
-Individual repositories can carry their own `raid.yaml` at their root to define repo-specific environments and install tasks. These are merged with the profile configuration at load time. Committing this file to each repo is the recommended way to share setup knowledge with your team.
+Individual repositories can carry their own `raid.yaml` at their root to define repo-specific environments and tasks. These are merged with the profile configuration at load time. Committing this file to each repo is the recommended way to share knowledge with your team.
 
 ```yaml
 # yaml-language-server: $schema=schemas/raid-repo.schema.json

--- a/schemas/raid-defs.schema.json
+++ b/schemas/raid-defs.schema.json
@@ -96,7 +96,7 @@
                             "type": { "type": "string", "const": "Group" },
                             "concurrent": { "$ref": "#/$defs/concurrent" },
                             "condition": { "$ref": "#/$defs/condition" },
-                            "ref": { "type": "string", "description": "Name of the group to execute, as defined in the profile's top-level groups map" }
+                            "ref": { "type": "string", "description": "Name of the task group to execute, as defined in the profile's top-level task_groups map" }
                         },
                         "required": ["type", "ref"],
                         "additionalProperties": false

--- a/schemas/raid-defs.schema.json
+++ b/schemas/raid-defs.schema.json
@@ -96,7 +96,10 @@
                             "type": { "type": "string", "const": "Group" },
                             "concurrent": { "$ref": "#/$defs/concurrent" },
                             "condition": { "$ref": "#/$defs/condition" },
-                            "ref": { "type": "string", "description": "Name of the task group to execute, as defined in the profile's top-level task_groups map" }
+                            "ref": { "type": "string", "description": "Name of the task group to execute, as defined in the profile's top-level task_groups map" },
+                            "parallel": { "type": "boolean", "description": "Run all tasks in the group concurrently, then wait for all to finish", "default": false },
+                            "attempts": { "type": "integer", "minimum": 1, "description": "Retry the group on failure up to this many times" },
+                            "delay": { "type": "string", "description": "Duration to wait between retry attempts (e.g. 1s, 500ms). Default: 1s." }
                         },
                         "required": ["type", "ref"],
                         "additionalProperties": false
@@ -145,17 +148,6 @@
                     {
                         "type": "object",
                         "properties": {
-                            "type": { "type": "string", "const": "Parallel" },
-                            "concurrent": { "$ref": "#/$defs/concurrent" },
-                            "condition": { "$ref": "#/$defs/condition" },
-                            "ref": { "type": "string", "description": "Name of the group whose tasks will all be executed concurrently" }
-                        },
-                        "required": ["type", "ref"],
-                        "additionalProperties": false
-                    },
-                    {
-                        "type": "object",
-                        "properties": {
                             "type": { "type": "string", "const": "Print" },
                             "concurrent": { "$ref": "#/$defs/concurrent" },
                             "condition": { "$ref": "#/$defs/condition" },
@@ -174,23 +166,6 @@
                         "required": ["type", "message"],
                         "additionalProperties": false
                     },
-                    {
-                        "type": "object",
-                        "properties": {
-                            "type": { "type": "string", "const": "Retry" },
-                            "concurrent": { "$ref": "#/$defs/concurrent" },
-                            "condition": { "$ref": "#/$defs/condition" },
-                            "ref": { "type": "string", "description": "Name of the group to retry on failure" },
-                            "attempts": {
-                                "type": "integer",
-                                "minimum": 1,
-                                "description": "Maximum number of attempts (default: 3)"
-                            },
-                            "delay": { "type": "string", "description": "Duration to wait between attempts (e.g. 1s, 500ms). Default: 1s." }
-                        },
-                        "required": ["type", "ref"],
-                        "additionalProperties": false
-                    }
                 ]
             }
         },

--- a/schemas/raid-profile.schema.json
+++ b/schemas/raid-profile.schema.json
@@ -39,7 +39,7 @@
     "install": {
       "$ref": "raid-defs.schema.json#/properties/install"
     },
-    "groups": {
+    "task_groups": {
       "type": "object",
       "description": "Named reusable task sequences. Reference them in any task list with type: Group and ref: <name>.",
       "additionalProperties": {

--- a/schemas/raid-profile.schema.json
+++ b/schemas/raid-profile.schema.json
@@ -34,20 +34,20 @@
       "minItems": 1
     },
     "environments": {
-      "$ref": "https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-defs.schema.json#/properties/environments"
+      "$ref": "raid-defs.schema.json#/properties/environments"
     },
     "install": {
-      "$ref": "https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-defs.schema.json#/properties/install"
+      "$ref": "raid-defs.schema.json#/properties/install"
     },
     "task_groups": {
       "type": "object",
       "description": "Named reusable task sequences. Reference them in any task list with type: Group and ref: <name>.",
       "additionalProperties": {
-        "$ref": "https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-defs.schema.json#/properties/tasks"
+        "$ref": "raid-defs.schema.json#/properties/tasks"
       }
     },
     "commands": {
-      "$ref": "https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-defs.schema.json#/properties/commands"
+      "$ref": "raid-defs.schema.json#/properties/commands"
     }
   },
   "required": ["name"]

--- a/schemas/raid-profile.schema.json
+++ b/schemas/raid-profile.schema.json
@@ -34,20 +34,20 @@
       "minItems": 1
     },
     "environments": {
-      "$ref": "raid-defs.schema.json#/properties/environments"
+      "$ref": "https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-defs.schema.json#/properties/environments"
     },
     "install": {
-      "$ref": "raid-defs.schema.json#/properties/install"
+      "$ref": "https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-defs.schema.json#/properties/install"
     },
     "task_groups": {
       "type": "object",
       "description": "Named reusable task sequences. Reference them in any task list with type: Group and ref: <name>.",
       "additionalProperties": {
-        "$ref": "raid-defs.schema.json#/properties/tasks"
+        "$ref": "https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-defs.schema.json#/properties/tasks"
       }
     },
     "commands": {
-      "$ref": "raid-defs.schema.json#/properties/commands"
+      "$ref": "https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-defs.schema.json#/properties/commands"
     }
   },
   "required": ["name"]

--- a/schemas/raid-repo.schema.json
+++ b/schemas/raid-repo.schema.json
@@ -15,13 +15,13 @@
             "description": "The branch to checkout"
         },
         "environments": {
-            "$ref": "https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-defs.schema.json#/properties/environments"
+            "$ref": "raid-defs.schema.json#/properties/environments"
         },
         "install": {
-            "$ref": "https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-defs.schema.json#/properties/install"
+            "$ref": "raid-defs.schema.json#/properties/install"
         },
         "commands": {
-            "$ref": "https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-defs.schema.json#/properties/commands"
+            "$ref": "raid-defs.schema.json#/properties/commands"
         }
     },
     "required": ["name","branch"]

--- a/schemas/raid-repo.schema.json
+++ b/schemas/raid-repo.schema.json
@@ -15,13 +15,13 @@
             "description": "The branch to checkout"
         },
         "environments": {
-            "$ref": "raid-defs.schema.json#/properties/environments"
+            "$ref": "https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-defs.schema.json#/properties/environments"
         },
         "install": {
-            "$ref": "raid-defs.schema.json#/properties/install"
+            "$ref": "https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-defs.schema.json#/properties/install"
         },
         "commands": {
-            "$ref": "raid-defs.schema.json#/properties/commands"
+            "$ref": "https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-defs.schema.json#/properties/commands"
         }
     },
     "required": ["name","branch"]

--- a/src/cmd/doctor/doctor.go
+++ b/src/cmd/doctor/doctor.go
@@ -1,0 +1,52 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/8bitalex/raid/src/raid"
+	"github.com/spf13/cobra"
+)
+
+// Command is the doctor subcommand that checks the raid configuration for issues.
+var Command = &cobra.Command{
+	Use:   "doctor",
+	Short: "Check the raid configuration and report any issues",
+	Args:  cobra.NoArgs,
+	Run:   runDoctor,
+}
+
+func runDoctor(_ *cobra.Command, _ []string) {
+	findings := raid.Doctor()
+
+	warnings, errors := 0, 0
+	for _, f := range findings {
+		switch f.Severity {
+		case raid.SeverityOK:
+			fmt.Printf("  [ok]    %s: %s\n", f.Check, f.Message)
+		case raid.SeverityWarn:
+			warnings++
+			fmt.Printf("  [warn]  %s: %s\n", f.Check, f.Message)
+			if f.Suggestion != "" {
+				fmt.Printf("          → %s\n", f.Suggestion)
+			}
+		case raid.SeverityError:
+			errors++
+			fmt.Printf("  [error] %s: %s\n", f.Check, f.Message)
+			if f.Suggestion != "" {
+				fmt.Printf("          → %s\n", f.Suggestion)
+			}
+		}
+	}
+
+	fmt.Println()
+	switch {
+	case errors > 0:
+		fmt.Printf("%d error(s) detected.\n", errors)
+		os.Exit(1)
+	case warnings > 0:
+		fmt.Printf("%d warning(s).\n", warnings)
+	default:
+		fmt.Println("No issues found.")
+	}
+}

--- a/src/cmd/profile/create.go
+++ b/src/cmd/profile/create.go
@@ -1,0 +1,180 @@
+package profile
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/8bitalex/raid/src/internal/sys"
+	pro "github.com/8bitalex/raid/src/raid/profile"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// profileDraft is the minimal structure written to a new profile file.
+type profileDraft struct {
+	Name         string      `yaml:"name"`
+	Repositories []repoDraft `yaml:"repositories,omitempty"`
+}
+
+// repoDraft holds the fields collected for each repository during the wizard.
+type repoDraft struct {
+	Name   string `yaml:"name"`
+	Path   string `yaml:"path"`
+	URL    string `yaml:"url"`
+	Branch string `yaml:"branch,omitempty"`
+}
+
+var CreateProfileCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Interactively create a new profile",
+	Args:  cobra.NoArgs,
+	Run:   runCreateWizard,
+}
+
+func runCreateWizard(cmd *cobra.Command, args []string) {
+	reader := bufio.NewReader(os.Stdin)
+
+	var name string
+	for {
+		name = readLine(reader, "Profile name: ")
+		if err := sys.ValidateFileName(name); err != nil {
+			fmt.Printf("Invalid name: %v\n", err)
+			continue
+		}
+		break
+	}
+
+	defaultPath := filepath.Join(sys.GetHomeDir(), name+".raid.yaml")
+	rawPath := readLine(reader, fmt.Sprintf("Save path [%s]: ", defaultPath))
+	savePath := defaultPath
+	if rawPath != "" {
+		savePath = sys.ExpandPath(rawPath)
+	}
+
+	repos := collectRepos(reader)
+
+	draft := profileDraft{Name: name, Repositories: repos}
+	if err := writeProfileFile(draft, savePath); err != nil {
+		fmt.Printf("Failed to write profile: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := registerProfile(name, savePath); err != nil {
+		fmt.Printf("Failed to register profile: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("\nProfile '%s' created at %s\n", name, savePath)
+
+	if len(repos) > 0 && readYesNo(reader, "\nCreate a raid.yaml config for each repository? [y/N]: ") {
+		createRepoConfigs(repos)
+	}
+}
+
+func collectRepos(reader *bufio.Reader) []repoDraft {
+	var repos []repoDraft
+	for {
+		fmt.Println()
+		if !readYesNo(reader, "Add a repository? [y/N]: ") {
+			break
+		}
+		name := readLine(reader, "  Name: ")
+		url := readLine(reader, "  URL: ")
+		path := readLine(reader, "  Local path: ")
+		branch := readLine(reader, "  Default branch [main]: ")
+		if branch == "" {
+			branch = "main"
+		}
+		repo := repoDraft{
+			Name:   name,
+			URL:    url,
+			Path:   path,
+			Branch: branch,
+		}
+		if repo.Name == "" || repo.URL == "" || repo.Path == "" {
+			fmt.Println("  Name, URL, and path are all required. Skipping.")
+			continue
+		}
+		repos = append(repos, repo)
+	}
+	return repos
+}
+
+func writeProfileFile(draft profileDraft, path string) error {
+	data, err := yaml.Marshal(draft)
+	if err != nil {
+		return fmt.Errorf("serializing profile: %w", err)
+	}
+
+	content := "# yaml-language-server: $schema=https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-profile.schema.json\n\n" + string(data)
+
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("creating directory: %w", err)
+	}
+	return os.WriteFile(path, []byte(content), 0644)
+}
+
+func registerProfile(name, path string) error {
+	if err := pro.Validate(path); err != nil {
+		return fmt.Errorf("validation failed: %w", err)
+	}
+
+	profiles, err := pro.Unmarshal(path)
+	if err != nil {
+		return fmt.Errorf("reading profile: %w", err)
+	}
+
+	if err := pro.AddAll(profiles); err != nil {
+		return fmt.Errorf("saving profile: %w", err)
+	}
+
+	if pro.Get().IsZero() {
+		if err := pro.Set(name); err != nil {
+			return fmt.Errorf("setting active profile: %w", err)
+		}
+		fmt.Printf("Profile '%s' set as active.\n", name)
+	}
+
+	return nil
+}
+
+func createRepoConfigs(repos []repoDraft) {
+	for _, repo := range repos {
+		repoPath := sys.ExpandPath(repo.Path)
+		if err := os.MkdirAll(repoPath, 0755); err != nil {
+			fmt.Printf("  Failed to create directory for '%s': %v\n", repo.Name, err)
+			continue
+		}
+
+		configPath := filepath.Join(repoPath, "raid.yaml")
+		if sys.FileExists(configPath) {
+			fmt.Printf("  raid.yaml already exists at %s, skipping.\n", configPath)
+			continue
+		}
+
+		content := "# yaml-language-server: $schema=https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-repo.schema.json\n\nname: " + repo.Name + "\n"
+		if repo.Branch != "" {
+			content += "branch: " + repo.Branch + "\n"
+		}
+		if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+			fmt.Printf("  Failed to write repo config for '%s': %v\n", repo.Name, err)
+			continue
+		}
+		fmt.Printf("  Created %s\n", configPath)
+	}
+}
+
+
+func readLine(reader *bufio.Reader, prompt string) string {
+	fmt.Print(prompt)
+	line, _ := reader.ReadString('\n')
+	return strings.TrimSpace(line)
+}
+
+func readYesNo(reader *bufio.Reader, prompt string) bool {
+	answer := readLine(reader, prompt)
+	return strings.EqualFold(answer, "y") || strings.EqualFold(answer, "yes")
+}

--- a/src/cmd/profile/create.go
+++ b/src/cmd/profile/create.go
@@ -4,30 +4,14 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
 
 	"github.com/8bitalex/raid/src/internal/sys"
 	pro "github.com/8bitalex/raid/src/raid/profile"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
-// profileDraft is the minimal structure written to a new profile file.
-type profileDraft struct {
-	Name         string      `yaml:"name"`
-	Repositories []repoDraft `yaml:"repositories,omitempty"`
-}
-
-// repoDraft holds the fields collected for each repository during the wizard.
-type repoDraft struct {
-	Name   string `yaml:"name"`
-	Path   string `yaml:"path"`
-	URL    string `yaml:"url"`
-	Branch string `yaml:"branch,omitempty"`
-}
-
+// CreateProfileCmd is the interactive wizard for creating a new profile.
 var CreateProfileCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Interactively create a new profile",
@@ -40,7 +24,7 @@ func runCreateWizard(cmd *cobra.Command, args []string) {
 
 	var name string
 	for {
-		name = readLine(reader, "Profile name: ")
+		name = sys.ReadLine(reader, "Profile name: ")
 		if err := sys.ValidateFileName(name); err != nil {
 			fmt.Printf("Invalid name: %v\n", err)
 			continue
@@ -49,157 +33,44 @@ func runCreateWizard(cmd *cobra.Command, args []string) {
 	}
 
 	defaultPath := filepath.Join(sys.GetHomeDir(), name+".raid.yaml")
-	rawPath := readLine(reader, fmt.Sprintf("Save path [%s]: ", defaultPath))
+	rawPath := sys.ReadLine(reader, fmt.Sprintf("Save path [%s]: ", defaultPath))
 	savePath := defaultPath
 	if rawPath != "" {
 		savePath = sys.ExpandPath(rawPath)
 	}
 
-	repos := collectRepos(reader)
+	repos := pro.CollectRepos(reader)
 
-	draft := profileDraft{Name: name, Repositories: repos}
-	if err := writeProfileFile(draft, savePath); err != nil {
+	draft := pro.ProfileDraft{Name: name, Repositories: repos}
+	if err := pro.WriteFile(draft, savePath); err != nil {
 		fmt.Printf("Failed to write profile: %v\n", err)
 		os.Exit(1)
 	}
 
-	if err := registerProfile(name, savePath); err != nil {
+	if err := pro.Validate(savePath); err != nil {
 		fmt.Printf("Failed to register profile: %v\n", err)
 		os.Exit(1)
 	}
-
-	fmt.Printf("\nProfile '%s' created at %s\n", name, savePath)
-
-	if len(repos) > 0 && readYesNo(reader, "\nCreate a raid.yaml config for each repository? [y/N]: ") {
-		createRepoConfigs(repos)
-	}
-}
-
-func collectRepos(reader *bufio.Reader) []repoDraft {
-	var repos []repoDraft
-	for {
-		fmt.Println()
-		if !readYesNo(reader, "Add a repository? [y/N]: ") {
-			break
-		}
-		name := readLine(reader, "  Name: ")
-		url := readLine(reader, "  URL: ")
-		path := readLine(reader, "  Local path: ")
-		defaultBranch := detectDefaultBranch(url)
-		branchPrompt := "  Default branch: "
-		if defaultBranch != "" {
-			branchPrompt = fmt.Sprintf("  Default branch [%s]: ", defaultBranch)
-		}
-		branch := readLine(reader, branchPrompt)
-		if branch == "" {
-			branch = defaultBranch
-		}
-		if branch == "" {
-			branch = "main"
-		}
-		repo := repoDraft{
-			Name:   name,
-			URL:    url,
-			Path:   path,
-			Branch: branch,
-		}
-		if repo.Name == "" || repo.URL == "" || repo.Path == "" {
-			fmt.Println("  Name, URL, and path are all required. Skipping.")
-			continue
-		}
-		repos = append(repos, repo)
-	}
-	return repos
-}
-
-func writeProfileFile(draft profileDraft, path string) error {
-	data, err := yaml.Marshal(draft)
+	profiles, err := pro.Unmarshal(savePath)
 	if err != nil {
-		return fmt.Errorf("serializing profile: %w", err)
+		fmt.Printf("Failed to register profile: %v\n", err)
+		os.Exit(1)
 	}
-
-	content := "# yaml-language-server: $schema=https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-profile.schema.json\n\n" + string(data)
-
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return fmt.Errorf("creating directory: %w", err)
-	}
-	return os.WriteFile(path, []byte(content), 0644)
-}
-
-func registerProfile(name, path string) error {
-	if err := pro.Validate(path); err != nil {
-		return fmt.Errorf("validation failed: %w", err)
-	}
-
-	profiles, err := pro.Unmarshal(path)
-	if err != nil {
-		return fmt.Errorf("reading profile: %w", err)
-	}
-
 	if err := pro.AddAll(profiles); err != nil {
-		return fmt.Errorf("saving profile: %w", err)
+		fmt.Printf("Failed to register profile: %v\n", err)
+		os.Exit(1)
 	}
-
 	if pro.Get().IsZero() {
 		if err := pro.Set(name); err != nil {
-			return fmt.Errorf("setting active profile: %w", err)
+			fmt.Printf("Failed to set active profile: %v\n", err)
+			os.Exit(1)
 		}
 		fmt.Printf("Profile '%s' set as active.\n", name)
 	}
 
-	return nil
-}
+	fmt.Printf("\nProfile '%s' created at %s\n", name, savePath)
 
-func createRepoConfigs(repos []repoDraft) {
-	for _, repo := range repos {
-		repoPath := sys.ExpandPath(repo.Path)
-		if err := os.MkdirAll(repoPath, 0755); err != nil {
-			fmt.Printf("  Failed to create directory for '%s': %v\n", repo.Name, err)
-			continue
-		}
-
-		configPath := filepath.Join(repoPath, "raid.yaml")
-		if sys.FileExists(configPath) {
-			fmt.Printf("  raid.yaml already exists at %s, skipping.\n", configPath)
-			continue
-		}
-
-		content := "# yaml-language-server: $schema=https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-repo.schema.json\n\nname: " + repo.Name + "\n"
-		if repo.Branch != "" {
-			content += "branch: " + repo.Branch + "\n"
-		}
-		if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
-			fmt.Printf("  Failed to write repo config for '%s': %v\n", repo.Name, err)
-			continue
-		}
-		fmt.Printf("  Created %s\n", configPath)
+	if len(repos) > 0 && sys.ReadYesNo(reader, "\nCreate a raid.yaml config for each repository? [y/N]: ") {
+		pro.CreateRepoConfigs(repos)
 	}
-}
-
-
-// detectDefaultBranch queries the remote to find its default branch without cloning.
-// Returns an empty string if the remote is unreachable or the branch cannot be determined.
-func detectDefaultBranch(url string) string {
-	out, err := exec.Command("git", "ls-remote", "--symref", url, "HEAD").Output()
-	if err != nil {
-		return ""
-	}
-	for _, line := range strings.Split(string(out), "\n") {
-		// Format: "ref: refs/heads/<branch>\tHEAD"
-		if strings.HasPrefix(line, "ref: refs/heads/") {
-			return strings.TrimPrefix(strings.SplitN(line, "\t", 2)[0], "ref: refs/heads/")
-		}
-	}
-	return ""
-}
-
-func readLine(reader *bufio.Reader, prompt string) string {
-	fmt.Print(prompt)
-	line, _ := reader.ReadString('\n')
-	return strings.TrimSpace(line)
-}
-
-func readYesNo(reader *bufio.Reader, prompt string) bool {
-	answer := readLine(reader, prompt)
-	return strings.EqualFold(answer, "y") || strings.EqualFold(answer, "yes")
 }

--- a/src/cmd/profile/create.go
+++ b/src/cmd/profile/create.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -84,7 +85,15 @@ func collectRepos(reader *bufio.Reader) []repoDraft {
 		name := readLine(reader, "  Name: ")
 		url := readLine(reader, "  URL: ")
 		path := readLine(reader, "  Local path: ")
-		branch := readLine(reader, "  Default branch [main]: ")
+		defaultBranch := detectDefaultBranch(url)
+		branchPrompt := "  Default branch: "
+		if defaultBranch != "" {
+			branchPrompt = fmt.Sprintf("  Default branch [%s]: ", defaultBranch)
+		}
+		branch := readLine(reader, branchPrompt)
+		if branch == "" {
+			branch = defaultBranch
+		}
 		if branch == "" {
 			branch = "main"
 		}
@@ -167,6 +176,22 @@ func createRepoConfigs(repos []repoDraft) {
 	}
 }
 
+
+// detectDefaultBranch queries the remote to find its default branch without cloning.
+// Returns an empty string if the remote is unreachable or the branch cannot be determined.
+func detectDefaultBranch(url string) string {
+	out, err := exec.Command("git", "ls-remote", "--symref", url, "HEAD").Output()
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		// Format: "ref: refs/heads/<branch>\tHEAD"
+		if strings.HasPrefix(line, "ref: refs/heads/") {
+			return strings.TrimPrefix(strings.SplitN(line, "\t", 2)[0], "ref: refs/heads/")
+		}
+	}
+	return ""
+}
 
 func readLine(reader *bufio.Reader, prompt string) string {
 	fmt.Print(prompt)

--- a/src/cmd/profile/profile.go
+++ b/src/cmd/profile/profile.go
@@ -10,6 +10,7 @@ import (
 
 func init() {
 	Command.AddCommand(AddProfileCmd)
+	Command.AddCommand(CreateProfileCmd)
 	Command.AddCommand(ListProfileCmd)
 	Command.AddCommand(RemoveProfileCmd)
 }

--- a/src/cmd/raid.go
+++ b/src/cmd/raid.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/8bitalex/raid/src/cmd/doctor"
 	"github.com/8bitalex/raid/src/cmd/env"
 	"github.com/8bitalex/raid/src/cmd/install"
 	"github.com/8bitalex/raid/src/cmd/profile"
@@ -18,6 +19,7 @@ var reservedNames = map[string]bool{
 	"profile":    true,
 	"install":    true,
 	"env":        true,
+	"doctor":     true,
 	"help":       true,
 	"version":    true,
 	"completion": true,
@@ -38,6 +40,7 @@ func init() {
 	rootCmd.AddCommand(profile.Command)
 	rootCmd.AddCommand(install.Command)
 	rootCmd.AddCommand(env.Command)
+	rootCmd.AddCommand(doctor.Command)
 }
 
 func Execute() {

--- a/src/internal/lib/doctor.go
+++ b/src/internal/lib/doctor.go
@@ -1,0 +1,161 @@
+package lib
+
+import (
+	"fmt"
+	"path/filepath"
+
+	sys "github.com/8bitalex/raid/src/internal/sys"
+)
+
+// Severity indicates the importance of a doctor finding.
+type Severity int
+
+const (
+	SeverityOK    Severity = iota
+	SeverityWarn
+	SeverityError
+)
+
+// Finding represents the result of a single doctor check.
+type Finding struct {
+	Severity   Severity
+	Check      string
+	Message    string
+	Suggestion string // shown when non-empty
+}
+
+// RunDoctor performs all configuration checks and returns the findings.
+func RunDoctor() []Finding {
+	var findings []Finding
+	findings = append(findings, checkGit()...)
+	findings = append(findings, checkProfile()...)
+	return findings
+}
+
+func checkGit() []Finding {
+	if isGitInstalled() {
+		return []Finding{{Severity: SeverityOK, Check: "git", Message: "installed"}}
+	}
+	return []Finding{{
+		Severity:   SeverityError,
+		Check:      "git",
+		Message:    "not installed or not in the PATH",
+		Suggestion: "install git from https://git-scm.com",
+	}}
+}
+
+func checkProfile() []Finding {
+	var findings []Finding
+
+	profile := GetProfile()
+	if profile.IsZero() {
+		return []Finding{{
+			Severity:   SeverityError,
+			Check:      "profile",
+			Message:    "no active profile set",
+			Suggestion: "run 'raid profile create' to create one, or 'raid profile <name>' to activate an existing profile",
+		}}
+	}
+
+	findings = append(findings, Finding{
+		Severity: SeverityOK,
+		Check:    "profile",
+		Message:  fmt.Sprintf("%s (active)", profile.Name),
+	})
+
+	if !sys.FileExists(profile.Path) {
+		return append(findings, Finding{
+			Severity:   SeverityError,
+			Check:      "profile file",
+			Message:    fmt.Sprintf("not found: %s", profile.Path),
+			Suggestion: "re-create the profile file or register its new path with 'raid profile add'",
+		})
+	}
+	findings = append(findings, Finding{
+		Severity: SeverityOK,
+		Check:    "profile file",
+		Message:  fmt.Sprintf("found at %s", profile.Path),
+	})
+
+	if err := ValidateProfile(profile.Path); err != nil {
+		return append(findings, Finding{
+			Severity:   SeverityError,
+			Check:      "profile schema",
+			Message:    err.Error(),
+			Suggestion: "fix the profile file to match the schema",
+		})
+	}
+	findings = append(findings, Finding{Severity: SeverityOK, Check: "profile schema", Message: "valid"})
+
+	fullProfile, err := ExtractProfile(profile.Name, profile.Path)
+	if err != nil {
+		return append(findings, Finding{
+			Severity: SeverityError,
+			Check:    "profile load",
+			Message:  err.Error(),
+		})
+	}
+
+	if len(fullProfile.Repositories) == 0 {
+		return append(findings, Finding{
+			Severity:   SeverityWarn,
+			Check:      "repositories",
+			Message:    "none configured",
+			Suggestion: "add repositories to your profile or run 'raid profile create'",
+		})
+	}
+
+	for _, repo := range fullProfile.Repositories {
+		findings = append(findings, checkRepo(repo)...)
+	}
+	return findings
+}
+
+func checkRepo(repo Repo) []Finding {
+	var findings []Finding
+	repoPath := sys.ExpandPath(repo.Path)
+
+	if !sys.FileExists(repoPath) {
+		return append(findings, Finding{
+			Severity:   SeverityWarn,
+			Check:      fmt.Sprintf("repo/%s", repo.Name),
+			Message:    fmt.Sprintf("not cloned at %s", repoPath),
+			Suggestion: "run 'raid install' to clone all repositories",
+		})
+	}
+
+	findings = append(findings, Finding{
+		Severity: SeverityOK,
+		Check:    fmt.Sprintf("repo/%s", repo.Name),
+		Message:  fmt.Sprintf("found at %s", repoPath),
+	})
+
+	if !isGitRepository(repoPath) {
+		findings = append(findings, Finding{
+			Severity: SeverityWarn,
+			Check:    fmt.Sprintf("repo/%s", repo.Name),
+			Message:  "directory exists but is not a git repository",
+		})
+	}
+
+	raidFile := filepath.Join(repoPath, RaidConfigFileName)
+	if !sys.FileExists(raidFile) {
+		return findings
+	}
+
+	if err := ValidateRepo(raidFile); err != nil {
+		findings = append(findings, Finding{
+			Severity:   SeverityError,
+			Check:      fmt.Sprintf("repo/%s raid.yaml", repo.Name),
+			Message:    err.Error(),
+			Suggestion: fmt.Sprintf("fix %s to match the repo schema", raidFile),
+		})
+	} else {
+		findings = append(findings, Finding{
+			Severity: SeverityOK,
+			Check:    fmt.Sprintf("repo/%s raid.yaml", repo.Name),
+			Message:  "valid",
+		})
+	}
+	return findings
+}

--- a/src/internal/lib/doctor_test.go
+++ b/src/internal/lib/doctor_test.go
@@ -6,7 +6,36 @@ import (
 	"testing"
 )
 
+// --- RunDoctor ---
+
+func TestRunDoctor_returnsFindings(t *testing.T) {
+	setupTestConfig(t)
+
+	findings := RunDoctor()
+	if len(findings) == 0 {
+		t.Fatal("RunDoctor(): expected at least one finding, got none")
+	}
+}
+
 // --- checkGit ---
+
+func TestCheckGit_notInstalled(t *testing.T) {
+	// Hide git by clearing PATH so exec.Command("git", "--version") fails.
+	old := os.Getenv("PATH")
+	os.Setenv("PATH", "")
+	t.Cleanup(func() { os.Setenv("PATH", old) })
+
+	findings := checkGit()
+	if len(findings) != 1 {
+		t.Fatalf("checkGit(): got %d findings, want 1", len(findings))
+	}
+	if findings[0].Severity != SeverityError {
+		t.Errorf("checkGit(): severity = %v, want SeverityError", findings[0].Severity)
+	}
+	if findings[0].Suggestion == "" {
+		t.Error("checkGit(): missing suggestion when git not found")
+	}
+}
 
 func TestCheckGit_installed(t *testing.T) {
 	findings := checkGit()
@@ -95,6 +124,28 @@ func TestCheckProfile_noRepositories(t *testing.T) {
 	}
 	if !severities[SeverityWarn] {
 		t.Error("checkProfile(): expected a warning finding for no repositories")
+	}
+}
+
+func TestCheckProfile_extractProfileError(t *testing.T) {
+	setupTestConfig(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "profile.yaml")
+	// File contains "bob" but we register it as "alice" — ExtractProfile will fail.
+	os.WriteFile(path, []byte("name: bob\n"), 0644)
+
+	if err := AddProfile(Profile{Name: "alice", Path: path}); err != nil {
+		t.Fatal(err)
+	}
+	if err := SetProfile("alice"); err != nil {
+		t.Fatal(err)
+	}
+
+	findings := checkProfile()
+	severities := severitySet(findings)
+	if !severities[SeverityError] {
+		t.Error("checkProfile(): expected an error finding when profile name not found in file")
 	}
 }
 

--- a/src/internal/lib/doctor_test.go
+++ b/src/internal/lib/doctor_test.go
@@ -1,0 +1,202 @@
+package lib
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// --- checkGit ---
+
+func TestCheckGit_installed(t *testing.T) {
+	findings := checkGit()
+	if len(findings) != 1 {
+		t.Fatalf("checkGit(): got %d findings, want 1", len(findings))
+	}
+	if findings[0].Severity != SeverityOK {
+		t.Errorf("checkGit(): severity = %v, want SeverityOK", findings[0].Severity)
+	}
+}
+
+// --- checkProfile ---
+
+func TestCheckProfile_noActiveProfile(t *testing.T) {
+	setupTestConfig(t)
+
+	findings := checkProfile()
+	if len(findings) != 1 {
+		t.Fatalf("checkProfile(): got %d findings, want 1", len(findings))
+	}
+	f := findings[0]
+	if f.Severity != SeverityError {
+		t.Errorf("checkProfile(): severity = %v, want SeverityError", f.Severity)
+	}
+	if f.Suggestion == "" {
+		t.Error("checkProfile(): missing suggestion for no-profile case")
+	}
+}
+
+func TestCheckProfile_missingFile(t *testing.T) {
+	setupTestConfig(t)
+
+	if err := AddProfile(Profile{Name: "ghost", Path: "/nonexistent/ghost.raid.yaml"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := SetProfile("ghost"); err != nil {
+		t.Fatal(err)
+	}
+
+	findings := checkProfile()
+	severities := severitySet(findings)
+	if !severities[SeverityError] {
+		t.Error("checkProfile(): expected an error finding for missing profile file")
+	}
+}
+
+func TestCheckProfile_invalidSchema(t *testing.T) {
+	setupTestConfig(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "profile.yaml")
+	os.WriteFile(path, []byte("name: test\nbadfield: invalid"), 0644)
+
+	if err := AddProfile(Profile{Name: "test", Path: path}); err != nil {
+		t.Fatal(err)
+	}
+	if err := SetProfile("test"); err != nil {
+		t.Fatal(err)
+	}
+
+	findings := checkProfile()
+	severities := severitySet(findings)
+	if !severities[SeverityError] {
+		t.Error("checkProfile(): expected an error finding for schema violation")
+	}
+}
+
+func TestCheckProfile_noRepositories(t *testing.T) {
+	setupTestConfig(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "profile.yaml")
+	os.WriteFile(path, []byte("name: empty\n"), 0644)
+
+	if err := AddProfile(Profile{Name: "empty", Path: path}); err != nil {
+		t.Fatal(err)
+	}
+	if err := SetProfile("empty"); err != nil {
+		t.Fatal(err)
+	}
+
+	findings := checkProfile()
+	severities := severitySet(findings)
+	if severities[SeverityError] {
+		t.Errorf("checkProfile(): unexpected error findings: %v", findings)
+	}
+	if !severities[SeverityWarn] {
+		t.Error("checkProfile(): expected a warning finding for no repositories")
+	}
+}
+
+func TestCheckProfile_validWithRepos(t *testing.T) {
+	setupTestConfig(t)
+
+	dir := t.TempDir()
+	repoDir := filepath.Join(dir, "myrepo")
+	os.MkdirAll(filepath.Join(repoDir, ".git"), 0755)
+
+	path := filepath.Join(dir, "profile.yaml")
+	content := "name: valid\nrepositories:\n  - name: myrepo\n    path: " + repoDir + "\n    url: http://example.com/repo.git\n"
+	os.WriteFile(path, []byte(content), 0644)
+
+	if err := AddProfile(Profile{Name: "valid", Path: path}); err != nil {
+		t.Fatal(err)
+	}
+	if err := SetProfile("valid"); err != nil {
+		t.Fatal(err)
+	}
+
+	findings := checkProfile()
+	severities := severitySet(findings)
+	if severities[SeverityError] {
+		t.Errorf("checkProfile(): unexpected error findings: %v", findings)
+	}
+}
+
+// --- checkRepo ---
+
+func TestCheckRepo_notCloned(t *testing.T) {
+	repo := Repo{
+		Name: "missing",
+		Path: "/nonexistent/path/that/does/not/exist",
+		URL:  "http://example.com/repo.git",
+	}
+	findings := checkRepo(repo)
+	if len(findings) != 1 || findings[0].Severity != SeverityWarn {
+		t.Errorf("checkRepo(): got %v, want single warn finding for uncloned repo", findings)
+	}
+	if findings[0].Suggestion == "" {
+		t.Error("checkRepo(): missing suggestion for uncloned repo")
+	}
+}
+
+func TestCheckRepo_clonedNoRaidYaml(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, ".git"), 0755)
+
+	repo := Repo{Name: "present", Path: dir, URL: "http://example.com/repo.git"}
+	findings := checkRepo(repo)
+	severities := severitySet(findings)
+	if severities[SeverityError] || severities[SeverityWarn] {
+		t.Errorf("checkRepo(): got unexpected warn/error findings for a valid cloned repo with no raid.yaml: %v", findings)
+	}
+}
+
+func TestCheckRepo_invalidRaidYaml(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, ".git"), 0755)
+	os.WriteFile(filepath.Join(dir, RaidConfigFileName), []byte("name: myrepo\nbadfield: invalid"), 0644)
+
+	repo := Repo{Name: "badconfig", Path: dir, URL: "http://example.com/repo.git"}
+	findings := checkRepo(repo)
+	severities := severitySet(findings)
+	if !severities[SeverityError] {
+		t.Error("checkRepo(): expected an error finding for invalid raid.yaml")
+	}
+}
+
+func TestCheckRepo_validRaidYaml(t *testing.T) {
+	setupTestConfig(t)
+
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, ".git"), 0755)
+	os.WriteFile(filepath.Join(dir, RaidConfigFileName), []byte("name: myrepo\nbranch: main\n"), 0644)
+
+	repo := Repo{Name: "good", Path: dir, URL: "http://example.com/repo.git"}
+	findings := checkRepo(repo)
+	severities := severitySet(findings)
+	if severities[SeverityError] {
+		t.Errorf("checkRepo(): unexpected error findings for valid raid.yaml: %v", findings)
+	}
+}
+
+func TestCheckRepo_notGitRepository(t *testing.T) {
+	dir := t.TempDir()
+	// Directory exists but has no .git — not a git repo.
+
+	repo := Repo{Name: "notgit", Path: dir, URL: "http://example.com/repo.git"}
+	findings := checkRepo(repo)
+	severities := severitySet(findings)
+	if !severities[SeverityWarn] {
+		t.Error("checkRepo(): expected a warning for directory that is not a git repository")
+	}
+}
+
+// severitySet returns a set of all severities present in findings.
+func severitySet(findings []Finding) map[Severity]bool {
+	out := make(map[Severity]bool, len(findings))
+	for _, f := range findings {
+		out[f.Severity] = true
+	}
+	return out
+}

--- a/src/internal/lib/profile.go
+++ b/src/internal/lib/profile.go
@@ -25,7 +25,7 @@ type Profile struct {
 	Repositories []Repo            `json:"repositories"`
 	Environments []Env             `json:"environments"`
 	Install      OnInstall         `json:"install"`
-	Groups       map[string][]Task `json:"groups"`
+	Groups       map[string][]Task `json:"task_groups" yaml:"task_groups"`
 	Commands     []Command         `json:"commands"`
 }
 

--- a/src/internal/lib/profile.go
+++ b/src/internal/lib/profile.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -218,6 +219,93 @@ func ContainsProfile(name string) bool {
 // ValidateProfile validates the profile file at path against the profile JSON schema.
 func ValidateProfile(path string) error {
 	return validateWithEmbeddedSchema(path, profileSchemaPath)
+}
+
+const (
+	profileSchemaURL = "https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-profile.schema.json"
+	repoSchemaURL    = "https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-repo.schema.json"
+)
+
+// ProfileDraft is the minimal structure written to a new profile file.
+type ProfileDraft struct {
+	Name         string      `yaml:"name"`
+	Repositories []RepoDraft `yaml:"repositories,omitempty"`
+}
+
+// RepoDraft holds the fields collected for each repository during profile creation.
+type RepoDraft struct {
+	Name   string `yaml:"name"`
+	Path   string `yaml:"path"`
+	URL    string `yaml:"url"`
+	Branch string `yaml:"branch,omitempty"`
+}
+
+// WriteProfileFile serializes draft as YAML and writes it to path, creating parent directories as needed.
+func WriteProfileFile(draft ProfileDraft, path string) error {
+	data, err := yaml.Marshal(draft)
+	if err != nil {
+		return fmt.Errorf("serializing profile: %w", err)
+	}
+	content := "# yaml-language-server: $schema=" + profileSchemaURL + "\n\n" + string(data)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("creating directory: %w", err)
+	}
+	return os.WriteFile(path, []byte(content), 0644)
+}
+
+// CollectRepos runs an interactive prompt loop to collect repository details from reader.
+func CollectRepos(reader *bufio.Reader) []RepoDraft {
+	var repos []RepoDraft
+	for {
+		fmt.Println()
+		if !sys.ReadYesNo(reader, "Add a repository? [y/N]: ") {
+			break
+		}
+		name := sys.ReadLine(reader, "  Name: ")
+		url := sys.ReadLine(reader, "  URL: ")
+		path := sys.ReadLine(reader, "  Local path: ")
+		defaultBranch := sys.DetectGitDefaultBranch(url)
+		branchPrompt := "  Default branch: "
+		if defaultBranch != "" {
+			branchPrompt = fmt.Sprintf("  Default branch [%s]: ", defaultBranch)
+		}
+		branch := sys.ReadLine(reader, branchPrompt)
+		if branch == "" {
+			branch = defaultBranch
+		}
+		repo := RepoDraft{Name: name, URL: url, Path: path, Branch: branch}
+		if repo.Name == "" || repo.URL == "" || repo.Path == "" {
+			fmt.Println("  Name, URL, and path are all required. Skipping.")
+			continue
+		}
+		repos = append(repos, repo)
+	}
+	return repos
+}
+
+// CreateRepoConfigs writes a raid.yaml stub into each repository's local directory.
+func CreateRepoConfigs(repos []RepoDraft) {
+	for _, repo := range repos {
+		repoPath := sys.ExpandPath(repo.Path)
+		if err := os.MkdirAll(repoPath, 0755); err != nil {
+			fmt.Printf("  Failed to create directory for '%s': %v\n", repo.Name, err)
+			continue
+		}
+		configPath := filepath.Join(repoPath, "raid.yaml")
+		if sys.FileExists(configPath) {
+			fmt.Printf("  raid.yaml already exists at %s, skipping.\n", configPath)
+			continue
+		}
+		content := "# yaml-language-server: $schema=" + repoSchemaURL + "\n\nname: " + repo.Name + "\n"
+		if repo.Branch != "" {
+			content += "branch: " + repo.Branch + "\n"
+		}
+		if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+			fmt.Printf("  Failed to write repo config for '%s': %v\n", repo.Name, err)
+			continue
+		}
+		fmt.Printf("  Created %s\n", configPath)
+	}
 }
 
 func buildProfile(profile Profile) (Profile, error) {

--- a/src/internal/lib/profile_test.go
+++ b/src/internal/lib/profile_test.go
@@ -1,9 +1,12 @@
 package lib
 
 import (
+	"bufio"
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -390,4 +393,194 @@ func TestValidateProfile_schemaViolation(t *testing.T) {
 	if err := ValidateProfile(path); err == nil {
 		t.Fatal("ValidateProfile() expected error for schema violation")
 	}
+}
+
+// --- WriteProfileFile ---
+
+func TestWriteProfileFile_createsFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.raid.yaml")
+
+	if err := WriteProfileFile(ProfileDraft{Name: "test-profile"}, path); err != nil {
+		t.Fatalf("WriteProfileFile() unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "yaml-language-server") {
+		t.Error("WriteProfileFile(): missing schema comment")
+	}
+	if !strings.Contains(content, "name: test-profile") {
+		t.Error("WriteProfileFile(): missing profile name in output")
+	}
+}
+
+func TestWriteProfileFile_createsParentDirectories(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "deep", "test.raid.yaml")
+
+	if err := WriteProfileFile(ProfileDraft{Name: "nested"}, path); err != nil {
+		t.Fatalf("WriteProfileFile() unexpected error: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("WriteProfileFile(): file not found at %s: %v", path, err)
+	}
+}
+
+func TestWriteProfileFile_mkdirAllError(t *testing.T) {
+	file, err := os.CreateTemp("", "raid-lib-profile-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	file.Close()
+	defer os.Remove(file.Name())
+
+	path := filepath.Join(file.Name(), "subdir", "test.raid.yaml")
+	if err := WriteProfileFile(ProfileDraft{Name: "x"}, path); err == nil {
+		t.Fatal("WriteProfileFile(): expected error when parent path contains a file")
+	}
+}
+
+// --- CollectRepos ---
+
+// initRepoWithBranch creates a non-bare git repo with one empty commit on the
+// given branch. ls-remote requires at least one object to return the symref.
+func initRepoWithBranch(t *testing.T, branch string) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	cmds := [][]string{
+		{"git", "init", dir},
+		{"git", "-C", dir, "symbolic-ref", "HEAD", "refs/heads/" + branch},
+		{"git", "-C", dir, "config", "user.email", "test@example.com"},
+		{"git", "-C", dir, "config", "user.name", "Test"},
+		{"git", "-C", dir, "commit", "--allow-empty", "-m", "init"},
+	}
+	for _, cmd := range cmds {
+		if err := exec.Command(cmd[0], cmd[1:]...).Run(); err != nil {
+			t.Fatalf("%v: %v", cmd, err)
+		}
+	}
+	return dir
+}
+
+func TestCollectRepos_noRepos(t *testing.T) {
+	reader := bufio.NewReader(strings.NewReader("n\n"))
+	repos := CollectRepos(reader)
+	if len(repos) != 0 {
+		t.Errorf("CollectRepos(): got %d repos, want 0", len(repos))
+	}
+}
+
+func TestCollectRepos_skipsWhenRequiredFieldMissing(t *testing.T) {
+	// Answer yes but leave name blank — repo should be skipped.
+	input := "y\n\nhttps://127.0.0.1:1/repo.git\n/some/path\nmain\nn\n"
+	reader := bufio.NewReader(strings.NewReader(input))
+	repos := CollectRepos(reader)
+	if len(repos) != 0 {
+		t.Errorf("CollectRepos(): expected skipped repo, got %d", len(repos))
+	}
+}
+
+func TestCollectRepos_collectsCompleteRepo(t *testing.T) {
+	// Use 127.0.0.1:1 so DetectGitDefaultBranch fails fast; branch is supplied manually.
+	input := "y\nmy-repo\nhttps://127.0.0.1:1/repo.git\n/tmp/my-repo\nmain\nn\n"
+	reader := bufio.NewReader(strings.NewReader(input))
+	repos := CollectRepos(reader)
+	if len(repos) != 1 {
+		t.Fatalf("CollectRepos(): got %d repos, want 1", len(repos))
+	}
+	r := repos[0]
+	if r.Name != "my-repo" {
+		t.Errorf("Name: got %q, want %q", r.Name, "my-repo")
+	}
+	if r.Branch != "main" {
+		t.Errorf("Branch: got %q, want %q", r.Branch, "main")
+	}
+}
+
+func TestCollectRepos_usesDetectedBranch(t *testing.T) {
+	repoDir := initRepoWithBranch(t, "trunk")
+
+	// Leave branch input blank — should pick up "trunk" from the remote.
+	input := "y\nmy-repo\nfile://" + repoDir + "\n/tmp/my-repo\n\nn\n"
+	reader := bufio.NewReader(strings.NewReader(input))
+	repos := CollectRepos(reader)
+	if len(repos) != 1 {
+		t.Fatalf("CollectRepos(): got %d repos, want 1", len(repos))
+	}
+	if repos[0].Branch != "trunk" {
+		t.Errorf("Branch: got %q, want %q", repos[0].Branch, "trunk")
+	}
+}
+
+// --- CreateRepoConfigs ---
+
+func TestCreateRepoConfigs_createsConfig(t *testing.T) {
+	dir := t.TempDir()
+	CreateRepoConfigs([]RepoDraft{
+		{Name: "my-repo", URL: "https://example.com", Path: dir, Branch: "main"},
+	})
+
+	data, err := os.ReadFile(filepath.Join(dir, "raid.yaml"))
+	if err != nil {
+		t.Fatalf("raid.yaml not created: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "name: my-repo") {
+		t.Error("raid.yaml: missing name field")
+	}
+	if !strings.Contains(content, "branch: main") {
+		t.Error("raid.yaml: missing branch field")
+	}
+}
+
+func TestCreateRepoConfigs_skipsExistingConfig(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "raid.yaml")
+	original := "original content\n"
+	os.WriteFile(configPath, []byte(original), 0644)
+
+	CreateRepoConfigs([]RepoDraft{
+		{Name: "my-repo", URL: "https://example.com", Path: dir, Branch: "main"},
+	})
+
+	data, _ := os.ReadFile(configPath)
+	if string(data) != original {
+		t.Error("CreateRepoConfigs(): overwrote existing raid.yaml")
+	}
+}
+
+func TestCreateRepoConfigs_omitsBranchWhenEmpty(t *testing.T) {
+	dir := t.TempDir()
+	CreateRepoConfigs([]RepoDraft{
+		{Name: "no-branch", URL: "https://example.com", Path: dir, Branch: ""},
+	})
+
+	data, err := os.ReadFile(filepath.Join(dir, "raid.yaml"))
+	if err != nil {
+		t.Fatalf("raid.yaml not created: %v", err)
+	}
+	if strings.Contains(string(data), "branch:") {
+		t.Error("CreateRepoConfigs(): wrote branch field when Branch is empty")
+	}
+}
+
+func TestCreateRepoConfigs_mkdirAllError(t *testing.T) {
+	file, err := os.CreateTemp("", "raid-lib-profile-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	file.Close()
+	defer os.Remove(file.Name())
+
+	// Should not panic — just print error and continue.
+	CreateRepoConfigs([]RepoDraft{
+		{Name: "x", URL: "https://example.com", Path: filepath.Join(file.Name(), "subdir"), Branch: "main"},
+	})
 }

--- a/src/internal/lib/profile_test.go
+++ b/src/internal/lib/profile_test.go
@@ -584,3 +584,17 @@ func TestCreateRepoConfigs_mkdirAllError(t *testing.T) {
 		{Name: "x", URL: "https://example.com", Path: filepath.Join(file.Name(), "subdir"), Branch: "main"},
 	})
 }
+
+func TestCreateRepoConfigs_writeError(t *testing.T) {
+	dir := t.TempDir()
+	// Make the repo directory read-only so os.WriteFile cannot create raid.yaml.
+	if err := os.Chmod(dir, 0555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(dir, 0755) })
+
+	// Should not panic — just print error and continue.
+	CreateRepoConfigs([]RepoDraft{
+		{Name: "x", URL: "https://example.com", Path: dir, Branch: "main"},
+	})
+}

--- a/src/internal/lib/task.go
+++ b/src/internal/lib/task.go
@@ -37,8 +37,9 @@ type Task struct {
 	Timeout string `json:"timeout,omitempty"`
 	// Template
 	Src string `json:"src,omitempty"`
-	// Group / Parallel / Retry
-	Ref string `json:"ref,omitempty"`
+	// Group
+	Ref      string `json:"ref,omitempty"`
+	Parallel bool   `json:"parallel,omitempty"`
 	// Git
 	Op     string `json:"op,omitempty"`
 	Branch string `json:"branch,omitempty"`
@@ -75,6 +76,7 @@ func (t Task) Expand() Task {
 		Timeout:    t.Timeout,
 		Src:        sys.ExpandPath(t.Src),
 		Ref:        t.Ref,
+		Parallel:   t.Parallel,
 		Op:         t.Op,
 		Branch:     sys.Expand(t.Branch),
 		Message:    sys.Expand(t.Message),
@@ -95,13 +97,11 @@ const (
 	HTTP     TaskType = "http"
 	Wait     TaskType = "wait"
 	Template TaskType = "template"
-	Group    TaskType = "group"
-	Git      TaskType = "git"
-	Prompt   TaskType = "prompt"
-	Confirm  TaskType = "confirm"
-	Parallel TaskType = "parallel"
-	Print    TaskType = "print"
-	Retry    TaskType = "retry"
+	Group   TaskType = "group"
+	Git     TaskType = "git"
+	Prompt  TaskType = "prompt"
+	Confirm TaskType = "confirm"
+	Print   TaskType = "print"
 )
 
 // ToLower returns the task type normalized to lowercase for case-insensitive comparisons.

--- a/src/internal/lib/task_runner.go
+++ b/src/internal/lib/task_runner.go
@@ -357,12 +357,12 @@ func execGroup(task Task) error {
 		return fmt.Errorf("ref is required for Group task")
 	}
 	if context == nil || context.Profile.Groups == nil {
-		return fmt.Errorf("no groups defined in the active profile")
+		return fmt.Errorf("no task_groups defined in the active profile")
 	}
 
 	tasks, ok := context.Profile.Groups[task.Ref]
 	if !ok {
-		return fmt.Errorf("group '%s' not found in profile", task.Ref)
+		return fmt.Errorf("task group '%s' not found in profile", task.Ref)
 	}
 
 	return ExecuteTasks(tasks)
@@ -485,12 +485,12 @@ func execParallel(task Task) error {
 		return fmt.Errorf("ref is required for Parallel task")
 	}
 	if context == nil || context.Profile.Groups == nil {
-		return fmt.Errorf("no groups defined in the active profile")
+		return fmt.Errorf("no task_groups defined in the active profile")
 	}
 
 	tasks, ok := context.Profile.Groups[task.Ref]
 	if !ok {
-		return fmt.Errorf("group '%s' not found in profile", task.Ref)
+		return fmt.Errorf("task group '%s' not found in profile", task.Ref)
 	}
 
 	concurrent := make([]Task, len(tasks))
@@ -524,12 +524,12 @@ func execRetry(task Task) error {
 		return fmt.Errorf("ref is required for Retry task")
 	}
 	if context == nil || context.Profile.Groups == nil {
-		return fmt.Errorf("no groups defined in the active profile")
+		return fmt.Errorf("no task_groups defined in the active profile")
 	}
 
 	tasks, ok := context.Profile.Groups[task.Ref]
 	if !ok {
-		return fmt.Errorf("group '%s' not found in profile", task.Ref)
+		return fmt.Errorf("task group '%s' not found in profile", task.Ref)
 	}
 
 	attempts := task.Attempts

--- a/src/internal/lib/task_runner.go
+++ b/src/internal/lib/task_runner.go
@@ -130,12 +130,8 @@ func ExecuteTask(task Task) error {
 		return execPrompt(task)
 	case Confirm:
 		return execConfirm(task)
-	case Parallel:
-		return execParallel(task)
 	case Print:
 		return execPrint(task)
-	case Retry:
-		return execRetry(task)
 	default:
 		return fmt.Errorf("invalid task type: %s", task.Type)
 	}
@@ -365,7 +361,46 @@ func execGroup(task Task) error {
 		return fmt.Errorf("task group '%s' not found in profile", task.Ref)
 	}
 
+	if task.Parallel {
+		concurrent := make([]Task, len(tasks))
+		for i, t := range tasks {
+			t.Concurrent = true
+			concurrent[i] = t
+		}
+		tasks = concurrent
+	}
+
+	if task.Attempts > 0 {
+		return execGroupWithRetry(tasks, task.Attempts, task.Delay)
+	}
+
 	return ExecuteTasks(tasks)
+}
+
+func execGroupWithRetry(tasks []Task, attempts int, delayStr string) error {
+	delay := time.Second
+	if delayStr != "" {
+		d, err := time.ParseDuration(delayStr)
+		if err != nil {
+			return fmt.Errorf("invalid delay '%s': %w", delayStr, err)
+		}
+		delay = d
+	}
+
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		if i > 0 {
+			fmt.Fprintf(commandStdout, "Retrying... (attempt %d/%d)\n", i+1, attempts)
+			time.Sleep(delay)
+		}
+		if err := ExecuteTasks(tasks); err != nil {
+			lastErr = err
+			continue
+		}
+		return nil
+	}
+
+	return fmt.Errorf("all %d attempts failed: %w", attempts, lastErr)
 }
 
 func execGit(task Task) error {
@@ -480,27 +515,6 @@ func execConfirm(task Task) error {
 	return nil
 }
 
-func execParallel(task Task) error {
-	if task.Ref == "" {
-		return fmt.Errorf("ref is required for Parallel task")
-	}
-	if context == nil || context.Profile.Groups == nil {
-		return fmt.Errorf("no task_groups defined in the active profile")
-	}
-
-	tasks, ok := context.Profile.Groups[task.Ref]
-	if !ok {
-		return fmt.Errorf("task group '%s' not found in profile", task.Ref)
-	}
-
-	concurrent := make([]Task, len(tasks))
-	for i, t := range tasks {
-		t.Concurrent = true
-		concurrent[i] = t
-	}
-
-	return ExecuteTasks(concurrent)
-}
 
 func execPrint(task Task) error {
 	msg := task.Message
@@ -519,48 +533,6 @@ func execPrint(task Task) error {
 	return nil
 }
 
-func execRetry(task Task) error {
-	if task.Ref == "" {
-		return fmt.Errorf("ref is required for Retry task")
-	}
-	if context == nil || context.Profile.Groups == nil {
-		return fmt.Errorf("no task_groups defined in the active profile")
-	}
-
-	tasks, ok := context.Profile.Groups[task.Ref]
-	if !ok {
-		return fmt.Errorf("task group '%s' not found in profile", task.Ref)
-	}
-
-	attempts := task.Attempts
-	if attempts <= 0 {
-		attempts = 3
-	}
-
-	delay := time.Second
-	if task.Delay != "" {
-		d, err := time.ParseDuration(task.Delay)
-		if err != nil {
-			return fmt.Errorf("invalid delay '%s': %w", task.Delay, err)
-		}
-		delay = d
-	}
-
-	var lastErr error
-	for i := 0; i < attempts; i++ {
-		if i > 0 {
-			fmt.Fprintf(commandStdout, "Retrying... (attempt %d/%d)\n", i+1, attempts)
-			time.Sleep(delay)
-		}
-		if err := ExecuteTasks(tasks); err != nil {
-			lastErr = err
-			continue
-		}
-		return nil
-	}
-
-	return fmt.Errorf("all %d attempts failed: %w", attempts, lastErr)
-}
 
 // withDefaultDir returns a copy of tasks with path set to dir on any Shell task
 // that does not already have an explicit path. Used to apply profile-level (home)

--- a/src/internal/lib/task_runner_extra_test.go
+++ b/src/internal/lib/task_runner_extra_test.go
@@ -67,9 +67,9 @@ func TestExecuteTask_prompt_readError(t *testing.T) {
 	}
 }
 
-// --- execParallel / execRetry group not found ---
+// --- Group parallel/retry group not found ---
 
-func TestExecuteTask_parallel_groupNotFound(t *testing.T) {
+func TestExecuteTask_group_parallel_groupNotFound(t *testing.T) {
 	context = &Context{
 		Profile: Profile{
 			Groups: map[string][]Task{
@@ -79,13 +79,13 @@ func TestExecuteTask_parallel_groupNotFound(t *testing.T) {
 	}
 	defer func() { context = nil }()
 
-	task := Task{Type: Parallel, Ref: "nonexistent"}
+	task := Task{Type: Group, Ref: "nonexistent", Parallel: true}
 	if err := ExecuteTask(task); err == nil {
-		t.Fatal("expected error for nonexistent parallel group ref, got nil")
+		t.Fatal("expected error for nonexistent group ref, got nil")
 	}
 }
 
-func TestExecuteTask_retry_groupNotFound(t *testing.T) {
+func TestExecuteTask_group_retry_groupNotFound(t *testing.T) {
 	context = &Context{
 		Profile: Profile{
 			Groups: map[string][]Task{
@@ -95,9 +95,9 @@ func TestExecuteTask_retry_groupNotFound(t *testing.T) {
 	}
 	defer func() { context = nil }()
 
-	task := Task{Type: Retry, Ref: "nonexistent"}
+	task := Task{Type: Group, Ref: "nonexistent", Attempts: 1}
 	if err := ExecuteTask(task); err == nil {
-		t.Fatal("expected error for nonexistent retry group ref, got nil")
+		t.Fatal("expected error for nonexistent group ref, got nil")
 	}
 }
 

--- a/src/internal/lib/task_runner_test.go
+++ b/src/internal/lib/task_runner_test.go
@@ -1090,24 +1090,24 @@ func TestExecuteTask_confirm_no(t *testing.T) {
 	}
 }
 
-// --- Parallel tasks ---
+// --- Group parallel mode ---
 
-func TestExecuteTask_parallel_noContext(t *testing.T) {
+func TestExecuteTask_group_parallel_noContext(t *testing.T) {
 	context = nil
-	task := Task{Type: Parallel, Ref: "mygroup"}
+	task := Task{Type: Group, Ref: "mygroup", Parallel: true}
 	if err := ExecuteTask(task); err == nil {
 		t.Fatal("expected error when context is nil, got nil")
 	}
 }
 
-func TestExecuteTask_parallel_missingRef(t *testing.T) {
-	task := Task{Type: Parallel, Ref: ""}
+func TestExecuteTask_group_parallel_missingRef(t *testing.T) {
+	task := Task{Type: Group, Ref: "", Parallel: true}
 	if err := ExecuteTask(task); err == nil {
 		t.Fatal("expected error for empty ref, got nil")
 	}
 }
 
-func TestExecuteTask_parallel_success(t *testing.T) {
+func TestExecuteTask_group_parallel_success(t *testing.T) {
 	markerA := filepath.Join(t.TempDir(), "a")
 	markerB := filepath.Join(t.TempDir(), "b")
 	context = &Context{
@@ -1122,7 +1122,7 @@ func TestExecuteTask_parallel_success(t *testing.T) {
 	}
 	defer func() { context = nil }()
 
-	task := Task{Type: Parallel, Ref: "workers"}
+	task := Task{Type: Group, Ref: "workers", Parallel: true}
 	if err := ExecuteTask(task); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1133,7 +1133,7 @@ func TestExecuteTask_parallel_success(t *testing.T) {
 	}
 }
 
-func TestExecuteTask_parallel_propagatesFailure(t *testing.T) {
+func TestExecuteTask_group_parallel_propagatesFailure(t *testing.T) {
 	context = &Context{
 		Profile: Profile{
 			Groups: map[string][]Task{
@@ -1145,30 +1145,30 @@ func TestExecuteTask_parallel_propagatesFailure(t *testing.T) {
 	}
 	defer func() { context = nil }()
 
-	task := Task{Type: Parallel, Ref: "broken"}
+	task := Task{Type: Group, Ref: "broken", Parallel: true}
 	if err := ExecuteTask(task); err == nil {
-		t.Fatal("expected error from failing parallel task, got nil")
+		t.Fatal("expected error from failing parallel group, got nil")
 	}
 }
 
-// --- Retry tasks ---
+// --- Group retry mode ---
 
-func TestExecuteTask_retry_missingRef(t *testing.T) {
-	task := Task{Type: Retry, Ref: ""}
+func TestExecuteTask_group_retry_missingRef(t *testing.T) {
+	task := Task{Type: Group, Ref: "", Attempts: 3}
 	if err := ExecuteTask(task); err == nil {
 		t.Fatal("expected error for empty ref, got nil")
 	}
 }
 
-func TestExecuteTask_retry_noContext(t *testing.T) {
+func TestExecuteTask_group_retry_noContext(t *testing.T) {
 	context = nil
-	task := Task{Type: Retry, Ref: "mygroup"}
+	task := Task{Type: Group, Ref: "mygroup", Attempts: 1}
 	if err := ExecuteTask(task); err == nil {
 		t.Fatal("expected error when context is nil, got nil")
 	}
 }
 
-func TestExecuteTask_retry_succeedsOnFirstAttempt(t *testing.T) {
+func TestExecuteTask_group_retry_succeedsOnFirstAttempt(t *testing.T) {
 	marker := filepath.Join(t.TempDir(), "ran")
 	context = &Context{
 		Profile: Profile{
@@ -1179,16 +1179,16 @@ func TestExecuteTask_retry_succeedsOnFirstAttempt(t *testing.T) {
 	}
 	defer func() { context = nil }()
 
-	task := Task{Type: Retry, Ref: "work", Attempts: 3}
+	task := Task{Type: Group, Ref: "work", Attempts: 3}
 	if err := ExecuteTask(task); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if _, err := os.Stat(marker); err != nil {
-		t.Error("expected marker to exist after successful retry task")
+		t.Error("expected marker to exist after successful group retry")
 	}
 }
 
-func TestExecuteTask_retry_exhaustsAllAttempts(t *testing.T) {
+func TestExecuteTask_group_retry_exhaustsAllAttempts(t *testing.T) {
 	context = &Context{
 		Profile: Profile{
 			Groups: map[string][]Task{
@@ -1198,7 +1198,7 @@ func TestExecuteTask_retry_exhaustsAllAttempts(t *testing.T) {
 	}
 	defer func() { context = nil }()
 
-	task := Task{Type: Retry, Ref: "always-fail", Attempts: 2, Delay: "1ms"}
+	task := Task{Type: Group, Ref: "always-fail", Attempts: 2, Delay: "1ms"}
 	err := ExecuteTask(task)
 	if err == nil {
 		t.Fatal("expected error after all retries exhausted, got nil")
@@ -1208,7 +1208,7 @@ func TestExecuteTask_retry_exhaustsAllAttempts(t *testing.T) {
 	}
 }
 
-func TestExecuteTask_retry_invalidDelay(t *testing.T) {
+func TestExecuteTask_group_retry_invalidDelay(t *testing.T) {
 	context = &Context{
 		Profile: Profile{
 			Groups: map[string][]Task{
@@ -1218,7 +1218,7 @@ func TestExecuteTask_retry_invalidDelay(t *testing.T) {
 	}
 	defer func() { context = nil }()
 
-	task := Task{Type: Retry, Ref: "work", Delay: "not-a-duration"}
+	task := Task{Type: Group, Ref: "work", Attempts: 1, Delay: "not-a-duration"}
 	if err := ExecuteTask(task); err == nil {
 		t.Fatal("expected error for invalid delay, got nil")
 	}

--- a/src/internal/sys/system.go
+++ b/src/internal/sys/system.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"unicode"
 
 	"github.com/mitchellh/go-homedir"
 )
@@ -104,6 +105,28 @@ func SplitInput(input string) []string {
 		out = append(out, b.String())
 	}
 	return out
+}
+
+// ValidateFileName reports whether name is safe to use as a filename across
+// common operating systems. It rejects empty names, path separators, shell
+// special characters, control characters, and names composed only of dots or spaces.
+func ValidateFileName(name string) error {
+	if name == "" {
+		return fmt.Errorf("name cannot be empty")
+	}
+	for _, r := range name {
+		if r == '/' || r == '\\' || r == ':' || r == '*' || r == '?' ||
+			r == '"' || r == '<' || r == '>' || r == '|' || r == '\x00' {
+			return fmt.Errorf("contains invalid character %q", r)
+		}
+		if unicode.IsControl(r) {
+			return fmt.Errorf("contains control character")
+		}
+	}
+	if strings.Trim(name, ". ") == "" {
+		return fmt.Errorf("cannot consist only of dots or spaces")
+	}
+	return nil
 }
 
 // GetPlatform returns the current operating system as a Platform value.

--- a/src/internal/sys/system.go
+++ b/src/internal/sys/system.go
@@ -1,9 +1,11 @@
 package sys
 
 import (
+	"bufio"
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -127,6 +129,35 @@ func ValidateFileName(name string) error {
 		return fmt.Errorf("cannot consist only of dots or spaces")
 	}
 	return nil
+}
+
+// ReadLine prints prompt to stdout and returns the trimmed line read from reader.
+func ReadLine(reader *bufio.Reader, prompt string) string {
+	fmt.Print(prompt)
+	line, _ := reader.ReadString('\n')
+	return strings.TrimSpace(line)
+}
+
+// ReadYesNo prompts the user and returns true if they answer "y" or "yes" (case-insensitive).
+func ReadYesNo(reader *bufio.Reader, prompt string) bool {
+	answer := ReadLine(reader, prompt)
+	return strings.EqualFold(answer, "y") || strings.EqualFold(answer, "yes")
+}
+
+// DetectGitDefaultBranch queries the remote at url to find its default branch without cloning.
+// Returns an empty string if the remote is unreachable or the branch cannot be determined.
+func DetectGitDefaultBranch(url string) string {
+	out, err := exec.Command("git", "ls-remote", "--symref", url, "HEAD").Output()
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		// Format: "ref: refs/heads/<branch>\tHEAD"
+		if strings.HasPrefix(line, "ref: refs/heads/") {
+			return strings.TrimPrefix(strings.SplitN(line, "\t", 2)[0], "ref: refs/heads/")
+		}
+	}
+	return ""
 }
 
 // GetPlatform returns the current operating system as a Platform value.

--- a/src/internal/sys/system_test.go
+++ b/src/internal/sys/system_test.go
@@ -1,8 +1,11 @@
 package sys
 
 import (
+	"bufio"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -210,4 +213,89 @@ func TestCreateFile_existingFile(t *testing.T) {
 		t.Fatalf("CreateFile() on existing file error: %v", err)
 	}
 	f.Close()
+}
+
+// --- ReadLine ---
+
+func TestReadLine(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"hello world\n", "hello world"},
+		{"  trimmed  \n", "trimmed"},
+		{"\n", ""},
+	}
+	for _, tc := range cases {
+		reader := bufio.NewReader(strings.NewReader(tc.input))
+		got := ReadLine(reader, "")
+		if got != tc.want {
+			t.Errorf("ReadLine(%q): got %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+// --- ReadYesNo ---
+
+func TestReadYesNo(t *testing.T) {
+	cases := []struct {
+		input string
+		want  bool
+	}{
+		{"y\n", true},
+		{"Y\n", true},
+		{"yes\n", true},
+		{"YES\n", true},
+		{"n\n", false},
+		{"no\n", false},
+		{"\n", false},
+		{"maybe\n", false},
+	}
+	for _, tc := range cases {
+		reader := bufio.NewReader(strings.NewReader(tc.input))
+		got := ReadYesNo(reader, "")
+		if got != tc.want {
+			t.Errorf("ReadYesNo(%q): got %v, want %v", tc.input, got, tc.want)
+		}
+	}
+}
+
+// --- DetectGitDefaultBranch ---
+
+// initRepoWithBranch creates a non-bare git repo with one empty commit on the
+// given branch. ls-remote requires at least one object to return the symref.
+func initRepoWithBranch(t *testing.T, branch string) string {
+	t.Helper()
+	dir := t.TempDir()
+	cmds := [][]string{
+		{"git", "init", dir},
+		{"git", "-C", dir, "symbolic-ref", "HEAD", "refs/heads/" + branch},
+		{"git", "-C", dir, "config", "user.email", "test@example.com"},
+		{"git", "-C", dir, "config", "user.name", "Test"},
+		{"git", "-C", dir, "commit", "--allow-empty", "-m", "init"},
+	}
+	for _, cmd := range cmds {
+		if err := exec.Command(cmd[0], cmd[1:]...).Run(); err != nil {
+			t.Fatalf("%v: %v", cmd, err)
+		}
+	}
+	return dir
+}
+
+func TestDetectGitDefaultBranch_localRepo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := initRepoWithBranch(t, "develop")
+	got := DetectGitDefaultBranch("file://" + dir)
+	if got != "develop" {
+		t.Errorf("DetectGitDefaultBranch: got %q, want %q", got, "develop")
+	}
+}
+
+func TestDetectGitDefaultBranch_unreachable(t *testing.T) {
+	got := DetectGitDefaultBranch("https://127.0.0.1:1/nonexistent.git")
+	if got != "" {
+		t.Errorf("DetectGitDefaultBranch: got %q, want empty string for unreachable remote", got)
+	}
 }

--- a/src/internal/sys/system_test.go
+++ b/src/internal/sys/system_test.go
@@ -215,6 +215,43 @@ func TestCreateFile_existingFile(t *testing.T) {
 	f.Close()
 }
 
+// --- ValidateFileName ---
+
+func TestValidateFileName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"valid simple name", "my-profile", false},
+		{"valid with underscores", "my_profile_2", false},
+		{"empty string", "", true},
+		{"forward slash", "foo/bar", true},
+		{"backslash", `foo\bar`, true},
+		{"colon", "foo:bar", true},
+		{"asterisk", "foo*bar", true},
+		{"question mark", "foo?bar", true},
+		{"double quote", `foo"bar`, true},
+		{"less than", "foo<bar", true},
+		{"greater than", "foo>bar", true},
+		{"pipe", "foo|bar", true},
+		{"null byte", "foo\x00bar", true},
+		{"control character", "foo\x01bar", true},
+		{"dots only", "...", true},
+		{"spaces only", "   ", true},
+		{"dots and spaces", " . ", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateFileName(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateFileName(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 // --- ReadLine ---
 
 func TestReadLine(t *testing.T) {
@@ -297,5 +334,27 @@ func TestDetectGitDefaultBranch_unreachable(t *testing.T) {
 	got := DetectGitDefaultBranch("https://127.0.0.1:1/nonexistent.git")
 	if got != "" {
 		t.Errorf("DetectGitDefaultBranch: got %q, want empty string for unreachable remote", got)
+	}
+}
+
+func TestDetectGitDefaultBranch_detachedHEAD(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	// Create a repo, then detach HEAD — ls-remote will return no symref line.
+	dir := initRepoWithBranch(t, "main")
+	// Detach HEAD by checking out the commit hash directly.
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("rev-parse HEAD: %v", err)
+	}
+	hash := strings.TrimSpace(string(out))
+	if err := exec.Command("git", "-C", dir, "checkout", "--detach", hash).Run(); err != nil {
+		t.Fatalf("checkout --detach: %v", err)
+	}
+
+	got := DetectGitDefaultBranch("file://" + dir)
+	if got != "" {
+		t.Errorf("DetectGitDefaultBranch with detached HEAD: got %q, want empty string", got)
 	}
 }

--- a/src/raid/profile/profile.go
+++ b/src/raid/profile/profile.go
@@ -1,9 +1,15 @@
 // Manage raid profiles.
 package profile
 
-import "github.com/8bitalex/raid/src/internal/lib"
+import (
+	"bufio"
+
+	"github.com/8bitalex/raid/src/internal/lib"
+)
 
 type Profile = lib.Profile
+type ProfileDraft = lib.ProfileDraft
+type RepoDraft = lib.RepoDraft
 
 // Returns the active profile
 func Get() Profile {
@@ -48,4 +54,19 @@ func Validate(path string) error {
 // Checks if a profile exists
 func Contains(name string) bool {
 	return lib.ContainsProfile(name)
+}
+
+// WriteFile serializes draft to path as a YAML profile file.
+func WriteFile(draft ProfileDraft, path string) error {
+	return lib.WriteProfileFile(draft, path)
+}
+
+// CollectRepos runs an interactive prompt loop to collect repository details from reader.
+func CollectRepos(reader *bufio.Reader) []RepoDraft {
+	return lib.CollectRepos(reader)
+}
+
+// CreateRepoConfigs writes a raid.yaml stub into each repository's local directory.
+func CreateRepoConfigs(repos []RepoDraft) {
+	lib.CreateRepoConfigs(repos)
 }

--- a/src/raid/raid.go
+++ b/src/raid/raid.go
@@ -41,7 +41,8 @@ func Initialize() {
 		log.Fatalf("init config: %v", err)
 	}
 	if err := Load(); err != nil {
-		log.Fatalf("load profile: %v", err)
+		// Non-fatal: allows 'raid doctor' to run and report the underlying issue.
+		fmt.Fprintf(os.Stderr, "warning: could not load profile: %v\n", err)
 	}
 	if err := lib.LoadEnv(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
@@ -71,4 +72,21 @@ func GetCommands() []lib.Command {
 // ExecuteCommand runs the named command from the active profile.
 func ExecuteCommand(name string) error {
 	return lib.ExecuteCommand(name)
+}
+
+// Severity indicates the importance of a Doctor finding.
+type Severity = lib.Severity
+
+const (
+	SeverityOK    = lib.SeverityOK
+	SeverityWarn  = lib.SeverityWarn
+	SeverityError = lib.SeverityError
+)
+
+// Finding represents the result of a single Doctor check.
+type Finding = lib.Finding
+
+// Doctor performs all configuration checks and returns the findings.
+func Doctor() []Finding {
+	return lib.RunDoctor()
 }


### PR DESCRIPTION
This pull request introduces two major new features to the project: an interactive wizard for creating profiles (`raid profile create`) and a configuration health check command (`raid doctor`). Alongside these, it updates documentation and schemas to improve clarity and consistency, particularly around task groups and task modifiers. Deprecated task types (`Parallel`, `Retry`) are removed in favor of enhanced `Group` task functionality.

**New CLI Features**

* Adds a new interactive profile creation wizard, accessible via `raid profile create`, allowing users to easily set up and register a new profile and its repositories through guided prompts. [[1]](diffhunk://#diff-51790e9ef5ff09f430d12c599ab7a06f4201ea6d6f0151959b54334412023f32R1-R76) [[2]](diffhunk://#diff-79163fbb4aebc82fe79542e1543b0a285d7d2c297ad4d63b02136fee75da1293R13)
* Introduces `raid doctor`, a command that checks the current configuration (including git, profiles, and repositories), reports issues, and offers suggestions for fixes. [[1]](diffhunk://#diff-683ad39999ddedffd027c614092037a2755fc196ff9fc05539deb058d5b8a5b6R1-R52) [[2]](diffhunk://#diff-bc1a602d899d85223ee4050edb87f38c5cfd25193a2c17213e647819c7442ee9R9) [[3]](diffhunk://#diff-bc1a602d899d85223ee4050edb87f38c5cfd25193a2c17213e647819c7442ee9R22) [[4]](diffhunk://#diff-bc1a602d899d85223ee4050edb87f38c5cfd25193a2c17213e647819c7442ee9R43) [[5]](diffhunk://#diff-f3c687f16cecea38c9f596f5292c00a59e5835e10ccf0397086f48641a908975R1-R161)

**Documentation Improvements**

* Updates the `README.md` to document the new `raid profile create` and `raid doctor` commands, clarifies the use of `task_groups` (replacing `groups`), and explains the new `Group` task modifiers (`parallel`, `attempts`, `delay`). Also removes references to deprecated `Parallel` and `Retry` task types. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L42-R48) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L58-R58) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R73-R76) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L88-R100) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L129-R134) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R155-R166) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R191-R205) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L248-R277) [[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L306-L316)

**Schema and Configuration Updates**

* Updates all schema references in `raid-profile.schema.json` and `raid-repo.schema.json` to use absolute URLs for improved editor support and validation. [[1]](diffhunk://#diff-e29a1e52023927019fb9a329b1593359d71071149c7168b24f6fdcc3b3a9fd60L37-R50) [[2]](diffhunk://#diff-19631d141c8b3537be808e35ef20f75e0266d86d7e2e3ef68703709b03239d33L18-R24)
* Renames the `groups` property to `task_groups` in schemas and documentation for clarity and to align with new task group functionality. [[1]](diffhunk://#diff-e29a1e52023927019fb9a329b1593359d71071149c7168b24f6fdcc3b3a9fd60L37-R50) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L129-R134)
* Enhances the `Group` task type in `raid-defs.schema.json` to support `parallel`, `attempts`, and `delay` modifiers, and removes the now-obsolete `Parallel` and `Retry` task types. [[1]](diffhunk://#diff-1fe2c2e673dab6cb7520326cd8f868074729a4c38a98ff7878d4567eecba3efcL99-R102) [[2]](diffhunk://#diff-1fe2c2e673dab6cb7520326cd8f868074729a4c38a98ff7878d4567eecba3efcL145-L155) [[3]](diffhunk://#diff-1fe2c2e673dab6cb7520326cd8f868074729a4c38a98ff7878d4567eecba3efcL177-L193)

These changes make it easier for users to set up and validate their raid configurations, while simplifying and unifying the task execution model.