### PR TITLE
Implement session management and enhance command execution handling

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+  workflow_dispatch:
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -249,6 +249,27 @@ Run a command string in a configurable shell.
   path: ~/project  # optional: working directory. Defaults to ~ for profile tasks, repo dir for repo tasks
 ```
 
+**Shell variable propagation** — variables exported inside a Shell task are automatically captured and made available to subsequent tasks in the same command run. This means you can compute a value in one Shell task and reference it in a later `Set` task or another Shell task:
+
+```yaml
+commands:
+  - name: release
+    tasks:
+      - type: Shell
+        cmd: |
+          VERSION=$(git describe --tags --abbrev=0)
+          export VERSION
+      - type: Set
+        var: RELEASE_TAG
+        value: myapp:$VERSION   # $VERSION was exported above
+      - type: Shell
+        cmd: docker push $RELEASE_TAG
+```
+
+Shell-local variables used within the same task (never exported) are resolved by the shell itself and are not visible to later tasks.
+
+**Exit code propagation** — when a Shell task exits with a non-zero status, raid stops executing the current command and exits with the same exit code. No additional noise is printed beyond what the shell command itself wrote to stderr.
+
 ### Script
 
 Execute a script file directly.
@@ -345,7 +366,7 @@ Pause and require explicit confirmation (`y` or `yes`) before continuing. Useful
 
 ### Set
 
-Set a variable to a static or derived value, making it available to all subsequent tasks. Values persist across runs and take precedence over `.env` files and OS environment variables.
+Set a variable to a static or derived value, making it available to all subsequent tasks. Values persist across runs in `~/.raid/vars`.
 
 ```yaml
 - type: Set
