### PR TITLE
Add support for command-line arguments in ExecuteCommand and update R…

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ raid build        # run the "build" command
 raid deploy       # run the "deploy" command
 ```
 
+Arguments passed after the command name are available inside tasks as `$RAID_ARG_1`, `$RAID_ARG_2`, etc.
+
+```bash
+raid deploy staging v1.2.3   # $RAID_ARG_1=staging, $RAID_ARG_2=v1.2.3
+```
+
 Custom commands appear alongside built-in commands in `raid --help`. Commands defined in a profile take priority over same-named commands from repositories.
 
 ---
@@ -369,6 +375,20 @@ commands:
 - `file` — additionally write all output to this path; supports `$VAR` expansion
 
 **Priority** — when a profile and one of its repositories define a command with the same name, the profile's definition wins.
+
+**Arguments** — any arguments passed after the command name are exposed as environment variables `RAID_ARG_1`, `RAID_ARG_2`, etc. and are available to all tasks in the command.
+
+```yaml
+commands:
+  - name: deploy
+    usage: "Deploy a service to an environment"
+    tasks:
+      - type: Shell
+        cmd: ./deploy.sh $RAID_ARG_1 $RAID_ARG_2
+```
+```bash
+raid deploy staging v1.2.3   # $RAID_ARG_1=staging, $RAID_ARG_2=v1.2.3
+```
 
 ---
 

--- a/src/cmd/raid.go
+++ b/src/cmd/raid.go
@@ -128,7 +128,7 @@ func Execute() {
 			Use:   name,
 			Short: cmd.Usage,
 			RunE: func(c *cobra.Command, args []string) error {
-				return raid.ExecuteCommand(name)
+				return raid.ExecuteCommand(name, args)
 			},
 		})
 	}

--- a/src/internal/lib/command.go
+++ b/src/internal/lib/command.go
@@ -40,7 +40,11 @@ func GetCommands() []Command {
 }
 
 // ExecuteCommand runs the tasks for the named command, applying any output configuration.
-func ExecuteCommand(name string) error {
+// Args are exposed as RAID_ARG_1, RAID_ARG_2, ... environment variables.
+func ExecuteCommand(name string, args []string) error {
+	for i, arg := range args {
+		os.Setenv(fmt.Sprintf("RAID_ARG_%d", i+1), arg)
+	}
 	for _, cmd := range GetCommands() {
 		if cmd.Name == name {
 			return runCommand(cmd)

--- a/src/internal/lib/command.go
+++ b/src/internal/lib/command.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/8bitalex/raid/src/internal/sys"
 )
@@ -40,17 +41,37 @@ func GetCommands() []Command {
 }
 
 // ExecuteCommand runs the tasks for the named command, applying any output configuration.
-// Args are exposed as RAID_ARG_1, RAID_ARG_2, ... environment variables.
+// Args are exposed as RAID_ARG_1, RAID_ARG_2, ... environment variables for the duration
+// of the command and are unset afterwards.
 func ExecuteCommand(name string, args []string) error {
+	var found Command
+	for _, cmd := range GetCommands() {
+		if cmd.Name == name {
+			found = cmd
+			break
+		}
+	}
+	if found.IsZero() {
+		return fmt.Errorf("command '%s' not found", name)
+	}
+
+	clearRaidArgs()
+	defer clearRaidArgs()
 	for i, arg := range args {
 		os.Setenv(fmt.Sprintf("RAID_ARG_%d", i+1), arg)
 	}
-	for _, cmd := range GetCommands() {
-		if cmd.Name == name {
-			return runCommand(cmd)
+
+	return runCommand(found)
+}
+
+// clearRaidArgs unsets all RAID_ARG_* environment variables.
+func clearRaidArgs() {
+	for _, kv := range os.Environ() {
+		key, _, _ := strings.Cut(kv, "=")
+		if strings.HasPrefix(key, "RAID_ARG_") {
+			os.Unsetenv(key)
 		}
 	}
-	return fmt.Errorf("command '%s' not found", name)
 }
 
 func runCommand(cmd Command) error {

--- a/src/internal/lib/command_test.go
+++ b/src/internal/lib/command_test.go
@@ -70,7 +70,7 @@ func TestExecuteCommand_notFound(t *testing.T) {
 		},
 	}
 
-	if err := ExecuteCommand("nonexistent"); err == nil {
+	if err := ExecuteCommand("nonexistent", nil); err == nil {
 		t.Fatal("ExecuteCommand() expected error for unknown command, got nil")
 	}
 }
@@ -87,7 +87,7 @@ func TestExecuteCommand_success(t *testing.T) {
 		},
 	}
 
-	if err := ExecuteCommand("noop"); err != nil {
+	if err := ExecuteCommand("noop", nil); err != nil {
 		t.Errorf("ExecuteCommand() error: %v", err)
 	}
 }
@@ -100,8 +100,35 @@ func TestExecuteCommand_taskFailure(t *testing.T) {
 		},
 	}
 
-	if err := ExecuteCommand("fail"); err == nil {
+	if err := ExecuteCommand("fail", nil); err == nil {
 		t.Fatal("ExecuteCommand() expected error from failing task, got nil")
+	}
+}
+
+func TestExecuteCommand_argsSetAsEnvVars(t *testing.T) {
+	setupTestConfig(t)
+	origOut := commandStdout
+	commandStdout = io.Discard
+	t.Cleanup(func() {
+		commandStdout = origOut
+		os.Unsetenv("RAID_ARG_1")
+		os.Unsetenv("RAID_ARG_2")
+	})
+
+	context = &Context{
+		Profile: Profile{
+			Commands: []Command{{Name: "noop", Tasks: []Task{{Type: Shell, Cmd: "exit 0"}}}},
+		},
+	}
+
+	if err := ExecuteCommand("noop", []string{"foo", "bar"}); err != nil {
+		t.Fatalf("ExecuteCommand() error: %v", err)
+	}
+	if got := os.Getenv("RAID_ARG_1"); got != "foo" {
+		t.Errorf("RAID_ARG_1 = %q, want %q", got, "foo")
+	}
+	if got := os.Getenv("RAID_ARG_2"); got != "bar" {
+		t.Errorf("RAID_ARG_2 = %q, want %q", got, "bar")
 	}
 }
 

--- a/src/internal/lib/command_test.go
+++ b/src/internal/lib/command_test.go
@@ -107,28 +107,96 @@ func TestExecuteCommand_taskFailure(t *testing.T) {
 
 func TestExecuteCommand_argsSetAsEnvVars(t *testing.T) {
 	setupTestConfig(t)
-	origOut := commandStdout
-	commandStdout = io.Discard
-	t.Cleanup(func() {
-		commandStdout = origOut
-		os.Unsetenv("RAID_ARG_1")
-		os.Unsetenv("RAID_ARG_2")
-	})
+	origOut, origErr := commandStdout, commandStderr
+	commandStdout, commandStderr = io.Discard, io.Discard
+	t.Cleanup(func() { commandStdout = origOut; commandStderr = origErr })
 
+	outFile := filepath.Join(t.TempDir(), "args.txt")
 	context = &Context{
 		Profile: Profile{
-			Commands: []Command{{Name: "noop", Tasks: []Task{{Type: Shell, Cmd: "exit 0"}}}},
+			Commands: []Command{{Name: "capture", Tasks: []Task{
+				{Type: Shell, Cmd: "printf '%s\\n%s' \"$RAID_ARG_1\" \"$RAID_ARG_2\" > " + outFile},
+			}}},
 		},
 	}
 
-	if err := ExecuteCommand("noop", []string{"foo", "bar"}); err != nil {
+	if err := ExecuteCommand("capture", []string{"foo", "bar"}); err != nil {
 		t.Fatalf("ExecuteCommand() error: %v", err)
 	}
-	if got := os.Getenv("RAID_ARG_1"); got != "foo" {
-		t.Errorf("RAID_ARG_1 = %q, want %q", got, "foo")
+
+	// Args must be available during execution.
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
 	}
-	if got := os.Getenv("RAID_ARG_2"); got != "bar" {
-		t.Errorf("RAID_ARG_2 = %q, want %q", got, "bar")
+	lines := strings.SplitN(string(data), "\n", 2)
+	if lines[0] != "foo" {
+		t.Errorf("RAID_ARG_1 during exec = %q, want %q", lines[0], "foo")
+	}
+	if len(lines) < 2 || lines[1] != "bar" {
+		t.Errorf("RAID_ARG_2 during exec = %q, want %q", func() string {
+			if len(lines) < 2 {
+				return ""
+			}
+			return lines[1]
+		}(), "bar")
+	}
+
+	// Args must be cleared after execution.
+	if got := os.Getenv("RAID_ARG_1"); got != "" {
+		t.Errorf("RAID_ARG_1 after exec = %q, want cleared", got)
+	}
+	if got := os.Getenv("RAID_ARG_2"); got != "" {
+		t.Errorf("RAID_ARG_2 after exec = %q, want cleared", got)
+	}
+}
+
+func TestExecuteCommand_staleArgsCleared(t *testing.T) {
+	setupTestConfig(t)
+	origOut, origErr := commandStdout, commandStderr
+	commandStdout, commandStderr = io.Discard, io.Discard
+	t.Cleanup(func() { commandStdout = origOut; commandStderr = origErr })
+
+	outFile := filepath.Join(t.TempDir(), "args.txt")
+	context = &Context{
+		Profile: Profile{
+			Commands: []Command{{Name: "capture", Tasks: []Task{
+				{Type: Shell, Cmd: "printf '%s' \"$RAID_ARG_2\" > " + outFile},
+			}}},
+		},
+	}
+
+	// First call with two args, second call with one — RAID_ARG_2 must not bleed through.
+	if err := ExecuteCommand("capture", []string{"first", "stale"}); err != nil {
+		t.Fatalf("first ExecuteCommand() error: %v", err)
+	}
+	if err := ExecuteCommand("capture", []string{"second"}); err != nil {
+		t.Fatalf("second ExecuteCommand() error: %v", err)
+	}
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if got := string(data); got != "" {
+		t.Errorf("RAID_ARG_2 on second call = %q, want empty (stale value leaked)", got)
+	}
+}
+
+func TestExecuteCommand_notFoundDoesNotSetArgs(t *testing.T) {
+	setupTestConfig(t)
+	os.Unsetenv("RAID_ARG_1")
+	t.Cleanup(func() { os.Unsetenv("RAID_ARG_1") })
+
+	context = &Context{
+		Profile: Profile{
+			Commands: []Command{{Name: "other", Tasks: []Task{{Type: Shell, Cmd: "exit 0"}}}},
+		},
+	}
+
+	_ = ExecuteCommand("nonexistent", []string{"should-not-be-set"})
+	if got := os.Getenv("RAID_ARG_1"); got != "" {
+		t.Errorf("RAID_ARG_1 set to %q after not-found error, want empty", got)
 	}
 }
 

--- a/src/internal/lib/command_test.go
+++ b/src/internal/lib/command_test.go
@@ -111,11 +111,17 @@ func TestExecuteCommand_argsSetAsEnvVars(t *testing.T) {
 	commandStdout, commandStderr = io.Discard, io.Discard
 	t.Cleanup(func() { commandStdout = origOut; commandStderr = origErr })
 
-	outFile := filepath.Join(t.TempDir(), "args.txt")
+	dir := t.TempDir()
+	srcFile := filepath.Join(dir, "args.tmpl")
+	outFile := filepath.Join(dir, "args.txt")
+	if err := os.WriteFile(srcFile, []byte("$RAID_ARG_1\n$RAID_ARG_2"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
 	context = &Context{
 		Profile: Profile{
 			Commands: []Command{{Name: "capture", Tasks: []Task{
-				{Type: Shell, Cmd: "printf '%s\\n%s' \"$RAID_ARG_1\" \"$RAID_ARG_2\" > " + outFile},
+				{Type: Template, Src: srcFile, Dest: outFile},
 			}}},
 		},
 	}
@@ -134,12 +140,11 @@ func TestExecuteCommand_argsSetAsEnvVars(t *testing.T) {
 		t.Errorf("RAID_ARG_1 during exec = %q, want %q", lines[0], "foo")
 	}
 	if len(lines) < 2 || lines[1] != "bar" {
-		t.Errorf("RAID_ARG_2 during exec = %q, want %q", func() string {
-			if len(lines) < 2 {
-				return ""
-			}
-			return lines[1]
-		}(), "bar")
+		arg2 := ""
+		if len(lines) >= 2 {
+			arg2 = lines[1]
+		}
+		t.Errorf("RAID_ARG_2 during exec = %q, want %q", arg2, "bar")
 	}
 
 	// Args must be cleared after execution.
@@ -157,11 +162,17 @@ func TestExecuteCommand_staleArgsCleared(t *testing.T) {
 	commandStdout, commandStderr = io.Discard, io.Discard
 	t.Cleanup(func() { commandStdout = origOut; commandStderr = origErr })
 
-	outFile := filepath.Join(t.TempDir(), "args.txt")
+	dir := t.TempDir()
+	srcFile := filepath.Join(dir, "args.tmpl")
+	outFile := filepath.Join(dir, "args.txt")
+	if err := os.WriteFile(srcFile, []byte("$RAID_ARG_2"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
 	context = &Context{
 		Profile: Profile{
 			Commands: []Command{{Name: "capture", Tasks: []Task{
-				{Type: Shell, Cmd: "printf '%s' \"$RAID_ARG_2\" > " + outFile},
+				{Type: Template, Src: srcFile, Dest: outFile},
 			}}},
 		},
 	}

--- a/src/raid/raid.go
+++ b/src/raid/raid.go
@@ -71,8 +71,8 @@ func GetCommands() []lib.Command {
 }
 
 // ExecuteCommand runs the named command from the active profile.
-func ExecuteCommand(name string) error {
-	return lib.ExecuteCommand(name)
+func ExecuteCommand(name string, args []string) error {
+	return lib.ExecuteCommand(name, args)
 }
 
 // Severity indicates the importance of a Doctor finding.

--- a/src/resources/app.properties
+++ b/src/resources/app.properties
@@ -1,2 +1,2 @@
-version=0.2.7-beta
+version=0.3.7-beta
 environment=development


### PR DESCRIPTION
This pull request adds support for passing arguments to custom and built-in commands in the `raid` tool, making them accessible as environment variables (`RAID_ARG_1`, `RAID_ARG_2`, etc.) within tasks. The documentation has been updated to explain this new feature, and tests have been added to ensure correct behavior.

**Feature: Command Arguments as Environment Variables**
* The `ExecuteCommand` function now accepts arguments and exposes them as `RAID_ARG_1`, `RAID_ARG_2`, etc. for use in tasks. (`src/internal/lib/command.go` [[1]](diffhunk://#diff-0aaab944ea9327f5e78500e117bf6c621b075792de5f8e23f432ddcbcce2d415L43-R47) `src/cmd/raid.go` [[2]](diffhunk://#diff-bc1a602d899d85223ee4050edb87f38c5cfd25193a2c17213e647819c7442ee9L131-R131) `src/raid/raid.go` [[3]](diffhunk://#diff-92224a39c7939d8fbe62dae7683f4388e60520f3200589d14fc4cb6ecf17ee8eL74-R75)
* Added a test to verify that arguments are correctly set as environment variables. (`src/internal/lib/command_test.go` [src/internal/lib/command_test.goL103-R134](diffhunk://#diff-b5d4376cf5eebf769e77e867f8bf0bb1bb3b022f8c45691139d2080b1854ae4cL103-R134))

**Documentation Updates**
* Updated the `README.md` to document how command arguments are passed and accessed within tasks, including examples in both shell and YAML formats. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R103-R108) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R379-R392)

**Other Changes**
* Updated function calls and tests to use the new `ExecuteCommand` signature. (`src/internal/lib/command_test.go` [[1]](diffhunk://#diff-b5d4376cf5eebf769e77e867f8bf0bb1bb3b022f8c45691139d2080b1854ae4cL73-R73) [[2]](diffhunk://#diff-b5d4376cf5eebf769e77e867f8bf0bb1bb3b022f8c45691139d2080b1854ae4cL90-R90)
* Bumped the application version to `0.3.7-beta`. (`src/resources/app.properties` [src/resources/app.propertiesL1-R1](diffhunk://#diff-6db51b65e0ac97cc75a30bd02e6d299f3ab8f29024d5903518eecab43c8b8800L1-R1))…EADME