### PR TITLE
Add version tag check to GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,8 @@ jobs:
           echo "Version ${TAG} is new."
 
   build:
+    needs: version-check
+    if: always() && (needs.version-check.result == 'success' || needs.version-check.result == 'skipped')
     runs-on: ${{ matrix.os }}
     strategy:
         matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           VERSION=$(awk -F= '/^version=/{print $2}' src/resources/app.properties)
           TAG="v${VERSION}"
           if git rev-parse "${TAG}" >/dev/null 2>&1; then
-            echo "::error::Tag ${TAG} already exists as a release or pre-release. Bump the version in src/resources/app.properties."
+            echo "::error::Tag ${TAG} already exists as a git tag. Bump the version in src/resources/app.properties."
             exit 1
           fi
           echo "Version ${TAG} is new."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,23 @@ on:
   workflow_dispatch:
 
 jobs:
+  version-check:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Fail if version tag already exists
+        run: |
+          VERSION=$(awk -F= '/^version=/{print $2}' src/resources/app.properties)
+          TAG="v${VERSION}"
+          if git rev-parse "${TAG}" >/dev/null 2>&1; then
+            echo "::error::Tag ${TAG} already exists as a release or pre-release. Bump the version in src/resources/app.properties."
+            exit 1
+          fi
+          echo "Version ${TAG} is new."
+
   build:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           VERSION=$(awk -F= '/^version=/{print $2}' src/resources/app.properties)
           TAG="v${VERSION}"
-          if git rev-parse "${TAG}" >/dev/null 2>&1; then
+          if git rev-parse "refs/tags/${TAG}" >/dev/null 2>&1; then
             echo "::error::Tag ${TAG} already exists as a git tag. Bump the version in src/resources/app.properties."
             exit 1
           fi

--- a/src/resources/app.properties
+++ b/src/resources/app.properties
@@ -1,2 +1,2 @@
-version=0.2.2-beta
+version=0.2.3-beta
 environment=development


### PR DESCRIPTION
This pull request introduces a new workflow job to prevent duplicate version tags during pull requests. Specifically, it adds a `version-check` job to the GitHub Actions workflow, ensuring that the version specified in `src/resources/app.properties` has not already been tagged in the repository. This helps maintain proper release versioning and avoids accidental overwrites.

**CI/CD improvements:**

* Added a `version-check` job to `.github/workflows/build.yml` that runs on pull requests. This job checks if the version tag from `src/resources/app.properties` already exists, and fails the workflow if it does, prompting the user to bump the version.