@@ -364,6 +385,11 @@ Set a variable to a static or derived value, making it available to all subseque
 - type: Shell
   cmd: docker push $IMAGE_TAG
 ```
+
+**Variable precedence** (highest to lowest):
+1. `Set` task values
+2. Variables exported by Shell tasks in the current command run
+3. OS environment variables
 
 ---
 

--- a/profile.raid.yml
+++ b/profile.raid.yml
@@ -14,21 +14,17 @@ environments:
           WORD="Hello, World!"
           export WORD
           echo $WORD
-      - type: Set
-        var: GREET
-        value: $WORD
-      - type: Shell
-        cmd: echo $GREET && exit 1
 
 commands:
   - name: test
     tasks:
       - type: Shell
+        literal: true
         cmd: |
           WORD="Hello, World!"
-          export WORD
-          echo ${WORD}
+          echo $WORD
           echo "This is a test command."
+          export WORD
       - type: Set
         var: GREET
         value: $WORD

--- a/profile.raid.yml
+++ b/profile.raid.yml
@@ -10,7 +10,27 @@ environments:
   - name: dev
     tasks:
       - type: Shell
-        cmd: echo "Hello, world! - From raid"
+        cmd: |
+          WORD="Hello, World!"
+          export WORD
+          echo $WORD
       - type: Set
         var: GREET
-        value: "HELLO!"
+        value: $WORD
+      - type: Shell
+        cmd: echo $GREET && exit 1
+
+commands:
+  - name: test
+    tasks:
+      - type: Shell
+        cmd: |
+          WORD="Hello, World!"
+          export WORD
+          echo ${WORD}
+          echo "This is a test command."
+      - type: Set
+        var: GREET
+        value: $WORD
+      - type: Shell
+        cmd: echo $GREET

--- a/src/cmd/raid.go
+++ b/src/cmd/raid.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
-	"log"
 	"os"
+	"os/exec"
 	"strings"
 	"time"
 
@@ -37,7 +38,8 @@ var rootCmd = &cobra.Command{
 func init() {
 	version, err := raid.GetProperty(raid.PropertyVersion)
 	if err != nil {
-		log.Fatalf("app.properties: %v", err)
+		fmt.Fprintln(os.Stderr, "raid: app.properties:", err)
+		os.Exit(1)
 	}
 	rootCmd.Version = version
 	rootCmd.Long = "Raid v" + version + "\n\nRaid is a configurable command-line application that orchestrates common development tasks, environments, and dependencies across distributed code repositories."
@@ -125,10 +127,17 @@ func Execute() {
 		}
 	}
 
+	rootCmd.SilenceErrors = true
+	rootCmd.SilenceUsage = true
 	registerUserCommands(rootCmd, cmds)
 
 	if err := rootCmd.Execute(); err != nil {
-		log.Fatalf("Failed to execute root command: %v", err)
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			os.Exit(exitErr.ExitCode())
+		}
+		fmt.Fprintln(os.Stderr, "raid:", err)
+		os.Exit(1)
 	}
 }
 

--- a/src/internal/lib/command.go
+++ b/src/internal/lib/command.go
@@ -61,6 +61,9 @@ func ExecuteCommand(name string, args []string) error {
 		os.Setenv(fmt.Sprintf("RAID_ARG_%d", i+1), arg)
 	}
 
+	startSession()
+	defer endSession()
+
 	return runCommand(found)
 }
 

--- a/src/internal/lib/lib.go
+++ b/src/internal/lib/lib.go
@@ -44,6 +44,41 @@ var (
 	raidVarsOverridePath string // set in tests to redirect the vars file
 )
 
+// commandSession holds environment variables exported by Shell tasks for the
+// duration of a single command execution. It is nil when no command is active.
+type commandSessionStore struct {
+	mu       sync.RWMutex
+	vars     map[string]string
+	baseline map[string]string // env+raidVars snapshot taken at session start
+}
+
+var commandSession *commandSessionStore
+
+// startSession initialises a fresh session store, snapshotting the current
+// environment and raidVars so that Shell-task exports can be diffed later.
+func startSession() {
+	baseline := make(map[string]string)
+	for _, kv := range os.Environ() {
+		k, v, _ := strings.Cut(kv, "=")
+		baseline[k] = v
+	}
+	raidVarsMu.RLock()
+	for k, v := range raidVars {
+		baseline[k] = v
+	}
+	raidVarsMu.RUnlock()
+
+	commandSession = &commandSessionStore{
+		vars:     make(map[string]string),
+		baseline: baseline,
+	}
+}
+
+// endSession clears the active session store.
+func endSession() {
+	commandSession = nil
+}
+
 func raidVarsPath() string {
 	if raidVarsOverridePath != "" {
 		return raidVarsOverridePath
@@ -68,14 +103,25 @@ func loadRaidVars() {
 	}
 }
 
-// expandRaid expands $VAR and ${VAR} references, checking the raid var store
-// first and falling back to the OS environment.
+// expandRaid expands $VAR and ${VAR} references. Lookup order:
+//  1. raidVars (Set tasks) — highest priority
+//  2. commandSession vars (exports from Shell tasks in the current command)
+//  3. OS environment — lowest priority
 func expandRaid(s string) string {
 	return os.Expand(s, func(key string) string {
 		raidVarsMu.RLock()
-		defer raidVarsMu.RUnlock()
-		if v, ok := raidVars[strings.ToUpper(key)]; ok {
+		v, ok := raidVars[strings.ToUpper(key)]
+		raidVarsMu.RUnlock()
+		if ok {
 			return v
+		}
+		if commandSession != nil {
+			commandSession.mu.RLock()
+			v, ok = commandSession.vars[key]
+			commandSession.mu.RUnlock()
+			if ok {
+				return v
+			}
 		}
 		return os.Getenv(key)
 	})

--- a/src/internal/lib/lib.go
+++ b/src/internal/lib/lib.go
@@ -150,8 +150,11 @@ func expandRaidForShell(s string) string {
 		if v, ok := os.LookupEnv(key); ok {
 			return v
 		}
-		// Unknown — pass through as a shell variable reference.
-		return "$" + key
+		// Unknown — pass through using ${key} so that parameter expansions
+		// like ${FOO:-default} or ${BAR:+val} are reconstructed exactly as
+		// written rather than becoming the invalid $FOO:-default form.
+		// For a simple identifier key this is equivalent to $key in the shell.
+		return "${" + key + "}"
 	})
 }
 

--- a/src/internal/lib/lib.go
+++ b/src/internal/lib/lib.go
@@ -127,6 +127,34 @@ func expandRaid(s string) string {
 	})
 }
 
+// expandRaidForShell is like expandRaid but leaves variables that cannot be
+// resolved as literal "$key" tokens so the shell subprocess can expand them
+// itself. This prevents shell-local variable references (e.g. ${WORD} set
+// earlier in the same script) from being silently replaced with empty strings.
+func expandRaidForShell(s string) string {
+	return os.Expand(s, func(key string) string {
+		raidVarsMu.RLock()
+		v, ok := raidVars[strings.ToUpper(key)]
+		raidVarsMu.RUnlock()
+		if ok {
+			return v
+		}
+		if commandSession != nil {
+			commandSession.mu.RLock()
+			v, ok = commandSession.vars[key]
+			commandSession.mu.RUnlock()
+			if ok {
+				return v
+			}
+		}
+		if v, ok := os.LookupEnv(key); ok {
+			return v
+		}
+		// Unknown — pass through as a shell variable reference.
+		return "$" + key
+	})
+}
+
 // QuietLoad attempts a best-effort, read-only profile load. It does not create
 // config files, does not emit warnings, and returns nil if the config is absent
 // or loading fails. Intended for info-command paths (--help, --version) where

--- a/src/internal/lib/session_test.go
+++ b/src/internal/lib/session_test.go
@@ -116,6 +116,32 @@ func TestUpdateSessionFromEnv_addsChangedBaselineVars(t *testing.T) {
 	}
 }
 
+func TestUpdateSessionFromEnv_removesStaleEntryOnReversion(t *testing.T) {
+	os.Setenv("RAID_REVERT_VAR", "baseline")
+	defer os.Unsetenv("RAID_REVERT_VAR")
+
+	startSession()
+	defer endSession()
+
+	// First update: variable overridden.
+	updateSessionFromEnv([]byte("RAID_REVERT_VAR=overridden\n"))
+	commandSession.mu.RLock()
+	if commandSession.vars["RAID_REVERT_VAR"] != "overridden" {
+		commandSession.mu.RUnlock()
+		t.Fatal("expected overridden value in session after first update")
+	}
+	commandSession.mu.RUnlock()
+
+	// Second update: variable reverted to baseline value.
+	updateSessionFromEnv([]byte("RAID_REVERT_VAR=baseline\n"))
+	commandSession.mu.RLock()
+	_, exists := commandSession.vars["RAID_REVERT_VAR"]
+	commandSession.mu.RUnlock()
+	if exists {
+		t.Error("session should not retain stale value after variable reverts to baseline")
+	}
+}
+
 func TestUpdateSessionFromEnv_nilSession(t *testing.T) {
 	// Should be a no-op without panicking.
 	commandSession = nil

--- a/src/internal/lib/session_test.go
+++ b/src/internal/lib/session_test.go
@@ -145,12 +145,36 @@ func TestExpandRaidForShell_knownOSEnvVar(t *testing.T) {
 	}
 }
 
-func TestExpandRaidForShell_unknownVarPreserved(t *testing.T) {
-	// A variable that exists nowhere should be left as a $VAR token, not "".
+func TestExpandRaidForShell_unknownSimpleVarPreserved(t *testing.T) {
+	// A simple unknown variable should come back as ${VAR} (equivalent to $VAR
+	// in the shell but always uses the braced form for consistency).
 	os.Unsetenv("RAID_DEFINITELY_UNDEFINED_XYZ")
 	got := expandRaidForShell("echo $RAID_DEFINITELY_UNDEFINED_XYZ")
-	if !strings.Contains(got, "$RAID_DEFINITELY_UNDEFINED_XYZ") {
-		t.Errorf("unknown var should be preserved; got %q", got)
+	if got != "echo ${RAID_DEFINITELY_UNDEFINED_XYZ}" {
+		t.Errorf("unknown var = %q, want %q", got, "echo ${RAID_DEFINITELY_UNDEFINED_XYZ}")
+	}
+}
+
+func TestExpandRaidForShell_parameterExpansionPreserved(t *testing.T) {
+	// Shell parameter expansions like ${FOO:-default} must survive intact.
+	// os.Expand extracts the key as "FOO:-default"; wrapping it back in ${}
+	// reconstructs the original form exactly.
+	os.Unsetenv("RAID_PARAM_EXP_VAR")
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"${RAID_PARAM_EXP_VAR:-fallback}", "${RAID_PARAM_EXP_VAR:-fallback}"},
+		{"${RAID_PARAM_EXP_VAR:+present}", "${RAID_PARAM_EXP_VAR:+present}"},
+		{"${RAID_PARAM_EXP_VAR:?error msg}", "${RAID_PARAM_EXP_VAR:?error msg}"},
+		{"${RAID_PARAM_EXP_VAR:0:5}", "${RAID_PARAM_EXP_VAR:0:5}"},
+		{"${#RAID_PARAM_EXP_VAR}", "${#RAID_PARAM_EXP_VAR}"},
+	}
+	for _, tc := range cases {
+		got := expandRaidForShell(tc.input)
+		if got != tc.want {
+			t.Errorf("expandRaidForShell(%q) = %q, want %q", tc.input, got, tc.want)
+		}
 	}
 }
 
@@ -273,6 +297,85 @@ func TestShellSession_exportedVarFlowsToSetThenShell(t *testing.T) {
 	got := strings.TrimSpace(buf.String())
 	if got != "Hello, World!" {
 		t.Errorf("final echo = %q, want %q", got, "Hello, World!")
+	}
+}
+
+func TestShellSession_earlyExitStillCapturesEnv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("session capture not supported on Windows")
+	}
+	setupTestConfig(t)
+	overrideRaidVarsPath(t)
+
+	commandStdout = bytes.NewBuffer(nil)
+	t.Cleanup(func() { commandStdout = os.Stdout })
+
+	// The script exports a variable then calls `exit 0` explicitly — the env
+	// dump must still happen via the EXIT trap, not the sequential append.
+	context = &Context{
+		Profile: Profile{
+			Commands: []Command{{
+				Name: "early",
+				Tasks: []Task{
+					{Type: Shell, Literal: true, Cmd: "export EARLY_VAR=captured\nexit 0\n"},
+					{Type: SetVar, Var: "RESULT", Value: "$EARLY_VAR"},
+					{Type: Shell, Cmd: "echo $RESULT"},
+				},
+			}},
+		},
+	}
+
+	var buf bytes.Buffer
+	origOut := commandStdout
+	commandStdout = &buf
+	t.Cleanup(func() { commandStdout = origOut })
+
+	if err := ExecuteCommand("early", nil); err != nil {
+		t.Fatalf("ExecuteCommand error: %v", err)
+	}
+	if got := strings.TrimSpace(buf.String()); got != "captured" {
+		t.Errorf("echo = %q, want %q", got, "captured")
+	}
+}
+
+func TestShellSession_setECapturesEnvBeforeFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("session capture not supported on Windows")
+	}
+	setupTestConfig(t)
+	overrideRaidVarsPath(t)
+
+	// With set -e, a failing command causes an immediate exit. The EXIT trap
+	// must still capture whatever was exported before the failure.
+	context = &Context{
+		Profile: Profile{
+			Commands: []Command{{
+				Name: "sete",
+				Tasks: []Task{
+					{Type: Shell, Literal: true, Cmd: "set -e\nexport BEFORE_FAIL=yes\nfalse\nexport AFTER_FAIL=no\n"},
+				},
+			}},
+		},
+	}
+
+	// The command fails (false exits 1), but BEFORE_FAIL must be captured.
+	_ = ExecuteCommand("sete", nil)
+
+	commandSession = &commandSessionStore{
+		vars:     map[string]string{},
+		baseline: map[string]string{},
+	}
+	// Manually verify via a direct ExecuteTask + session pair.
+	startSession()
+	defer endSession()
+	_ = ExecuteTask(Task{Type: Shell, Literal: true, Cmd: "set -e\nexport SETE_VAR=hello\nfalse\n"})
+
+	commandSession.mu.RLock()
+	got := commandSession.vars["SETE_VAR"]
+	commandSession.mu.RUnlock()
+
+	if got != "hello" {
+		t.Errorf("SETE_VAR = %q, want %q — EXIT trap should capture env even after set -e failure", got, "hello")
 	}
 }
 

--- a/src/internal/lib/session_test.go
+++ b/src/internal/lib/session_test.go
@@ -1,0 +1,404 @@
+package lib
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// --- parseEnvLines ---
+
+func TestParseEnvLines_basic(t *testing.T) {
+	input := "FOO=bar\nBAZ=qux\n"
+	got := parseEnvLines(input)
+	if got["FOO"] != "bar" {
+		t.Errorf("FOO = %q, want %q", got["FOO"], "bar")
+	}
+	if got["BAZ"] != "qux" {
+		t.Errorf("BAZ = %q, want %q", got["BAZ"], "qux")
+	}
+}
+
+func TestParseEnvLines_valueContainsEquals(t *testing.T) {
+	// Only the first '=' is used as the delimiter.
+	input := "URL=http://host:8080/path?a=1&b=2\n"
+	got := parseEnvLines(input)
+	if got["URL"] != "http://host:8080/path?a=1&b=2" {
+		t.Errorf("URL = %q, want %q", got["URL"], "http://host:8080/path?a=1&b=2")
+	}
+}
+
+func TestParseEnvLines_emptyAndMalformedLines(t *testing.T) {
+	input := "\nFOO=bar\nno-equals-sign\n=emptykey\n"
+	got := parseEnvLines(input)
+	// Valid line.
+	if got["FOO"] != "bar" {
+		t.Errorf("FOO = %q, want %q", got["FOO"], "bar")
+	}
+	// Line with no '=' should be skipped.
+	if _, ok := got["no-equals-sign"]; ok {
+		t.Error("malformed line should not produce a key")
+	}
+	// Line starting with '=' has empty key — should be skipped.
+	if _, ok := got[""]; ok {
+		t.Error("empty-key line should not be stored")
+	}
+}
+
+func TestParseEnvLines_emptyInput(t *testing.T) {
+	got := parseEnvLines("")
+	if len(got) != 0 {
+		t.Errorf("expected empty map for empty input, got %v", got)
+	}
+}
+
+// --- updateSessionFromEnv ---
+
+func TestUpdateSessionFromEnv_addsNewVars(t *testing.T) {
+	startSession()
+	defer endSession()
+
+	// Simulate env output that introduces a new variable not in the baseline.
+	data := []byte("RAID_SESSION_NEW=hello\n")
+	updateSessionFromEnv(data)
+
+	commandSession.mu.RLock()
+	got := commandSession.vars["RAID_SESSION_NEW"]
+	commandSession.mu.RUnlock()
+
+	if got != "hello" {
+		t.Errorf("session var = %q, want %q", got, "hello")
+	}
+}
+
+func TestUpdateSessionFromEnv_doesNotAddBaselineVars(t *testing.T) {
+	// Pre-set an OS env var so it appears in the baseline.
+	os.Setenv("RAID_SESSION_BASELINE_VAR", "original")
+	defer os.Unsetenv("RAID_SESSION_BASELINE_VAR")
+
+	startSession()
+	defer endSession()
+
+	// Env output with the same key and same value — no change.
+	data := []byte("RAID_SESSION_BASELINE_VAR=original\n")
+	updateSessionFromEnv(data)
+
+	commandSession.mu.RLock()
+	_, exists := commandSession.vars["RAID_SESSION_BASELINE_VAR"]
+	commandSession.mu.RUnlock()
+
+	if exists {
+		t.Error("unchanged baseline variable should not be added to session vars")
+	}
+}
+
+func TestUpdateSessionFromEnv_addsChangedBaselineVars(t *testing.T) {
+	os.Setenv("RAID_SESSION_CHANGED_VAR", "old")
+	defer os.Unsetenv("RAID_SESSION_CHANGED_VAR")
+
+	startSession()
+	defer endSession()
+
+	// Same key, different value — counts as a change.
+	data := []byte("RAID_SESSION_CHANGED_VAR=new\n")
+	updateSessionFromEnv(data)
+
+	commandSession.mu.RLock()
+	got := commandSession.vars["RAID_SESSION_CHANGED_VAR"]
+	commandSession.mu.RUnlock()
+
+	if got != "new" {
+		t.Errorf("changed var = %q, want %q", got, "new")
+	}
+}
+
+func TestUpdateSessionFromEnv_nilSession(t *testing.T) {
+	// Should be a no-op without panicking.
+	commandSession = nil
+	updateSessionFromEnv([]byte("FOO=bar\n"))
+}
+
+// --- expandRaidForShell ---
+
+func TestExpandRaidForShell_knownRaidVar(t *testing.T) {
+	overrideRaidVarsPath(t)
+	if err := ExecuteTask(Task{Type: SetVar, Var: "RAID_SHELL_KNOWN", Value: "raid-value"}); err != nil {
+		t.Fatal(err)
+	}
+	got := expandRaidForShell("prefix-$RAID_SHELL_KNOWN-suffix")
+	if got != "prefix-raid-value-suffix" {
+		t.Errorf("expandRaidForShell = %q, want %q", got, "prefix-raid-value-suffix")
+	}
+}
+
+func TestExpandRaidForShell_knownOSEnvVar(t *testing.T) {
+	os.Setenv("RAID_SHELL_OS_VAR", "os-value")
+	defer os.Unsetenv("RAID_SHELL_OS_VAR")
+
+	got := expandRaidForShell("$RAID_SHELL_OS_VAR")
+	if got != "os-value" {
+		t.Errorf("expandRaidForShell = %q, want %q", got, "os-value")
+	}
+}
+
+func TestExpandRaidForShell_unknownVarPreserved(t *testing.T) {
+	// A variable that exists nowhere should be left as a $VAR token, not "".
+	os.Unsetenv("RAID_DEFINITELY_UNDEFINED_XYZ")
+	got := expandRaidForShell("echo $RAID_DEFINITELY_UNDEFINED_XYZ")
+	if !strings.Contains(got, "$RAID_DEFINITELY_UNDEFINED_XYZ") {
+		t.Errorf("unknown var should be preserved; got %q", got)
+	}
+}
+
+func TestExpandRaidForShell_raidVarWinsOverSession(t *testing.T) {
+	overrideRaidVarsPath(t)
+	if err := ExecuteTask(Task{Type: SetVar, Var: "RAID_PRIORITY_VAR", Value: "from-set"}); err != nil {
+		t.Fatal(err)
+	}
+
+	startSession()
+	defer endSession()
+	commandSession.mu.Lock()
+	commandSession.vars["RAID_PRIORITY_VAR"] = "from-session"
+	commandSession.mu.Unlock()
+
+	got := expandRaidForShell("$RAID_PRIORITY_VAR")
+	if got != "from-set" {
+		t.Errorf("expandRaidForShell = %q, want raid var %q", got, "from-set")
+	}
+}
+
+// --- session priority in expandRaid ---
+
+func TestExpandRaid_sessionVarWinsOverOSEnv(t *testing.T) {
+	os.Setenv("RAID_SESSION_PRIO_VAR", "from-os")
+	defer os.Unsetenv("RAID_SESSION_PRIO_VAR")
+
+	startSession()
+	defer endSession()
+	commandSession.mu.Lock()
+	commandSession.vars["RAID_SESSION_PRIO_VAR"] = "from-session"
+	commandSession.mu.Unlock()
+
+	got := expandRaid("$RAID_SESSION_PRIO_VAR")
+	if got != "from-session" {
+		t.Errorf("expandRaid = %q, want session var %q", got, "from-session")
+	}
+}
+
+func TestExpandRaid_raidVarWinsOverSession(t *testing.T) {
+	overrideRaidVarsPath(t)
+	if err := ExecuteTask(Task{Type: SetVar, Var: "RAID_SET_WINS_VAR", Value: "from-set"}); err != nil {
+		t.Fatal(err)
+	}
+
+	startSession()
+	defer endSession()
+	commandSession.mu.Lock()
+	commandSession.vars["RAID_SET_WINS_VAR"] = "from-session"
+	commandSession.mu.Unlock()
+
+	got := expandRaid("$RAID_SET_WINS_VAR")
+	if got != "from-set" {
+		t.Errorf("expandRaid = %q, want Set task var %q", got, "from-set")
+	}
+}
+
+// --- session lifecycle ---
+
+func TestStartSession_capturesOSEnvBaseline(t *testing.T) {
+	os.Setenv("RAID_BASELINE_CHECK_VAR", "exists")
+	defer os.Unsetenv("RAID_BASELINE_CHECK_VAR")
+
+	startSession()
+	defer endSession()
+
+	if commandSession == nil {
+		t.Fatal("startSession should initialise commandSession")
+	}
+	if _, ok := commandSession.baseline["RAID_BASELINE_CHECK_VAR"]; !ok {
+		t.Error("baseline should include current OS env vars")
+	}
+}
+
+func TestEndSession_clearsSession(t *testing.T) {
+	startSession()
+	if commandSession == nil {
+		t.Fatal("session not started")
+	}
+	endSession()
+	if commandSession != nil {
+		t.Error("endSession should set commandSession to nil")
+	}
+}
+
+// --- end-to-end: shell export → Set → Shell ---
+
+func TestShellSession_exportedVarFlowsToSetThenShell(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("session capture not supported on Windows")
+	}
+	setupTestConfig(t)
+	overrideRaidVarsPath(t)
+
+	var buf bytes.Buffer
+	origOut := commandStdout
+	commandStdout = &buf
+	t.Cleanup(func() { commandStdout = origOut })
+
+	context = &Context{
+		Profile: Profile{
+			Commands: []Command{{
+				Name: "test",
+				Tasks: []Task{
+					// Export WORD inside a literal shell script.
+					{Type: Shell, Literal: true, Cmd: "WORD=\"Hello, World!\"\nexport WORD\n"},
+					// Set task should pick up WORD from the session.
+					{Type: SetVar, Var: "GREET", Value: "$WORD"},
+					// Final shell task should see GREET via raidVars expansion.
+					{Type: Shell, Cmd: "echo $GREET"},
+				},
+			}},
+		},
+	}
+
+	if err := ExecuteCommand("test", nil); err != nil {
+		t.Fatalf("ExecuteCommand error: %v", err)
+	}
+
+	got := strings.TrimSpace(buf.String())
+	if got != "Hello, World!" {
+		t.Errorf("final echo = %q, want %q", got, "Hello, World!")
+	}
+}
+
+func TestShellSession_shellLocalVarNotExpandedByRaid(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("session capture not supported on Windows")
+	}
+	setupTestConfig(t)
+
+	var buf bytes.Buffer
+	origOut := commandStdout
+	commandStdout = &buf
+	t.Cleanup(func() { commandStdout = origOut })
+
+	// A shell-local variable ($LOCAL) is set and echoed within the SAME task.
+	// expandRaidForShell should leave $LOCAL intact so the shell resolves it.
+	context = &Context{
+		Profile: Profile{
+			Commands: []Command{{
+				Name: "local",
+				Tasks: []Task{
+					{Type: Shell, Cmd: "LOCAL=from-shell; echo $LOCAL"},
+				},
+			}},
+		},
+	}
+
+	if err := ExecuteCommand("local", nil); err != nil {
+		t.Fatalf("ExecuteCommand error: %v", err)
+	}
+
+	got := strings.TrimSpace(buf.String())
+	if got != "from-shell" {
+		t.Errorf("echo = %q, want %q", got, "from-shell")
+	}
+}
+
+// --- shell exit code propagation ---
+
+func TestExecuteTasks_shellExitCodePreserved(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("exit code test uses bash exit built-in")
+	}
+	tasks := []Task{{Type: Shell, Cmd: "exit 42"}}
+	err := ExecuteTasks(tasks)
+	if err == nil {
+		t.Fatal("expected error for non-zero exit, got nil")
+	}
+	var exitErr *exec.ExitError
+	if !isExitError(err, &exitErr) {
+		t.Fatalf("expected *exec.ExitError in chain, got: %T %v", err, err)
+	}
+	if exitErr.ExitCode() != 42 {
+		t.Errorf("exit code = %d, want 42", exitErr.ExitCode())
+	}
+}
+
+// isExitError checks if any error in the chain (including errors.Join trees) is
+// an *exec.ExitError, mirroring the logic in cmd/raid.go.
+func isExitError(err error, target **exec.ExitError) bool {
+	if err == nil {
+		return false
+	}
+	// errors.As traverses Unwrap() []error chains from errors.Join.
+	return errorsAs(err, target)
+}
+
+func errorsAs(err error, target **exec.ExitError) bool {
+	if err == nil {
+		return false
+	}
+	if e, ok := err.(*exec.ExitError); ok {
+		*target = e
+		return true
+	}
+	type unwrapList interface{ Unwrap() []error }
+	if u, ok := err.(unwrapList); ok {
+		for _, e := range u.Unwrap() {
+			if errorsAs(e, target) {
+				return true
+			}
+		}
+	}
+	type unwrapSingle interface{ Unwrap() error }
+	if u, ok := err.(unwrapSingle); ok {
+		return errorsAs(u.Unwrap(), target)
+	}
+	return false
+}
+
+// --- session cleanup: temp files are removed after shell task ---
+
+func TestShellSession_tempFileCleanedUp(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("session capture not supported on Windows")
+	}
+	setupTestConfig(t)
+
+	// Run a shell task with a session active and verify no raid-session temp
+	// files are left behind in the system temp directory afterwards.
+	before := raidSessionTempFiles(t)
+
+	startSession()
+	_ = ExecuteTask(Task{Type: Shell, Cmd: "echo hi"})
+	endSession()
+
+	after := raidSessionTempFiles(t)
+	for f := range after {
+		if _, seen := before[f]; !seen {
+			t.Errorf("temp file not cleaned up: %s", f)
+		}
+	}
+}
+
+func raidSessionTempFiles(t *testing.T) map[string]struct{} {
+	t.Helper()
+	dir := os.TempDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := make(map[string]struct{})
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".raid-session-") {
+			m[filepath.Join(dir, e.Name())] = struct{}{}
+		}
+	}
+	return m
+}

--- a/src/internal/lib/task_runner.go
+++ b/src/internal/lib/task_runner.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -79,11 +80,11 @@ func ExecuteTasks(tasks []Task) error {
 				// Wait for any already-started concurrent tasks before returning.
 				wg.Wait()
 				close(errorChan)
-				errs := []error{fmt.Errorf("failed to execute task '%s': %w", task.Type, err)}
+				errs := []error{err}
 				for e := range errorChan {
 					errs = append(errs, e)
 				}
-				return fmt.Errorf("some tasks failed to execute: %v", errs)
+				return errors.Join(errs...)
 			}
 		}
 	}
@@ -91,16 +92,12 @@ func ExecuteTasks(tasks []Task) error {
 	wg.Wait()
 	close(errorChan)
 
-	var errors []error
+	var errs []error
 	for err := range errorChan {
-		errors = append(errors, err)
+		errs = append(errs, err)
 	}
 
-	if len(errors) > 0 {
-		return fmt.Errorf("some tasks failed to execute: %v", errors)
-	}
-
-	return nil
+	return errors.Join(errs...)
 }
 
 func ExecuteTask(task Task) error {

--- a/src/internal/lib/task_runner.go
+++ b/src/internal/lib/task_runner.go
@@ -149,18 +149,73 @@ func execShell(task Task) error {
 	}
 
 	shell := getShell(task.Shell)
-	cmd := exec.Command(shell[0], append(shell[1:], task.Cmd)...)
+	cmdStr := task.Cmd
+
+	// When a session is active and we're not on Windows, wrap the command so
+	// that the full environment after execution is dumped to a temp file.
+	// This lets us capture variables exported by the shell command and make
+	// them available to subsequent tasks in the same command run.
+	var tmpFile string
+	if commandSession != nil && sys.GetPlatform() != sys.Windows {
+		if f, err := os.CreateTemp("", ".raid-session-*"); err == nil {
+			tmpFile = f.Name()
+			f.Close()
+			// Run the command in a group so multi-line scripts work, preserve
+			// the exit code, dump env, then exit with the original code.
+			cmdStr = fmt.Sprintf("{\n%s\n}; __raid_exit=$?; env > '%s'; exit $__raid_exit", task.Cmd, tmpFile)
+		}
+	}
+
+	cmd := exec.Command(shell[0], append(shell[1:], cmdStr)...)
 	if task.Path != "" {
 		cmd.Dir = sys.ExpandPath(task.Path)
 	}
 	setCmdOutput(cmd)
 
-	err := cmd.Run()
-	if err != nil {
-		return fmt.Errorf("failed to execute shell command '%s': %w", task.Cmd, err)
+	runErr := cmd.Run()
+
+	if tmpFile != "" {
+		defer os.Remove(tmpFile)
+		if data, err := os.ReadFile(tmpFile); err == nil {
+			updateSessionFromEnv(data)
+		}
 	}
 
+	if runErr != nil {
+		return fmt.Errorf("failed to execute shell command '%s': %w", task.Cmd, runErr)
+	}
 	return nil
+}
+
+// updateSessionFromEnv parses the output of `env` and stores any variables
+// that are new or changed relative to the session baseline.
+func updateSessionFromEnv(data []byte) {
+	if commandSession == nil {
+		return
+	}
+	after := parseEnvLines(string(data))
+
+	commandSession.mu.Lock()
+	defer commandSession.mu.Unlock()
+	for k, v := range after {
+		baseVal, inBase := commandSession.baseline[k]
+		if !inBase || baseVal != v {
+			commandSession.vars[k] = v
+		}
+	}
+}
+
+// parseEnvLines parses newline-separated KEY=VALUE pairs as produced by `env`.
+// Values may contain '=' characters; only the first '=' is used as delimiter.
+func parseEnvLines(output string) map[string]string {
+	result := make(map[string]string)
+	for _, line := range strings.Split(output, "\n") {
+		k, v, found := strings.Cut(line, "=")
+		if found && k != "" {
+			result[k] = v
+		}
+	}
+	return result
 }
 
 func getShell(shell string) []string {

--- a/src/internal/lib/task_runner.go
+++ b/src/internal/lib/task_runner.go
@@ -139,7 +139,14 @@ func ExecuteTask(task Task) error {
 
 func execShell(task Task) error {
 	if !task.Literal {
-		task = task.Expand()
+		// Expand Path and Shell with the standard expander, but expand Cmd
+		// with the shell-aware expander so that variables not known to raid
+		// (e.g. shell-local vars set earlier in the same script) are left as
+		// "$VAR" tokens for the shell to resolve, rather than silently becoming
+		// empty strings.
+		task.Path = sys.ExpandPath(expandRaid(task.Path))
+		task.Shell = expandRaid(task.Shell)
+		task.Cmd = expandRaidForShell(task.Cmd)
 	}
 	if task.Cmd == "" {
 		return fmt.Errorf("cmd is required for Shell task")

--- a/src/internal/lib/task_runner.go
+++ b/src/internal/lib/task_runner.go
@@ -72,7 +72,7 @@ func ExecuteTasks(tasks []Task) error {
 			go func(task Task) {
 				defer wg.Done()
 				if err := ExecuteTask(task); err != nil {
-					errorChan <- fmt.Errorf("failed to execute task '%s': %w", task.Type, err)
+					errorChan <- err
 				}
 			}(task)
 		} else {
@@ -164,9 +164,14 @@ func execShell(task Task) error {
 		if f, err := os.CreateTemp("", ".raid-session-*"); err == nil {
 			tmpFile = f.Name()
 			f.Close()
-			// Run the command in a group so multi-line scripts work, preserve
-			// the exit code, dump env, then exit with the original code.
-			cmdStr = fmt.Sprintf("{\n%s\n}; __raid_exit=$?; env > '%s'; exit $__raid_exit", task.Cmd, tmpFile)
+			// Register an EXIT trap so the environment is dumped on all exit
+			// paths — including early exits from `exit N`, `set -e`, or any
+			// signal that terminates the shell. The trap captures $? before
+			// running env so the original exit code is preserved.
+			cmdStr = fmt.Sprintf(
+				"__raid_tmp='%s'\ntrap '__raid_exit=$?; env > \"$__raid_tmp\"; exit $__raid_exit' EXIT\n%s",
+				tmpFile, task.Cmd,
+			)
 		}
 	}
 

--- a/src/internal/lib/task_runner.go
+++ b/src/internal/lib/task_runner.go
@@ -196,8 +196,11 @@ func execShell(task Task) error {
 	return nil
 }
 
-// updateSessionFromEnv parses the output of `env` and stores any variables
-// that are new or changed relative to the session baseline.
+// updateSessionFromEnv parses the output of `env` and updates the session to
+// reflect variables that differ from the baseline. When a variable that was
+// previously captured in the session is seen with its baseline value again
+// (i.e. a later task reset it), the entry is removed so the baseline value
+// is used rather than a stale override from an earlier task.
 func updateSessionFromEnv(data []byte) {
 	if commandSession == nil {
 		return
@@ -210,6 +213,10 @@ func updateSessionFromEnv(data []byte) {
 		baseVal, inBase := commandSession.baseline[k]
 		if !inBase || baseVal != v {
 			commandSession.vars[k] = v
+		} else {
+			// Value matches the baseline — remove any stale session entry so
+			// a reversion by a later task is not hidden behind an older value.
+			delete(commandSession.vars, k)
 		}
 	}
 }

--- a/src/resources/app.properties
+++ b/src/resources/app.properties
@@ -1,2 +1,2 @@
-version=0.4.0-beta
+version=0.4.1-beta
 environment=development


### PR DESCRIPTION
This pull request introduces robust support for variable propagation between tasks and improves error handling and documentation. The most significant change is that variables exported in one Shell task are now automatically available to subsequent tasks in the same command run, enabling more dynamic and flexible workflows. Additionally, the documentation is updated to clarify variable precedence and persistence, and error handling is more consistent throughout the application.

**Variable Propagation and Session Management**
* Introduced a session store (`commandSessionStore`) to capture and propagate variables exported by Shell tasks, making them available to subsequent tasks within the same command run. This includes mechanisms to snapshot, diff, and update the environment as tasks are executed. (`src/internal/lib/lib.go` [[1]](diffhunk://#diff-c7d99b5a8cccee220ac156e6bfbfd3b058f22a87ce4fbfe64723769a49ca3776R47-R81) [[2]](diffhunk://#diff-c7d99b5a8cccee220ac156e6bfbfd3b058f22a87ce4fbfe64723769a49ca3776L71-R157); `src/internal/lib/task_runner.go` [[3]](diffhunk://#diff-48e07e0e139ed7669546b48951e65f2da713c15e862113ab68517e1f477f2fc0L145-R224) [[4]](diffhunk://#diff-48e07e0e139ed7669546b48951e65f2da713c15e862113ab68517e1f477f2fc0L82-R100); `src/internal/lib/command.go` [[5]](diffhunk://#diff-0aaab944ea9327f5e78500e117bf6c621b075792de5f8e23f432ddcbcce2d415R64-R66)
* Added a shell-aware variable expander (`expandRaidForShell`) to ensure that shell-local variables are not prematurely expanded by raid, preserving their correct resolution within the shell. (`src/internal/lib/lib.go` [[1]](diffhunk://#diff-c7d99b5a8cccee220ac156e6bfbfd3b058f22a87ce4fbfe64723769a49ca3776L71-R157) [[2]](diffhunk://#diff-48e07e0e139ed7669546b48951e65f2da713c15e862113ab68517e1f477f2fc0L145-R224)

**Documentation Updates**
* Updated the `README.md` to clearly explain shell variable propagation, exit code propagation, and the new variable precedence order. Also clarified that `Set` task values persist in `~/.raid/vars`. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R252-R272) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L348-R369) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R389-R393)
* Enhanced the example in `profile.raid.yml` to demonstrate variable export and propagation between tasks. (`profile.raid.yml` [profile.raid.ymlL13-R32](diffhunk://#diff-9833deb1452e2f9489bc7f0df048d55c95b3ddd5cdba86904193112de057cac5L13-R32))

**Error Handling Improvements**
* Standardized error handling by removing direct use of `log.Fatalf`, ensuring errors are printed to stderr and the process exits with appropriate codes, especially for shell task failures. (`src/cmd/raid.go` [[1]](diffhunk://#diff-bc1a602d899d85223ee4050edb87f38c5cfd25193a2c17213e647819c7442ee9R4-R7) [[2]](diffhunk://#diff-bc1a602d899d85223ee4050edb87f38c5cfd25193a2c17213e647819c7442ee9L40-R42) [[3]](diffhunk://#diff-bc1a602d899d85223ee4050edb87f38c5cfd25193a2c17213e647819c7442ee9R130-R140)
* Improved task runner error aggregation by using `errors.Join` for clearer multi-error reporting. (`src/internal/lib/task_runner.go` [src/internal/lib/task_runner.goL82-R100](diffhunk://#diff-48e07e0e139ed7669546b48951e65f2da713c15e862113ab68517e1f477f2fc0L82-R100))

**Miscellaneous**
* Bumped the application version from `0.4.0-beta` to `0.4.1-beta`. (`src/resources/app.properties` [src/resources/app.propertiesL1-R1](diffhunk://#diff-6db51b65e0ac97cc75a30bd02e6d299f3ab8f29024d5903518eecab43c8b8800L1-R1))