### PR TITLE
fix(task): share stdin reader across Prompt/Confirm tasks

### DIFF
--- a/src/internal/lib/task_runner.go
+++ b/src/internal/lib/task_runner.go
@@ -29,6 +29,30 @@ var (
 // tasks do not interleave reads or compete for input.
 var stdinMu sync.Mutex
 
+// stdinReader is a package-level buffered reader over os.Stdin, shared across
+// all Prompt and Confirm tasks so that bytes buffered ahead by one task are
+// still available to the next. Creating a fresh bufio.Reader per call would
+// discard any line(s) that got pulled into the old reader's buffer along with
+// the one that was actually returned — on piped input this caused the next
+// Prompt to see EOF instead of waiting for input.
+//
+// stdinReaderFor tracks which os.Stdin the reader was built for so that tests
+// that swap os.Stdin (e.g. to a pipe) get a fresh reader tied to the new fd.
+var (
+	stdinReader    *bufio.Reader
+	stdinReaderFor *os.File
+)
+
+// getStdinReader returns the shared stdin reader, (re)creating it whenever
+// os.Stdin has been swapped. Callers must hold stdinMu.
+func getStdinReader() *bufio.Reader {
+	if stdinReader == nil || stdinReaderFor != os.Stdin {
+		stdinReader = bufio.NewReader(os.Stdin)
+		stdinReaderFor = os.Stdin
+	}
+	return stdinReader
+}
+
 var colorCodes = map[string]string{
 	"red":    "\033[31m",
 	"green":  "\033[32m",
@@ -550,8 +574,7 @@ func execPrompt(task Task) error {
 
 	fmt.Fprint(commandStdout, message+" ")
 
-	reader := bufio.NewReader(os.Stdin)
-	value, err := reader.ReadString('\n')
+	value, err := getStdinReader().ReadString('\n')
 	if err != nil {
 		return fmt.Errorf("failed to read input: %w", err)
 	}
@@ -576,8 +599,7 @@ func execConfirm(task Task) error {
 
 	fmt.Fprint(commandStdout, message+" [y/N] ")
 
-	reader := bufio.NewReader(os.Stdin)
-	answer, err := reader.ReadString('\n')
+	answer, err := getStdinReader().ReadString('\n')
 	if err != nil {
 		return fmt.Errorf("failed to read input: %w", err)
 	}

--- a/src/internal/lib/task_runner_test.go
+++ b/src/internal/lib/task_runner_test.go
@@ -1064,7 +1064,10 @@ func TestExecuteTask_prompt_consecutiveReads(t *testing.T) {
 
 	origStdin := os.Stdin
 	os.Stdin = r
-	defer func() { os.Stdin = origStdin }()
+	defer func() {
+		os.Stdin = origStdin
+		_ = r.Close()
+	}()
 
 	if err := ExecuteTask(Task{Type: Prompt, Var: "RAID_PROMPT_FIRST"}); err != nil {
 		t.Fatalf("first prompt: unexpected error: %v", err)

--- a/src/internal/lib/task_runner_test.go
+++ b/src/internal/lib/task_runner_test.go
@@ -1042,6 +1042,45 @@ func TestExecuteTask_prompt_usesDefault(t *testing.T) {
 	os.Unsetenv("RAID_PROMPT_DEFAULT_TEST")
 }
 
+// TestExecuteTask_prompt_consecutiveReads is a regression test for a bug where
+// a fresh bufio.Reader was created on every Prompt/Confirm invocation. On
+// piped input, the first reader could buffer more than one line, return the
+// first, and discard the rest when it went out of scope — causing the next
+// Prompt to see EOF instead of waiting for input.
+func TestExecuteTask_prompt_consecutiveReads(t *testing.T) {
+	os.Unsetenv("RAID_PROMPT_FIRST")
+	os.Unsetenv("RAID_PROMPT_SECOND")
+	t.Cleanup(func() {
+		os.Unsetenv("RAID_PROMPT_FIRST")
+		os.Unsetenv("RAID_PROMPT_SECOND")
+	})
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.WriteString("alice\nsmith\n")
+	w.Close()
+
+	origStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin }()
+
+	if err := ExecuteTask(Task{Type: Prompt, Var: "RAID_PROMPT_FIRST"}); err != nil {
+		t.Fatalf("first prompt: unexpected error: %v", err)
+	}
+	if err := ExecuteTask(Task{Type: Prompt, Var: "RAID_PROMPT_SECOND"}); err != nil {
+		t.Fatalf("second prompt: unexpected error: %v", err)
+	}
+
+	if got := os.Getenv("RAID_PROMPT_FIRST"); got != "alice" {
+		t.Errorf("RAID_PROMPT_FIRST = %q, want %q", got, "alice")
+	}
+	if got := os.Getenv("RAID_PROMPT_SECOND"); got != "smith" {
+		t.Errorf("RAID_PROMPT_SECOND = %q, want %q", got, "smith")
+	}
+}
+
 // --- Confirm tasks ---
 
 func TestExecuteTask_confirm_yes(t *testing.T) {

--- a/src/resources/app.properties
+++ b/src/resources/app.properties
@@ -1,2 +1,2 @@
-version=0.5.2-beta
+version=0.5.3-beta
 environment=development


### PR DESCRIPTION
## Summary

Fixes a bug where the `Prompt` task appeared not to wait for user input.

`execPrompt` and `execConfirm` each constructed a fresh `bufio.Reader` over `os.Stdin` and discarded it at the end of the call. On piped input, the first reader could pull more than one line into its 4096-byte buffer, return the first line, and drop the rest when it went out of scope — leaving the next Prompt to read from an exhausted stdin and fail with `failed to read input: EOF` (or, if only some bytes were consumed, skip the user's next answer).

## Reproduction (before the fix)

```yaml
commands:
  - name: ask
    tasks:
      - type: Prompt
        var: FIRST_NAME
        message: "First name?"
      - type: Prompt
        var: LAST_NAME
        message: "Last name?"
```

```bash
$ printf "Alice\nSmith\n" | raid ask
First name? Last name? raid: failed to read input: EOF
```

## Fix

`Prompt` and `Confirm` now share a package-level `bufio.Reader` guarded by the existing `stdinMu`. The reader is lazily (re)created whenever `os.Stdin` is swapped (so tests that replace `os.Stdin` with a pipe still get a fresh reader tied to the new fd). Bytes the reader buffers ahead for one task remain visible to the next.

## Test plan

- [x] Added `TestExecuteTask_prompt_consecutiveReads` — a regression test that would have failed on `main` with `failed to read input: EOF`
- [x] All existing Prompt and Confirm tests still pass
- [x] `go test ./...` green
- [x] End-to-end: `printf "Alice\nSmith\n" | raid ask` now prints `Hello, Alice Smith!` and exits 0