### PR TITLE
Fix version comparison for preview updates in Execute function

### DIFF
--- a/src/cmd/raid.go
+++ b/src/cmd/raid.go
@@ -104,8 +104,7 @@ func Execute() {
 	}
 
 	version, _ := raid.GetProperty(raid.PropertyVersion)
-	compareVersion := strings.TrimSuffix(version, "-preview")
-	if latest != "" && latest != compareVersion {
+	if latest != "" && latest != baseVersion(version) {
 		var label string
 		if raid.Environment(environment) == raid.EnvironmentPreview {
 			label = "Preview update"
@@ -137,6 +136,12 @@ func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatalf("Failed to execute root command: %v", err)
 	}
+}
+
+// baseVersion strips any "-preview" suffix from a version string so that
+// preview builds compare correctly against their corresponding release tag.
+func baseVersion(version string) string {
+	return strings.TrimSuffix(version, "-preview")
 }
 
 // applyConfigFlag scans args for --config / -c so the config path is set

--- a/src/cmd/raid.go
+++ b/src/cmd/raid.go
@@ -104,7 +104,8 @@ func Execute() {
 	}
 
 	version, _ := raid.GetProperty(raid.PropertyVersion)
-	if latest != "" && latest != version {
+	compareVersion := strings.TrimSuffix(version, "-preview")
+	if latest != "" && latest != compareVersion {
 		var label string
 		if raid.Environment(environment) == raid.EnvironmentPreview {
 			label = "Preview update"

--- a/src/cmd/raid.go
+++ b/src/cmd/raid.go
@@ -138,10 +138,11 @@ func Execute() {
 	}
 }
 
-// baseVersion strips any "-preview" suffix from a version string so that
-// preview builds compare correctly against their corresponding release tag.
+// baseVersion strips "-preview" and anything following it from a version string
+// so that preview builds compare correctly against their corresponding release tag.
 func baseVersion(version string) string {
-	return strings.TrimSuffix(version, "-preview")
+	base, _, _ := strings.Cut(version, "-preview")
+	return base
 }
 
 // applyConfigFlag scans args for --config / -c so the config path is set

--- a/src/cmd/raid_test.go
+++ b/src/cmd/raid_test.go
@@ -6,6 +6,28 @@ import (
 	"github.com/8bitalex/raid/src/raid"
 )
 
+func TestBaseVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{"stable release", "1.2.3", "1.2.3"},
+		{"beta release", "1.2.3-beta", "1.2.3-beta"},
+		{"preview build", "1.2.3-preview", "1.2.3"},
+		{"beta preview build", "1.2.3-beta-preview", "1.2.3-beta"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := baseVersion(tt.version)
+			if got != tt.want {
+				t.Errorf("baseVersion(%q) = %q, want %q", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsInfoCommand(t *testing.T) {
 	tests := []struct {
 		name string

--- a/src/cmd/raid_test.go
+++ b/src/cmd/raid_test.go
@@ -16,6 +16,7 @@ func TestBaseVersion(t *testing.T) {
 		{"beta release", "1.2.3-beta", "1.2.3-beta"},
 		{"preview build", "1.2.3-preview", "1.2.3"},
 		{"beta preview build", "1.2.3-beta-preview", "1.2.3-beta"},
+		{"preview build with sha", "1.2.3-beta-preview.abc1234", "1.2.3-beta"},
 	}
 
 	for _, tt := range tests {

--- a/src/resources/app.properties
+++ b/src/resources/app.properties
@@ -1,2 +1,2 @@
-version=0.2.5-beta
+version=0.2.6-beta
 environment=development

--- a/src/resources/app.properties
+++ b/src/resources/app.properties
@@ -1,2 +1,2 @@
-version=0.2.4-beta
+version=0.2.5-beta
 environment=development


### PR DESCRIPTION
This pull request updates the application version and refines the version comparison logic to handle preview suffixes more accurately. The main changes are:

Versioning:

* Updated the `version` property in `app.properties` from `0.2.4-beta` to `0.2.5-beta` to reflect the new release.

Logic improvements:

* Modified the version comparison in the `Execute` function of `raid.go` to strip the `-preview` suffix before comparing with the latest version, ensuring correct update checks for preview builds.