### PR TITLE
Simplify version format in goreleaser configuration

### DIFF
--- a/.goreleaser.preview.yaml
+++ b/.goreleaser.preview.yaml
@@ -3,7 +3,7 @@ version: 2
 before:
   hooks:
     - go mod tidy
-    - bash -c 'VERSION=$(awk -F= "/^version=/{print $2}" src/resources/app.properties) && SHA=$(git rev-parse --short HEAD) && printf "version=%s-preview.%s\nenvironment=preview\n" "$VERSION" "$SHA" > src/resources/app.properties'
+    - bash -c 'VERSION=$(awk -F= "/^version=/{print \$2}" src/resources/app.properties) && printf "version=%s-preview\nenvironment=preview\n" "$VERSION" > src/resources/app.properties'
 
 builds:
   - env:

--- a/src/resources/app.properties
+++ b/src/resources/app.properties
@@ -1,2 +1,2 @@
-version=0.2.4-beta
+version=0.2.5-beta
 environment=development


### PR DESCRIPTION
This pull request makes a minor update to the application versioning. The main change is incrementing the version number in `app.properties`, and a small adjustment to the release script in `.goreleaser.preview.yaml` to simplify how the version string is set during preview builds.

Versioning updates:

* Incremented the application version from `0.2.4-beta` to `0.2.5-beta` in `src/resources/app.properties`.

Release script changes:

* Modified the preview build hook in `.goreleaser.preview.yaml` to remove the use of the Git SHA in the version string, simplifying it to just append `-preview`.