### PR TITLE
docs(seo): address Copilot review feedback from #35

### DIFF
--- a/docs/assets/gen_social_preview.py
+++ b/docs/assets/gen_social_preview.py
@@ -1,5 +1,21 @@
 #!/usr/bin/env python3
-"""Generate a GitHub social preview card for raid (1280x640)."""
+"""Generate a GitHub social preview card for raid (1280x640).
+
+Usage:
+    python3 docs/assets/gen_social_preview.py [--out PATH]
+
+Dependencies: Pillow (`pip install Pillow`).
+
+Fonts: uses DejaVu Sans (Regular/Bold) and DejaVu Sans Mono (Regular/Bold).
+Candidate paths below cover typical Linux, macOS, and Windows installations;
+pass any missing ones with DEJAVU_FONT_DIR=/path if your system keeps them
+somewhere custom.
+"""
+import argparse
+import os
+import sys
+from pathlib import Path
+
 from PIL import Image, ImageDraw, ImageFont
 
 W, H = 1280, 640
@@ -14,11 +30,40 @@ ACCENT    = (255, 107, 71)        # #FF6B47 warm coral
 GREEN     = (63, 185, 80)         # #3FB950
 YELLOW    = (210, 153, 34)        # #D29922
 
-# Fonts
-SANS_BOLD = "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf"
-SANS      = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
-MONO_BOLD = "/usr/share/fonts/truetype/dejavu/DejaVuSansMono-Bold.ttf"
-MONO      = "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf"
+
+def _find_font(filename: str) -> str:
+    """Locate a DejaVu font file across common platform locations."""
+    env_dir = os.environ.get("DEJAVU_FONT_DIR")
+    candidates = []
+    if env_dir:
+        candidates.append(Path(env_dir) / filename)
+    candidates += [
+        # Linux
+        Path("/usr/share/fonts/truetype/dejavu") / filename,
+        Path("/usr/share/fonts/TTF") / filename,
+        Path("/usr/share/fonts/dejavu") / filename,
+        # macOS (Homebrew cask + manual install)
+        Path("/opt/homebrew/share/fonts") / filename,
+        Path("/usr/local/share/fonts") / filename,
+        Path.home() / "Library/Fonts" / filename,
+        # Windows
+        Path(r"C:\Windows\Fonts") / filename,
+    ]
+    for p in candidates:
+        if p.is_file():
+            return str(p)
+    sys.exit(
+        f"error: could not find {filename}.\n"
+        "Install the DejaVu fonts (e.g. `apt install fonts-dejavu`, "
+        "`brew install --cask font-dejavu`) or set DEJAVU_FONT_DIR to "
+        "the directory containing them."
+    )
+
+
+SANS_BOLD = _find_font("DejaVuSans-Bold.ttf")
+SANS      = _find_font("DejaVuSans.ttf")
+MONO_BOLD = _find_font("DejaVuSansMono-Bold.ttf")
+MONO      = _find_font("DejaVuSansMono.ttf")
 
 img = Image.new("RGB", (W, H), BG)
 d = ImageDraw.Draw(img)
@@ -130,7 +175,17 @@ cursor_x = content_x + 22
 cursor_y = content_y - 2
 d.rectangle([cursor_x, cursor_y, cursor_x + 14, cursor_y + 26], fill=ACCENT)
 
-# Save
-out = "/home/user/raid/docs/assets/social-preview.png"
-img.save(out, "PNG", optimize=True)
-print(f"Wrote {out} ({W}x{H})")
+# Save — default to writing next to this script (docs/assets/social-preview.png)
+# so the script works from any checkout. Override with --out.
+parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+parser.add_argument(
+    "--out",
+    type=Path,
+    default=Path(__file__).resolve().parent / "social-preview.png",
+    help="Output PNG path (default: %(default)s)",
+)
+args = parser.parse_args()
+
+args.out.parent.mkdir(parents=True, exist_ok=True)
+img.save(args.out, "PNG", optimize=True)
+print(f"Wrote {args.out} ({W}x{H})")

--- a/llms.txt
+++ b/llms.txt
@@ -4,7 +4,7 @@
 
 Raid solves the "how do I run this, again?" problem for teams working across multiple Git repositories. A top-level **profile** (`*.raid.yaml`) describes repositories, environments, install steps, and custom commands. Each repo can also commit a `raid.yaml` at its root — Raid merges these automatically at load time. Developers use `raid install` to clone and set up everything, `raid env <name>` to switch the full system between local/staging/production, and `raid <cmd>` to run team-defined workflows like `raid test`, `raid patch`, or `raid deploy`.
 
-Raid is written in Go, distributed as a single static binary, and published under the GNU General Public License v3.0.
+Raid is written in Go, distributed as a single self-contained binary, and published under the GNU General Public License v3.0.
 
 ## Docs
 


### PR DESCRIPTION
Follow-up to merged #35 — addresses the three Copilot review comments that came in after the PR was merged.

## Changes

### `llms.txt`
> "single static binary" → "single **self-contained** binary"

Go binaries aren't strictly statically linked on macOS/Windows even with CGO disabled, so the original wording was overclaiming.

### `docs/assets/gen_social_preview.py`

1. **Portable font discovery.** Replaced the hardcoded Linux paths (`/usr/share/fonts/truetype/dejavu/...`) with a `_find_font()` helper that searches common Linux, macOS (Homebrew + user Library), and Windows locations. Honors `DEJAVU_FONT_DIR` as an override and prints a clear install hint if none of the candidates match.

2. **Portable output path.** Default `--out` is now `<this-script-dir>/social-preview.png` (resolved via `__file__`) instead of `/home/user/raid/docs/assets/social-preview.png`. Added an `argparse` `--out` flag and `mkdir(parents=True, exist_ok=True)` for the parent directory.

## Test plan

- [x] `python3 docs/assets/gen_social_preview.py` produces **byte-identical** output to the previously committed `social-preview.png` (verified via `cmp`)
- [x] `python3 docs/assets/gen_social_preview.py --out /tmp/custom.png` works with a non-default path
- [x] Script exits with a clear error message when DejaVu fonts aren't installed (tested by temporarily moving the fonts aside)
- [x] No other files in the repo reference the old hardcoded paths