### PR TITLE
Update GitHub Actions and add error handling for tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,9 @@ jobs:
         matrix:
           os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6.3.0
       with:
         go-version: '1.24.4'
     - name: Build

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -61,7 +61,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -13,13 +13,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.3.0
         with:
           go-version: '1.24.4'
       - name: Run Tests
         run: go test -coverprofile=coverage.txt -covermode=atomic ./...
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v5.5.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,12 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Fail if tag already exists
+        if: steps.tag.outputs.exists == 'true'
+        run: |
+          echo "::error::Tag ${{ steps.version.outputs.tag }} already exists. Bump the version in src/resources/app.properties."
+          exit 1
+
       - name: Create and push tag
         if: steps.tag.outputs.exists == 'false'
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
           echo "::error::Deploy cancelled. Check the box to confirm the version has been bumped in src/resources/app.properties."
           exit 1
 
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
@@ -47,11 +47,11 @@ jobs:
           git tag ${{ steps.version.outputs.tag }}
           git push origin ${{ steps.version.outputs.tag }}
 
-      - uses: actions/setup-go@v5.4.0
+      - uses: actions/setup-go@v6.3.0
         with:
           go-version: "1.24.4"
 
-      - uses: goreleaser/goreleaser-action@v6.3.0
+      - uses: goreleaser/goreleaser-action@v7.0.0
         with:
           version: "~> v2"
           args: release --clean

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
@@ -38,11 +38,11 @@ jobs:
           git tag ${{ steps.version.outputs.tag }}
           git push origin ${{ steps.version.outputs.tag }}
 
-      - uses: actions/setup-go@v5.4.0
+      - uses: actions/setup-go@v6.3.0
         with:
           go-version: "1.24.4"
 
-      - uses: goreleaser/goreleaser-action@v6.3.0
+      - uses: goreleaser/goreleaser-action@v7.0.0
         with:
           version: "~> v2"
           args: release --clean --config .goreleaser.preview.yaml

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -30,6 +30,12 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Fail if tag already exists
+        if: steps.tag.outputs.exists == 'true'
+        run: |
+          echo "::error::Tag ${{ steps.version.outputs.tag }} already exists. Bump the version in src/resources/app.properties."
+          exit 1
+
       - name: Create and push preview tag
         if: steps.tag.outputs.exists == 'false'
         run: |


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to use newer versions of actions and adds a safety check to prevent creating duplicate tags during deployment and preview releases. These changes improve CI reliability, security, and maintainability.

**Workflow action version upgrades:**

- Updated `actions/checkout` to `v6.0.2` across all workflows for improved performance and security. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L19-R21) [[2]](diffhunk://#diff-27456786e30ce9b1fa39c43f4e26f41177ee995f0a650d6d5aba7a826efbfe30L31-R31) [[3]](diffhunk://#diff-53fec9c265fdba82268df5cd90315b8da57cce43d8e20efbf5c0bdcd1de1342eL64-R64) [[4]](diffhunk://#diff-512f30627f95d7fcdc76dc362d896351e9a4539994b7ab00b41979e653a6d0a9L16-R23) [[5]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L23-R23) [[6]](diffhunk://#diff-16e486445ce2ea5726b0c68b85147885aad9b8e9b6fe2dcee6f0369a8bba5eeeL14-R14)
- Upgraded `actions/setup-go` to `v6.3.0` and `codecov/codecov-action` to `v5.5.2` for better compatibility and features. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L19-R21) [[2]](diffhunk://#diff-512f30627f95d7fcdc76dc362d896351e9a4539994b7ab00b41979e653a6d0a9L16-R23) [[3]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L50-R60) [[4]](diffhunk://#diff-16e486445ce2ea5726b0c68b85147885aad9b8e9b6fe2dcee6f0369a8bba5eeeL41-R51)
- Updated `goreleaser/goreleaser-action` to `v7.0.0` in deploy and preview workflows. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L50-R60) [[2]](diffhunk://#diff-16e486445ce2ea5726b0c68b85147885aad9b8e9b6fe2dcee6f0369a8bba5eeeL41-R51)

**Deployment and preview safety improvements:**

- Added a step to both deploy and preview workflows to fail the job if the git tag already exists, preventing accidental duplicate releases and prompting the user to bump the version. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R42-R47) [[2]](diffhunk://#diff-16e486445ce2ea5726b0c68b85147885aad9b8e9b6fe2dcee6f0369a8bba5eeeR33-R38)