### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   changed-files:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -9,6 +9,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       has_changes: ${{ steps.changes.outputs.has_changes }}
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/8bitAlex/raid/security/code-scanning/7](https://github.com/8bitAlex/raid/security/code-scanning/7)

Add an explicit workflow-level `permissions` block in `.github/workflows/build.yml` so all jobs inherit least-privilege token access.

Best fix here: insert at the top level (after `on:` block, before `jobs:`) the minimal required scope:

- `permissions:`
  - `contents: read`

This preserves existing functionality (`actions/checkout`, reading repo content, running build/tests) while preventing accidental broad token access now or in future default changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
