### PR TITLE
New Context command

### DIFF
--- a/profile.raid.yml
+++ b/profile.raid.yml
@@ -18,6 +18,7 @@ commands:
         message: "==> Building raid app"
         color: cyan
       - type: Shell
+        name: Build raid app
         cmd: go build ./...
         path: ~/Developer/raid
       - type: Print

--- a/schemas/raid-defs.schema.json
+++ b/schemas/raid-defs.schema.json
@@ -14,169 +14,375 @@
                 "type": "object",
                 "oneOf": [
                     {
-                        "type": "object",
-                        "properties": {
-                            "type": { "type": "string", "const": "Shell" },
-                            "concurrent": { "$ref": "#/$defs/concurrent" },
-                            "condition": { "$ref": "#/$defs/condition" },
-                            "cmd": { "type": "string", "description": "Command to execute" },
-                            "shell": {
-                                "type": "string",
-                                "enum": ["bash", "sh", "zsh", "powershell", "pwsh", "ps", "cmd"],
-                                "description": "Shell to use (default: bash)"
+                        "allOf": [
+                            {
+                                "$ref": "#/$defs/taskCommon"
                             },
-                            "literal": {
-                                "type": "boolean",
-                                "description": "Pass the command to the shell without prior env var expansion",
-                                "default": false
-                            },
-                            "path": {
-                                "type": "string",
-                                "description": "Working directory for the command. Defaults to ~ for profile tasks, the repo directory for repo tasks."
+                            {
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "const": "Shell"
+                                    },
+                                    "cmd": {
+                                        "type": "string",
+                                        "description": "Command to execute"
+                                    },
+                                    "shell": {
+                                        "type": "string",
+                                        "enum": [
+                                            "bash",
+                                            "sh",
+                                            "zsh",
+                                            "powershell",
+                                            "pwsh",
+                                            "ps",
+                                            "cmd"
+                                        ],
+                                        "description": "Shell to use (default: bash)"
+                                    },
+                                    "literal": {
+                                        "type": "boolean",
+                                        "description": "Pass the command to the shell without prior env var expansion",
+                                        "default": false
+                                    },
+                                    "path": {
+                                        "type": "string",
+                                        "description": "Working directory for the command. Defaults to ~ for profile tasks, the repo directory for repo tasks."
+                                    }
+                                },
+                                "required": [
+                                    "type",
+                                    "cmd"
+                                ]
                             }
-                        },
-                        "required": ["type", "cmd"],
-                        "additionalProperties": false
+                        ],
+                        "unevaluatedProperties": false
                     },
                     {
-                        "type": "object",
-                        "properties": {
-                            "type": { "type": "string", "const": "Script" },
-                            "concurrent": { "$ref": "#/$defs/concurrent" },
-                            "condition": { "$ref": "#/$defs/condition" },
-                            "path": { "type": "string", "description": "Path to the script file" },
-                            "runner": {
-                                "type": "string",
-                                "enum": ["bash", "sh", "zsh", "python", "python2", "python3", "node", "powershell"],
-                                "description": "Interpreter to use (optional)"
-                            }
-                        },
-                        "required": ["type", "path"],
-                        "additionalProperties": false
-                    },
-                    {
-                        "type": "object",
-                        "properties": {
-                            "type": { "type": "string", "const": "HTTP" },
-                            "concurrent": { "$ref": "#/$defs/concurrent" },
-                            "condition": { "$ref": "#/$defs/condition" },
-                            "url": { "type": "string", "description": "URL to download from" },
-                            "dest": { "type": "string", "description": "Local path to write the file to" }
-                        },
-                        "required": ["type", "url", "dest"],
-                        "additionalProperties": false
-                    },
-                    {
-                        "type": "object",
-                        "properties": {
-                            "type": { "type": "string", "const": "Wait" },
-                            "concurrent": { "$ref": "#/$defs/concurrent" },
-                            "condition": { "$ref": "#/$defs/condition" },
-                            "url": { "type": "string", "description": "HTTP(S) URL or TCP host:port to poll" },
-                            "timeout": { "type": "string", "description": "Max wait duration (e.g. 30s, 1m). Defaults to 30s." }
-                        },
-                        "required": ["type", "url"],
-                        "additionalProperties": false
-                    },
-                    {
-                        "type": "object",
-                        "properties": {
-                            "type": { "type": "string", "const": "Template" },
-                            "concurrent": { "$ref": "#/$defs/concurrent" },
-                            "condition": { "$ref": "#/$defs/condition" },
-                            "src": { "type": "string", "description": "Path to the template file. Supports $VAR and ${VAR} substitution." },
-                            "dest": { "type": "string", "description": "Path to write the rendered file to" }
-                        },
-                        "required": ["type", "src", "dest"],
-                        "additionalProperties": false
-                    },
-                    {
-                        "type": "object",
-                        "properties": {
-                            "type": { "type": "string", "const": "Group" },
-                            "concurrent": { "$ref": "#/$defs/concurrent" },
-                            "condition": { "$ref": "#/$defs/condition" },
-                            "ref": { "type": "string", "description": "Name of the task group to execute, as defined in the profile's top-level task_groups map" },
-                            "parallel": { "type": "boolean", "description": "Run all tasks in the group concurrently, then wait for all to finish", "default": false },
-                            "attempts": { "type": "integer", "minimum": 1, "description": "Retry the group on failure up to this many times" },
-                            "delay": { "type": "string", "description": "Duration to wait between retry attempts (e.g. 1s, 500ms). Default: 1s." }
-                        },
-                        "required": ["type", "ref"],
-                        "additionalProperties": false
-                    },
-                    {
-                        "type": "object",
-                        "properties": {
-                            "type": { "type": "string", "const": "Git" },
-                            "concurrent": { "$ref": "#/$defs/concurrent" },
-                            "condition": { "$ref": "#/$defs/condition" },
-                            "op": {
-                                "type": "string",
-                                "enum": ["pull", "checkout", "fetch", "reset"],
-                                "description": "Git operation to perform"
+                        "allOf": [
+                            {
+                                "$ref": "#/$defs/taskCommon"
                             },
-                            "branch": { "type": "string", "description": "Target branch (required for checkout, optional for others)" },
-                            "path": { "type": "string", "description": "Path to the git repository. Defaults to the current working directory." }
-                        },
-                        "required": ["type", "op"],
-                        "additionalProperties": false
-                    },
-                    {
-                        "type": "object",
-                        "properties": {
-                            "type": { "type": "string", "const": "Prompt" },
-                            "concurrent": { "$ref": "#/$defs/concurrent" },
-                            "condition": { "$ref": "#/$defs/condition" },
-                            "var": { "type": "string", "description": "Environment variable name to set with the user's input" },
-                            "message": { "type": "string", "description": "Message to display to the user" },
-                            "default": { "type": "string", "description": "Default value if the user provides no input" }
-                        },
-                        "required": ["type", "var"],
-                        "additionalProperties": false
-                    },
-                    {
-                        "type": "object",
-                        "properties": {
-                            "type": { "type": "string", "const": "Confirm" },
-                            "concurrent": { "$ref": "#/$defs/concurrent" },
-                            "condition": { "$ref": "#/$defs/condition" },
-                            "message": { "type": "string", "description": "Confirmation prompt to display to the user" }
-                        },
-                        "required": ["type"],
-                        "additionalProperties": false
-                    },
-                    {
-                        "type": "object",
-                        "properties": {
-                            "type": { "type": "string", "const": "Set" },
-                            "concurrent": { "$ref": "#/$defs/concurrent" },
-                            "condition": { "$ref": "#/$defs/condition" },
-                            "var": { "type": "string", "description": "Environment variable name to set" },
-                            "value": { "type": "string", "description": "Value to assign. Supports $VAR and ${VAR} substitution." }
-                        },
-                        "required": ["type", "var", "value"],
-                        "additionalProperties": false
-                    },
-                    {
-                        "type": "object",
-                        "properties": {
-                            "type": { "type": "string", "const": "Print" },
-                            "concurrent": { "$ref": "#/$defs/concurrent" },
-                            "condition": { "$ref": "#/$defs/condition" },
-                            "message": { "type": "string", "description": "Message to print. Supports $VAR substitution unless literal is true." },
-                            "color": {
-                                "type": "string",
-                                "enum": ["red", "green", "yellow", "blue", "cyan", "white"],
-                                "description": "Optional terminal color for the output"
-                            },
-                            "literal": {
-                                "type": "boolean",
-                                "description": "Skip environment variable expansion in the message",
-                                "default": false
+                            {
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "const": "Script"
+                                    },
+                                    "path": {
+                                        "type": "string",
+                                        "description": "Path to the script file"
+                                    },
+                                    "runner": {
+                                        "type": "string",
+                                        "enum": [
+                                            "bash",
+                                            "sh",
+                                            "zsh",
+                                            "python",
+                                            "python2",
+                                            "python3",
+                                            "node",
+                                            "powershell"
+                                        ],
+                                        "description": "Interpreter to use (optional)"
+                                    }
+                                },
+                                "required": [
+                                    "type",
+                                    "path"
+                                ]
                             }
-                        },
-                        "required": ["type", "message"],
-                        "additionalProperties": false
+                        ],
+                        "unevaluatedProperties": false
+                    },
+                    {
+                        "allOf": [
+                            {
+                                "$ref": "#/$defs/taskCommon"
+                            },
+                            {
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "const": "HTTP"
+                                    },
+                                    "url": {
+                                        "type": "string",
+                                        "description": "URL to download from"
+                                    },
+                                    "dest": {
+                                        "type": "string",
+                                        "description": "Local path to write the file to"
+                                    }
+                                },
+                                "required": [
+                                    "type",
+                                    "url",
+                                    "dest"
+                                ]
+                            }
+                        ],
+                        "unevaluatedProperties": false
+                    },
+                    {
+                        "allOf": [
+                            {
+                                "$ref": "#/$defs/taskCommon"
+                            },
+                            {
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "const": "Wait"
+                                    },
+                                    "url": {
+                                        "type": "string",
+                                        "description": "HTTP(S) URL or TCP host:port to poll"
+                                    },
+                                    "timeout": {
+                                        "type": "string",
+                                        "description": "Max wait duration (e.g. 30s, 1m). Defaults to 30s."
+                                    }
+                                },
+                                "required": [
+                                    "type",
+                                    "url"
+                                ]
+                            }
+                        ],
+                        "unevaluatedProperties": false
+                    },
+                    {
+                        "allOf": [
+                            {
+                                "$ref": "#/$defs/taskCommon"
+                            },
+                            {
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "const": "Template"
+                                    },
+                                    "src": {
+                                        "type": "string",
+                                        "description": "Path to the template file. Supports $VAR and ${VAR} substitution."
+                                    },
+                                    "dest": {
+                                        "type": "string",
+                                        "description": "Path to write the rendered file to"
+                                    }
+                                },
+                                "required": [
+                                    "type",
+                                    "src",
+                                    "dest"
+                                ]
+                            }
+                        ],
+                        "unevaluatedProperties": false
+                    },
+                    {
+                        "allOf": [
+                            {
+                                "$ref": "#/$defs/taskCommon"
+                            },
+                            {
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "const": "Group"
+                                    },
+                                    "ref": {
+                                        "type": "string",
+                                        "description": "Name of the task group to execute, as defined in the profile's top-level task_groups map"
+                                    },
+                                    "parallel": {
+                                        "type": "boolean",
+                                        "description": "Run all tasks in the group concurrently, then wait for all to finish",
+                                        "default": false
+                                    },
+                                    "attempts": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "description": "Retry the group on failure up to this many times"
+                                    },
+                                    "delay": {
+                                        "type": "string",
+                                        "description": "Duration to wait between retry attempts (e.g. 1s, 500ms). Default: 1s."
+                                    }
+                                },
+                                "required": [
+                                    "type",
+                                    "ref"
+                                ]
+                            }
+                        ],
+                        "unevaluatedProperties": false
+                    },
+                    {
+                        "allOf": [
+                            {
+                                "$ref": "#/$defs/taskCommon"
+                            },
+                            {
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "const": "Git"
+                                    },
+                                    "op": {
+                                        "type": "string",
+                                        "enum": [
+                                            "pull",
+                                            "checkout",
+                                            "fetch",
+                                            "reset"
+                                        ],
+                                        "description": "Git operation to perform"
+                                    },
+                                    "branch": {
+                                        "type": "string",
+                                        "description": "Target branch (required for checkout, optional for others)"
+                                    },
+                                    "path": {
+                                        "type": "string",
+                                        "description": "Path to the git repository. Defaults to the current working directory."
+                                    }
+                                },
+                                "required": [
+                                    "type",
+                                    "op"
+                                ]
+                            }
+                        ],
+                        "unevaluatedProperties": false
+                    },
+                    {
+                        "allOf": [
+                            {
+                                "$ref": "#/$defs/taskCommon"
+                            },
+                            {
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "const": "Prompt"
+                                    },
+                                    "var": {
+                                        "type": "string",
+                                        "description": "Environment variable name to set with the user's input"
+                                    },
+                                    "message": {
+                                        "type": "string",
+                                        "description": "Message to display to the user"
+                                    },
+                                    "default": {
+                                        "type": "string",
+                                        "description": "Default value if the user provides no input"
+                                    }
+                                },
+                                "required": [
+                                    "type",
+                                    "var"
+                                ]
+                            }
+                        ],
+                        "unevaluatedProperties": false
+                    },
+                    {
+                        "allOf": [
+                            {
+                                "$ref": "#/$defs/taskCommon"
+                            },
+                            {
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "const": "Confirm"
+                                    },
+                                    "message": {
+                                        "type": "string",
+                                        "description": "Confirmation prompt to display to the user"
+                                    }
+                                },
+                                "required": [
+                                    "type"
+                                ]
+                            }
+                        ],
+                        "unevaluatedProperties": false
+                    },
+                    {
+                        "allOf": [
+                            {
+                                "$ref": "#/$defs/taskCommon"
+                            },
+                            {
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "const": "Set"
+                                    },
+                                    "var": {
+                                        "type": "string",
+                                        "description": "Environment variable name to set"
+                                    },
+                                    "value": {
+                                        "type": "string",
+                                        "description": "Value to assign. Supports $VAR and ${VAR} substitution."
+                                    }
+                                },
+                                "required": [
+                                    "type",
+                                    "var",
+                                    "value"
+                                ]
+                            }
+                        ],
+                        "unevaluatedProperties": false
+                    },
+                    {
+                        "allOf": [
+                            {
+                                "$ref": "#/$defs/taskCommon"
+                            },
+                            {
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "const": "Print"
+                                    },
+                                    "message": {
+                                        "type": "string",
+                                        "description": "Message to print. Supports $VAR substitution unless literal is true."
+                                    },
+                                    "color": {
+                                        "type": "string",
+                                        "enum": [
+                                            "red",
+                                            "green",
+                                            "yellow",
+                                            "blue",
+                                            "cyan",
+                                            "white"
+                                        ],
+                                        "description": "Optional terminal color for the output"
+                                    },
+                                    "literal": {
+                                        "type": "boolean",
+                                        "description": "Skip environment variable expansion in the message",
+                                        "default": false
+                                    }
+                                },
+                                "required": [
+                                    "type",
+                                    "message"
+                                ]
+                            }
+                        ],
+                        "unevaluatedProperties": false
                     }
                 ]
             }
@@ -212,12 +418,17 @@
                                     "description": "The value of the variable"
                                 }
                             },
-                            "required": ["name", "value"],
+                            "required": [
+                                "name",
+                                "value"
+                            ],
                             "additionalProperties": false
                         }
                     }
                 },
-                "required": ["name"],
+                "required": [
+                    "name"
+                ],
                 "additionalProperties": false
             }
         },
@@ -269,35 +480,52 @@
                         "additionalProperties": false
                     }
                 },
-                "required": ["name", "tasks"],
+                "required": [
+                    "name",
+                    "tasks"
+                ],
                 "additionalProperties": false
             }
         }
     },
     "$defs": {
-        "concurrent": {
-            "type": "boolean",
-            "description": "Whether to execute the task concurrently with other tasks"
-        },
-        "condition": {
+        "taskCommon": {
             "type": "object",
-            "description": "All specified fields must be satisfied for the task to run",
+            "description": "Shared properties applied to every task type",
             "properties": {
-                "platform": {
+                "name": {
                     "type": "string",
-                    "enum": ["darwin", "linux", "windows"],
-                    "description": "Only run on this platform"
+                    "description": "Optional human-readable label for the task, surfaced in logs and agent output"
                 },
-                "exists": {
-                    "type": "string",
-                    "description": "Only run if this file or directory exists"
+                "concurrent": {
+                    "type": "boolean",
+                    "description": "Whether to execute the task concurrently with other tasks"
                 },
-                "cmd": {
-                    "type": "string",
-                    "description": "Only run if this command exits with code 0"
+                "condition": {
+                    "type": "object",
+                    "description": "All specified fields must be satisfied for the task to run",
+                    "properties": {
+                        "platform": {
+                            "type": "string",
+                            "enum": [
+                                "darwin",
+                                "linux",
+                                "windows"
+                            ],
+                            "description": "Only run on this platform"
+                        },
+                        "exists": {
+                            "type": "string",
+                            "description": "Only run if this file or directory exists"
+                        },
+                        "cmd": {
+                            "type": "string",
+                            "description": "Only run if this command exits with code 0"
+                        }
+                    },
+                    "additionalProperties": false
                 }
-            },
-            "additionalProperties": false
+            }
         }
     }
 }

--- a/site/docs/features/tasks.mdx
+++ b/site/docs/features/tasks.mdx
@@ -13,6 +13,7 @@ These fields apply to all task types.
 | Field | Description |
 |---|---|
 | `type` | Task type (required) |
+| `name` | Optional human-readable label, surfaced in logs and agent output. Does not affect execution. |
 | `concurrent` | Run this task in parallel with adjacent concurrent tasks |
 | `condition` | Only run this task if the condition passes |
 

--- a/site/docs/references/commands.mdx
+++ b/site/docs/references/commands.mdx
@@ -92,6 +92,25 @@ For more details, see [Doctor](/docs/usage/doctor).
 
 ---
 
+## raid context
+
+Print a condensed snapshot of the active workspace — profile, environment, and per-repository git state.
+
+```bash
+raid context           # pretty-printed
+raid context --json    # machine-readable JSON
+```
+
+| Flag | Description |
+|---|---|
+| `--json` | Emit machine-readable JSON instead of the human-readable table |
+
+Output is intentionally token-efficient and bounded — useful for piping into a chat agent or another tool.
+
+For more details, see [Context](/docs/usage/context).
+
+---
+
 ## raid \<command\>
 
 Run a custom command defined in the active profile or any of its repositories.

--- a/site/docs/references/schema.mdx
+++ b/site/docs/references/schema.mdx
@@ -183,6 +183,7 @@ All tasks share these common fields:
 | Field | Type | Required | Description |
 |---|---|---|---|
 | [`type`](#task-types) | string | Yes | Task type (case-sensitive, Title Case) |
+| `name` | string | No | Human-readable label, surfaced in logs and agent output. Does not affect execution. |
 | `concurrent` | bool | No | Run in parallel with adjacent concurrent tasks |
 | [`condition`](#condition) | object | No | Conditions that must all pass for the task to run |
 

--- a/site/docs/usage/context.mdx
+++ b/site/docs/usage/context.mdx
@@ -27,7 +27,7 @@ Followed by the workspace data:
 - **Active profile name**
 - **Active environment** (if one is set)
 - **Repositories** — name, configured path, current git branch, dirty status (uncommitted changes), and whether the repo has been cloned to disk
-- **Commands** — name and short description of every user-defined `raid <cmd>` available in the active profile. Script bodies are intentionally excluded so the snapshot stays token-efficient and free of inlined secrets. Built-in subcommands are listed under **Tools** above and are not duplicated here.
+- **Commands** — name and short description of every user-defined `raid <cmd>` available in the active profile. Script bodies are intentionally excluded so the snapshot stays token-efficient and free of inlined secrets. If any of a command's tasks have a `name` field set, those names also surface as a `steps` array — letting an agent see the outline of what the command does without exposing the underlying scripts. Built-in subcommands are listed under **Tools** above and are not duplicated here.
 - **Recent runs** — exit status, duration, and relative time of the most recent `raid <cmd>` invocations (capped at 10, persisted in `~/.raid/recent.json`). A run that was killed mid-execution (Ctrl+C, SIGTERM, etc.) is recorded as `interrupted` so you don't lose visibility into terminated commands.
 
 JSON keys use camelCase and the workspace data is grouped under a single `workspace` object. This shape aligns with the [Model Context Protocol](https://modelcontextprotocol.io) so a future `raid context serve` mode (a stdio MCP server) can lift these structures directly into JSON-RPC responses without translation.
@@ -59,6 +59,9 @@ Tools (5):
 
 Commands (3):
   deploy    Deploy to production
+            1. Build artifact
+            2. Push to registry
+            3. Apply migrations
   test      Run tests
   reset-db  Reset local database
 
@@ -120,8 +123,16 @@ Status values:
       }
     ],
     "commands": [
-      { "name": "deploy", "description": "Deploy to production" },
-      { "name": "test",   "description": "Run tests" }
+      {
+        "name": "deploy",
+        "description": "Deploy to production",
+        "steps": [
+          { "name": "Build artifact" },
+          { "name": "Push to registry" },
+          { "name": "Apply migrations" }
+        ]
+      },
+      { "name": "test", "description": "Run tests" }
     ],
     "recent": [
       {

--- a/site/docs/usage/context.mdx
+++ b/site/docs/usage/context.mdx
@@ -13,13 +13,13 @@ raid context --json    # machine-readable JSON
 
 ## What it emits
 
-The first iteration emits:
-
 - **Active profile name**
 - **Active environment** (if one is set)
-- **Repositories**, with for each: name, configured path, current git branch, dirty status (uncommitted changes), and whether the repo has been cloned to disk
+- **Repositories** — name, configured path, current git branch, dirty status (uncommitted changes), and whether the repo has been cloned to disk
+- **Commands** — name and short description of every `raid <cmd>` available in the active profile. Script bodies are intentionally excluded so the snapshot stays token-efficient and free of inlined secrets.
+- **Recent runs** — exit status, duration, and relative time of the most recent `raid <cmd>` invocations (capped at 10, persisted in `~/.raid/recent.json`)
 
-Future iterations will add task definitions, recent task exit statuses, and an MCP resource surface. Output is intentionally bounded — task script bodies are excluded so the snapshot stays token-efficient for AI agents.
+Future iterations will surface the same data as an MCP resource. Output is intentionally bounded — task script bodies are excluded so the snapshot stays token-efficient for AI agents.
 
 ## Pretty output
 
@@ -33,6 +33,15 @@ Repos (3):
   api       ~/dev/my-project/api       main      clean
   frontend  ~/dev/my-project/frontend  develop   dirty
   worker    ~/dev/my-project/worker              not cloned
+
+Commands (3):
+  deploy    Deploy to production
+  test      Run tests
+  reset-db  Reset local database
+
+Recent (2):
+  ✓ deploy   12.3s   2m ago
+  ✗ test      4.5s   5m ago
 ```
 
 Status values:
@@ -64,11 +73,23 @@ Status values:
       "path": "~/dev/my-project/worker",
       "cloned": false
     }
+  ],
+  "commands": [
+    { "name": "deploy", "description": "Deploy to production" },
+    { "name": "test", "description": "Run tests" }
+  ],
+  "recent": [
+    {
+      "command": "deploy",
+      "exit_code": 0,
+      "started_at": "2026-04-27T12:00:00Z",
+      "duration_ms": 12300
+    }
   ]
 }
 ```
 
-When a repository is not cloned, `branch` and `dirty` are omitted.
+When a repository is not cloned, `branch` and `dirty` are omitted. The `recent` array is omitted entirely when no commands have been run yet.
 
 ## Common uses
 

--- a/site/docs/usage/context.mdx
+++ b/site/docs/usage/context.mdx
@@ -15,9 +15,10 @@ raid context --json    # machine-readable JSON
 
 Every snapshot is **self-describing** so an agent that picks it up out of context can identify the producer:
 
-- **Tool** — always `raid`
+- **Name** — always `raid`
+- **Title** — the human-readable display name, `Raid`
 - **Version** — the raid binary version, useful for feature/schema detection
-- **Repository** — canonical GitHub URL the agent can follow for additional documentation, source code search, or issue reporting
+- **Website URL** — canonical GitHub URL the agent can follow for additional documentation, source code search, or issue reporting
 - **Generated at** — UTC timestamp of when the snapshot was produced
 
 Followed by the workspace data:
@@ -29,7 +30,9 @@ Followed by the workspace data:
 - **Commands** — name and short description of every user-defined `raid <cmd>` available in the active profile. Script bodies are intentionally excluded so the snapshot stays token-efficient and free of inlined secrets. Built-in subcommands are listed under **Tools** above and are not duplicated here.
 - **Recent runs** — exit status, duration, and relative time of the most recent `raid <cmd>` invocations (capped at 10, persisted in `~/.raid/recent.json`). A run that was killed mid-execution (Ctrl+C, SIGTERM, etc.) is recorded as `interrupted` so you don't lose visibility into terminated commands.
 
-Future iterations will surface the same data as an MCP resource. Output is intentionally bounded — task script bodies are excluded so the snapshot stays token-efficient for AI agents.
+JSON keys use camelCase and the workspace data is grouped under a single `workspace` object. This shape aligns with the [Model Context Protocol](https://modelcontextprotocol.io) so a future `raid context serve` mode (a stdio MCP server) can lift these structures directly into JSON-RPC responses without translation.
+
+Output is intentionally bounded — task script bodies are excluded so the snapshot stays token-efficient for AI agents.
 
 ## Pretty output
 
@@ -87,10 +90,11 @@ Status values:
 
 ```json
 {
-  "tool": "raid",
+  "name": "raid",
+  "title": "Raid",
   "version": "1.2.3",
-  "repository": "https://github.com/8bitalex/raid",
-  "generated_at": "2026-04-27T18:00:00Z",
+  "websiteUrl": "https://github.com/8bitalex/raid",
+  "generatedAt": "2026-04-27T18:00:00Z",
   "tools": [
     { "name": "context", "description": "Print a condensed summary of the active workspace" },
     { "name": "doctor",  "description": "Check the raid configuration and report any issues" },
@@ -98,45 +102,47 @@ Status values:
     { "name": "install", "description": "Install the active profile" },
     { "name": "profile", "description": "Manage raid profiles" }
   ],
-  "profile": "my-project",
-  "env": "dev",
-  "repos": [
-    {
-      "name": "api",
-      "path": "~/dev/my-project/api",
-      "cloned": true,
-      "branch": "main",
-      "dirty": false
-    },
-    {
-      "name": "worker",
-      "path": "~/dev/my-project/worker",
-      "cloned": false
-    }
-  ],
-  "commands": [
-    { "name": "deploy", "description": "Deploy to production" },
-    { "name": "test", "description": "Run tests" }
-  ],
-  "recent": [
-    {
-      "command": "deploy",
-      "status": "completed",
-      "exit_code": 0,
-      "started_at": "2026-04-27T12:00:00Z",
-      "duration_ms": 12300
-    },
-    {
-      "command": "migrate",
-      "status": "interrupted",
-      "exit_code": 0,
-      "started_at": "2026-04-27T11:42:00Z"
-    }
-  ]
+  "workspace": {
+    "profile": "my-project",
+    "env": "dev",
+    "repos": [
+      {
+        "name": "api",
+        "path": "~/dev/my-project/api",
+        "cloned": true,
+        "branch": "main",
+        "dirty": false
+      },
+      {
+        "name": "worker",
+        "path": "~/dev/my-project/worker",
+        "cloned": false
+      }
+    ],
+    "commands": [
+      { "name": "deploy", "description": "Deploy to production" },
+      { "name": "test",   "description": "Run tests" }
+    ],
+    "recent": [
+      {
+        "command": "deploy",
+        "status": "completed",
+        "exitCode": 0,
+        "startedAt": "2026-04-27T12:00:00Z",
+        "durationMs": 12300
+      },
+      {
+        "command": "migrate",
+        "status": "interrupted",
+        "exitCode": 0,
+        "startedAt": "2026-04-27T11:42:00Z"
+      }
+    ]
+  }
 }
 ```
 
-When a repository is not cloned, `branch` and `dirty` are omitted. The `recent` array is omitted entirely when no commands have been run yet.
+When a repository is not cloned, `branch` and `dirty` are omitted. The `workspace.recent` array is omitted entirely when no commands have been run yet.
 
 ## Common uses
 
@@ -145,5 +151,5 @@ When a repository is not cloned, `branch` and `dirty` are omitted. The `recent` 
 raid context | pbcopy
 
 # Feed JSON into another tool
-raid context --json | jq '.repos[] | select(.dirty)'
+raid context --json | jq '.workspace.repos[] | select(.dirty)'
 ```

--- a/site/docs/usage/context.mdx
+++ b/site/docs/usage/context.mdx
@@ -13,11 +13,20 @@ raid context --json    # machine-readable JSON
 
 ## What it emits
 
+Every snapshot is **self-describing** so an agent that picks it up out of context can identify the producer:
+
+- **Tool** — always `raid`
+- **Version** — the raid binary version, useful for feature/schema detection
+- **Repository** — canonical GitHub URL the agent can follow for additional documentation, source code search, or issue reporting
+- **Generated at** — UTC timestamp of when the snapshot was produced
+
+Followed by the workspace data:
+
 - **Active profile name**
 - **Active environment** (if one is set)
 - **Repositories** — name, configured path, current git branch, dirty status (uncommitted changes), and whether the repo has been cloned to disk
 - **Commands** — name and short description of every `raid <cmd>` available in the active profile. Script bodies are intentionally excluded so the snapshot stays token-efficient and free of inlined secrets.
-- **Recent runs** — exit status, duration, and relative time of the most recent `raid <cmd>` invocations (capped at 10, persisted in `~/.raid/recent.json`)
+- **Recent runs** — exit status, duration, and relative time of the most recent `raid <cmd>` invocations (capped at 10, persisted in `~/.raid/recent.json`). A run that was killed mid-execution (Ctrl+C, SIGTERM, etc.) is recorded as `interrupted` so you don't lose visibility into terminated commands.
 
 Future iterations will surface the same data as an MCP resource. Output is intentionally bounded — task script bodies are excluded so the snapshot stays token-efficient for AI agents.
 
@@ -26,6 +35,9 @@ Future iterations will surface the same data as an MCP resource. Output is inten
 Default invocation produces a fixed-width table for human reading:
 
 ```
+# raid v1.2.3 workspace context (2026-04-27T18:00:00Z)
+# https://github.com/8bitalex/raid
+
 Profile: my-project
 Env:     dev
 
@@ -39,10 +51,19 @@ Commands (3):
   test      Run tests
   reset-db  Reset local database
 
-Recent (2):
-  ✓ deploy   12.3s   2m ago
-  ✗ test      4.5s   5m ago
+Recent (3):
+  ✓ deploy   ok           12.3s  2m ago
+  ✗ test     failed       4.5s   5m ago
+  ⊘ migrate  interrupted  —      18m ago
 ```
+
+Each row shows a status glyph, the command name, a status word, the duration, and a relative timestamp.
+
+| Glyph | Status word | Meaning |
+|---|---|---|
+| `✓` | `ok` | Command completed with exit code 0 |
+| `✗` | `failed` | Command completed with a non-zero exit code |
+| `⊘` | `interrupted` | Command was killed before completing (SIGINT, SIGTERM, etc.). Duration is unknown and shown as `—`. |
 
 Status values:
 
@@ -58,6 +79,10 @@ Status values:
 
 ```json
 {
+  "tool": "raid",
+  "version": "1.2.3",
+  "repository": "https://github.com/8bitalex/raid",
+  "generated_at": "2026-04-27T18:00:00Z",
   "profile": "my-project",
   "env": "dev",
   "repos": [
@@ -81,9 +106,16 @@ Status values:
   "recent": [
     {
       "command": "deploy",
+      "status": "completed",
       "exit_code": 0,
       "started_at": "2026-04-27T12:00:00Z",
       "duration_ms": 12300
+    },
+    {
+      "command": "migrate",
+      "status": "interrupted",
+      "exit_code": 0,
+      "started_at": "2026-04-27T11:42:00Z"
     }
   ]
 }

--- a/site/docs/usage/context.mdx
+++ b/site/docs/usage/context.mdx
@@ -1,0 +1,81 @@
+---
+sidebar_position: 7
+---
+
+# Context
+
+Print a condensed snapshot of the active workspace — the profile, environment, and per-repository git state. Designed to be terse enough to paste into a chat agent or pipe into another tool.
+
+```bash
+raid context           # pretty-printed for humans
+raid context --json    # machine-readable JSON
+```
+
+## What it emits
+
+The first iteration emits:
+
+- **Active profile name**
+- **Active environment** (if one is set)
+- **Repositories**, with for each: name, configured path, current git branch, dirty status (uncommitted changes), and whether the repo has been cloned to disk
+
+Future iterations will add task definitions, recent task exit statuses, and an MCP resource surface. Output is intentionally bounded — task script bodies are excluded so the snapshot stays token-efficient for AI agents.
+
+## Pretty output
+
+Default invocation produces a fixed-width table for human reading:
+
+```
+Profile: my-project
+Env:     dev
+
+Repos (3):
+  api       ~/dev/my-project/api       main      clean
+  frontend  ~/dev/my-project/frontend  develop   dirty
+  worker    ~/dev/my-project/worker              not cloned
+```
+
+Status values:
+
+| Status | Meaning |
+|---|---|
+| `clean` | Repository is cloned and has no uncommitted changes |
+| `dirty` | Repository is cloned and has uncommitted changes (per `git status --porcelain`) |
+| `not cloned` | Path from the profile does not exist on disk, or is not a git repository |
+
+## JSON output
+
+`raid context --json` emits a stable, agent-friendly schema:
+
+```json
+{
+  "profile": "my-project",
+  "env": "dev",
+  "repos": [
+    {
+      "name": "api",
+      "path": "~/dev/my-project/api",
+      "cloned": true,
+      "branch": "main",
+      "dirty": false
+    },
+    {
+      "name": "worker",
+      "path": "~/dev/my-project/worker",
+      "cloned": false
+    }
+  ]
+}
+```
+
+When a repository is not cloned, `branch` and `dirty` are omitted.
+
+## Common uses
+
+```bash
+# Drop the current workspace state into a chat agent
+raid context | pbcopy
+
+# Feed JSON into another tool
+raid context --json | jq '.repos[] | select(.dirty)'
+```

--- a/site/docs/usage/context.mdx
+++ b/site/docs/usage/context.mdx
@@ -22,10 +22,11 @@ Every snapshot is **self-describing** so an agent that picks it up out of contex
 
 Followed by the workspace data:
 
+- **Tools** — name and short description of every built-in `raid` subcommand (`install`, `env`, `doctor`, `profile`, `context`). Lets an agent discover what raid itself can do without having to invoke `raid --help`.
 - **Active profile name**
 - **Active environment** (if one is set)
 - **Repositories** — name, configured path, current git branch, dirty status (uncommitted changes), and whether the repo has been cloned to disk
-- **Commands** — name and short description of every `raid <cmd>` available in the active profile. Script bodies are intentionally excluded so the snapshot stays token-efficient and free of inlined secrets.
+- **Commands** — name and short description of every user-defined `raid <cmd>` available in the active profile. Script bodies are intentionally excluded so the snapshot stays token-efficient and free of inlined secrets. Built-in subcommands are listed under **Tools** above and are not duplicated here.
 - **Recent runs** — exit status, duration, and relative time of the most recent `raid <cmd>` invocations (capped at 10, persisted in `~/.raid/recent.json`). A run that was killed mid-execution (Ctrl+C, SIGTERM, etc.) is recorded as `interrupted` so you don't lose visibility into terminated commands.
 
 Future iterations will surface the same data as an MCP resource. Output is intentionally bounded — task script bodies are excluded so the snapshot stays token-efficient for AI agents.
@@ -45,6 +46,13 @@ Repos (3):
   api       ~/dev/my-project/api       main      clean
   frontend  ~/dev/my-project/frontend  develop   dirty
   worker    ~/dev/my-project/worker              not cloned
+
+Tools (5):
+  context  Print a condensed summary of the active workspace
+  doctor   Check the raid configuration and report any issues
+  env      Execute an environment
+  install  Install the active profile
+  profile  Manage raid profiles
 
 Commands (3):
   deploy    Deploy to production
@@ -83,6 +91,13 @@ Status values:
   "version": "1.2.3",
   "repository": "https://github.com/8bitalex/raid",
   "generated_at": "2026-04-27T18:00:00Z",
+  "tools": [
+    { "name": "context", "description": "Print a condensed summary of the active workspace" },
+    { "name": "doctor",  "description": "Check the raid configuration and report any issues" },
+    { "name": "env",     "description": "Execute an environment" },
+    { "name": "install", "description": "Install the active profile" },
+    { "name": "profile", "description": "Manage raid profiles" }
+  ],
   "profile": "my-project",
   "env": "dev",
   "repos": [

--- a/src/cmd/context/context.go
+++ b/src/cmd/context/context.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/8bitalex/raid/src/raid/context"
 	"github.com/spf13/cobra"
@@ -50,42 +51,82 @@ func writePretty(w io.Writer, ws context.Workspace) error {
 		fmt.Fprintf(w, "Env:     %s\n", ws.Env)
 	}
 
-	if len(ws.Repos) == 0 {
-		fmt.Fprintln(w, "\nNo repositories configured.")
-		return nil
-	}
-
-	pathWidth, branchWidth := 0, 0
-	for _, r := range ws.Repos {
-		if len(r.Path) > pathWidth {
-			pathWidth = len(r.Path)
-		}
-		if len(r.Branch) > branchWidth {
-			branchWidth = len(r.Branch)
-		}
-	}
-
-	fmt.Fprintf(w, "\nRepos (%d):\n", len(ws.Repos))
-	for _, r := range ws.Repos {
-		status := repoStatus(r)
-		fmt.Fprintf(w, "  %-*s  %-*s  %-*s  %s\n",
-			nameWidth(ws.Repos), r.Name,
-			pathWidth, r.Path,
-			branchWidth, r.Branch,
-			status,
-		)
-	}
+	writeRepos(w, ws.Repos)
+	writeCommands(w, ws.Commands)
+	writeRecent(w, ws.Recent)
 	return nil
 }
 
-func nameWidth(repos []context.Repo) int {
-	w := 0
+func writeRepos(w io.Writer, repos []context.Repo) {
+	if len(repos) == 0 {
+		fmt.Fprintln(w, "\nRepos: none configured")
+		return
+	}
+
+	nameW, pathW, branchW := 0, 0, 0
 	for _, r := range repos {
-		if len(r.Name) > w {
-			w = len(r.Name)
+		if len(r.Name) > nameW {
+			nameW = len(r.Name)
+		}
+		if len(r.Path) > pathW {
+			pathW = len(r.Path)
+		}
+		if len(r.Branch) > branchW {
+			branchW = len(r.Branch)
 		}
 	}
-	return w
+
+	fmt.Fprintf(w, "\nRepos (%d):\n", len(repos))
+	for _, r := range repos {
+		fmt.Fprintf(w, "  %-*s  %-*s  %-*s  %s\n",
+			nameW, r.Name,
+			pathW, r.Path,
+			branchW, r.Branch,
+			repoStatus(r),
+		)
+	}
+}
+
+func writeCommands(w io.Writer, cmds []context.Command) {
+	if len(cmds) == 0 {
+		return
+	}
+	nameW := 0
+	for _, c := range cmds {
+		if len(c.Name) > nameW {
+			nameW = len(c.Name)
+		}
+	}
+	fmt.Fprintf(w, "\nCommands (%d):\n", len(cmds))
+	for _, c := range cmds {
+		fmt.Fprintf(w, "  %-*s  %s\n", nameW, c.Name, c.Description)
+	}
+}
+
+func writeRecent(w io.Writer, entries []context.Recent) {
+	if len(entries) == 0 {
+		return
+	}
+	nameW := 0
+	for _, e := range entries {
+		if len(e.Command) > nameW {
+			nameW = len(e.Command)
+		}
+	}
+	fmt.Fprintf(w, "\nRecent (%d):\n", len(entries))
+	now := time.Now()
+	for _, e := range entries {
+		mark := "✓"
+		if e.ExitCode != 0 {
+			mark = "✗"
+		}
+		fmt.Fprintf(w, "  %s %-*s  %6s  %s\n",
+			mark,
+			nameW, e.Command,
+			formatDuration(e.DurationMs),
+			relativeTime(now, e.StartedAt),
+		)
+	}
 }
 
 func repoStatus(r context.Repo) string {
@@ -96,4 +137,37 @@ func repoStatus(r context.Repo) string {
 		return "dirty"
 	}
 	return "clean"
+}
+
+func formatDuration(ms int64) string {
+	d := time.Duration(ms) * time.Millisecond
+	switch {
+	case d < time.Second:
+		return fmt.Sprintf("%dms", ms)
+	case d < time.Minute:
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	case d < time.Hour:
+		return fmt.Sprintf("%dm%02ds", int(d.Minutes()), int(d.Seconds())%60)
+	default:
+		return fmt.Sprintf("%dh%02dm", int(d.Hours()), int(d.Minutes())%60)
+	}
+}
+
+func relativeTime(now, then time.Time) string {
+	if then.IsZero() {
+		return ""
+	}
+	d := now.Sub(then)
+	switch {
+	case d < 30*time.Second:
+		return "just now"
+	case d < time.Minute:
+		return fmt.Sprintf("%ds ago", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	}
 }

--- a/src/cmd/context/context.go
+++ b/src/cmd/context/context.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 	"time"
 	"unicode/utf8"
 
@@ -28,11 +29,51 @@ var Command = &cobra.Command{
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		ws := context.Get()
+		ws.Tools = collectTools(cmd.Root())
 		if jsonOutput {
 			return writeJSON(cmd.OutOrStdout(), ws)
 		}
 		return writePretty(cmd.OutOrStdout(), ws)
 	},
+}
+
+// ignoredToolNames are cobra-builtin subcommands not part of raid's own
+// surface area; an agent should reach for the raid commands instead.
+var ignoredToolNames = map[string]bool{
+	"help":       true,
+	"completion": true,
+}
+
+// These mirror cmd.CommandSourceAnnotation / cmd.CommandSourceUser. The
+// constants are duplicated rather than imported because cmd already imports
+// cmd/context, so pulling cmd back the other way would create a cycle. If you
+// rename the values in cmd/raid.go, update them here too.
+const (
+	cmdSourceAnnotation = "raid:source"
+	cmdSourceUser       = "user"
+)
+
+// collectTools walks root's direct subcommands and returns the raid built-in
+// commands. User-defined commands (annotated by registerUserCommands) and
+// cobra's auto-added help/completion commands are excluded — user commands
+// are already exposed via WorkspaceContext.Commands and shouldn't appear in
+// the built-in tools list.
+func collectTools(root *cobra.Command) []context.Tool {
+	var tools []context.Tool
+	for _, sub := range root.Commands() {
+		if ignoredToolNames[sub.Name()] || sub.Hidden {
+			continue
+		}
+		if sub.Annotations[cmdSourceAnnotation] == cmdSourceUser {
+			continue
+		}
+		tools = append(tools, context.Tool{
+			Name:        sub.Name(),
+			Description: sub.Short,
+		})
+	}
+	sort.Slice(tools, func(i, j int) bool { return tools[i].Name < tools[j].Name })
+	return tools
 }
 
 func writeJSON(w io.Writer, ws context.Workspace) error {
@@ -54,9 +95,26 @@ func writePretty(w io.Writer, ws context.Workspace) error {
 	}
 
 	writeRepos(w, ws.Repos)
+	writeTools(w, ws.Tools)
 	writeCommands(w, ws.Commands)
 	writeRecent(w, ws.Recent)
 	return nil
+}
+
+func writeTools(w io.Writer, tools []context.Tool) {
+	if len(tools) == 0 {
+		return
+	}
+	nameW := 0
+	for _, t := range tools {
+		if len(t.Name) > nameW {
+			nameW = len(t.Name)
+		}
+	}
+	fmt.Fprintf(w, "\nTools (%d):\n", len(tools))
+	for _, t := range tools {
+		fmt.Fprintf(w, "  %-*s  %s\n", nameW, t.Name, t.Description)
+	}
 }
 
 // writeHeader emits an agent-readable preamble so the snapshot is

--- a/src/cmd/context/context.go
+++ b/src/cmd/context/context.go
@@ -76,28 +76,28 @@ func collectTools(root *cobra.Command) []context.Tool {
 	return tools
 }
 
-func writeJSON(w io.Writer, ws context.Workspace) error {
+func writeJSON(w io.Writer, ws context.Snapshot) error {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	return enc.Encode(ws)
 }
 
-func writePretty(w io.Writer, ws context.Workspace) error {
+func writePretty(w io.Writer, ws context.Snapshot) error {
 	writeHeader(w, ws)
-	if ws.Profile == "" {
+	if ws.Workspace.Profile == "" {
 		fmt.Fprintln(w, "No active profile.")
 		return nil
 	}
 
-	fmt.Fprintf(w, "Profile: %s\n", ws.Profile)
-	if ws.Env != "" {
-		fmt.Fprintf(w, "Env:     %s\n", ws.Env)
+	fmt.Fprintf(w, "Profile: %s\n", ws.Workspace.Profile)
+	if ws.Workspace.Env != "" {
+		fmt.Fprintf(w, "Env:     %s\n", ws.Workspace.Env)
 	}
 
-	writeRepos(w, ws.Repos)
+	writeRepos(w, ws.Workspace.Repos)
 	writeTools(w, ws.Tools)
-	writeCommands(w, ws.Commands)
-	writeRecent(w, ws.Recent)
+	writeCommands(w, ws.Workspace.Commands)
+	writeRecent(w, ws.Workspace.Recent)
 	return nil
 }
 
@@ -118,21 +118,21 @@ func writeTools(w io.Writer, tools []context.Tool) {
 }
 
 // writeHeader emits an agent-readable preamble so the snapshot is
-// self-describing when piped or pasted out of context. The repository URL is
+// self-describing when piped or pasted out of context. The website URL is
 // included as a discoverable entry point an agent can follow for additional
 // documentation, issue reporting, or source code search.
-func writeHeader(w io.Writer, ws context.Workspace) {
-	tool := ws.Tool
-	if tool == "" {
-		tool = "raid"
+func writeHeader(w io.Writer, ws context.Snapshot) {
+	name := ws.Name
+	if name == "" {
+		name = "raid"
 	}
 	if ws.Version != "" {
-		fmt.Fprintf(w, "# %s v%s workspace context (%s)\n", tool, ws.Version, ws.GeneratedAt.Format(time.RFC3339))
+		fmt.Fprintf(w, "# %s v%s workspace context (%s)\n", name, ws.Version, ws.GeneratedAt.Format(time.RFC3339))
 	} else {
-		fmt.Fprintf(w, "# %s workspace context (%s)\n", tool, ws.GeneratedAt.Format(time.RFC3339))
+		fmt.Fprintf(w, "# %s workspace context (%s)\n", name, ws.GeneratedAt.Format(time.RFC3339))
 	}
-	if ws.Repository != "" {
-		fmt.Fprintf(w, "# %s\n", ws.Repository)
+	if ws.WebsiteUrl != "" {
+		fmt.Fprintf(w, "# %s\n", ws.WebsiteUrl)
 	}
 	fmt.Fprintln(w)
 }

--- a/src/cmd/context/context.go
+++ b/src/cmd/context/context.go
@@ -97,7 +97,7 @@ func writePretty(w io.Writer, ws context.Snapshot) error {
 	writeRepos(w, ws.Workspace.Repos)
 	writeTools(w, ws.Tools)
 	writeCommands(w, ws.Workspace.Commands)
-	writeRecent(w, ws.Workspace.Recent)
+	writeRecent(w, ws.Workspace.Recent, ws.GeneratedAt)
 	return nil
 }
 
@@ -186,7 +186,11 @@ func writeCommands(w io.Writer, cmds []context.Command) {
 	}
 }
 
-func writeRecent(w io.Writer, entries []context.Recent) {
+// writeRecent renders the recent-runs section. now should be the snapshot's
+// own GeneratedAt timestamp so the "Xm ago" deltas are consistent with the
+// header timestamp and stay deterministic for any consumer that re-renders
+// the same Snapshot.
+func writeRecent(w io.Writer, entries []context.Recent, now time.Time) {
 	if len(entries) == 0 {
 		return
 	}
@@ -207,7 +211,6 @@ func writeRecent(w io.Writer, entries []context.Recent) {
 		}
 	}
 	fmt.Fprintf(w, "\nRecent (%d):\n", len(entries))
-	now := time.Now()
 	for i, e := range entries {
 		fmt.Fprintf(w, "  %s %-*s  %s%s  %s%s  %s\n",
 			recentMark(e),

--- a/src/cmd/context/context.go
+++ b/src/cmd/context/context.go
@@ -180,6 +180,9 @@ func writeCommands(w io.Writer, cmds []context.Command) {
 	fmt.Fprintf(w, "\nCommands (%d):\n", len(cmds))
 	for _, c := range cmds {
 		fmt.Fprintf(w, "  %-*s  %s\n", nameW, c.Name, c.Description)
+		for i, step := range c.Steps {
+			fmt.Fprintf(w, "  %-*s  %d. %s\n", nameW, "", i+1, step.Name)
+		}
 	}
 }
 

--- a/src/cmd/context/context.go
+++ b/src/cmd/context/context.go
@@ -1,0 +1,99 @@
+// Emit a condensed summary of the active raid workspace.
+package context
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/8bitalex/raid/src/raid/context"
+	"github.com/spf13/cobra"
+)
+
+var jsonOutput bool
+
+func init() {
+	Command.Flags().BoolVar(&jsonOutput, "json", false, "Emit machine-readable JSON output")
+}
+
+// Command is the `raid context` subcommand. It prints a condensed snapshot of
+// the active workspace — profile, environment, and per-repo branch / dirty
+// state — for human or agent consumption.
+var Command = &cobra.Command{
+	Use:   "context",
+	Short: "Print a condensed summary of the active workspace",
+	Long:  "Print a condensed, token-efficient snapshot of the active workspace: profile, environment, and per-repository git state. Use --json for machine-readable output.",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		ws := context.Get()
+		if jsonOutput {
+			return writeJSON(cmd.OutOrStdout(), ws)
+		}
+		return writePretty(cmd.OutOrStdout(), ws)
+	},
+}
+
+func writeJSON(w io.Writer, ws context.Workspace) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(ws)
+}
+
+func writePretty(w io.Writer, ws context.Workspace) error {
+	if ws.Profile == "" {
+		fmt.Fprintln(w, "No active profile.")
+		return nil
+	}
+
+	fmt.Fprintf(w, "Profile: %s\n", ws.Profile)
+	if ws.Env != "" {
+		fmt.Fprintf(w, "Env:     %s\n", ws.Env)
+	}
+
+	if len(ws.Repos) == 0 {
+		fmt.Fprintln(w, "\nNo repositories configured.")
+		return nil
+	}
+
+	pathWidth, branchWidth := 0, 0
+	for _, r := range ws.Repos {
+		if len(r.Path) > pathWidth {
+			pathWidth = len(r.Path)
+		}
+		if len(r.Branch) > branchWidth {
+			branchWidth = len(r.Branch)
+		}
+	}
+
+	fmt.Fprintf(w, "\nRepos (%d):\n", len(ws.Repos))
+	for _, r := range ws.Repos {
+		status := repoStatus(r)
+		fmt.Fprintf(w, "  %-*s  %-*s  %-*s  %s\n",
+			nameWidth(ws.Repos), r.Name,
+			pathWidth, r.Path,
+			branchWidth, r.Branch,
+			status,
+		)
+	}
+	return nil
+}
+
+func nameWidth(repos []context.Repo) int {
+	w := 0
+	for _, r := range repos {
+		if len(r.Name) > w {
+			w = len(r.Name)
+		}
+	}
+	return w
+}
+
+func repoStatus(r context.Repo) string {
+	if !r.Cloned {
+		return "not cloned"
+	}
+	if r.Dirty {
+		return "dirty"
+	}
+	return "clean"
+}

--- a/src/cmd/context/context.go
+++ b/src/cmd/context/context.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"time"
+	"unicode/utf8"
 
 	"github.com/8bitalex/raid/src/raid/context"
 	"github.com/spf13/cobra"
@@ -41,6 +42,7 @@ func writeJSON(w io.Writer, ws context.Workspace) error {
 }
 
 func writePretty(w io.Writer, ws context.Workspace) error {
+	writeHeader(w, ws)
 	if ws.Profile == "" {
 		fmt.Fprintln(w, "No active profile.")
 		return nil
@@ -55,6 +57,26 @@ func writePretty(w io.Writer, ws context.Workspace) error {
 	writeCommands(w, ws.Commands)
 	writeRecent(w, ws.Recent)
 	return nil
+}
+
+// writeHeader emits an agent-readable preamble so the snapshot is
+// self-describing when piped or pasted out of context. The repository URL is
+// included as a discoverable entry point an agent can follow for additional
+// documentation, issue reporting, or source code search.
+func writeHeader(w io.Writer, ws context.Workspace) {
+	tool := ws.Tool
+	if tool == "" {
+		tool = "raid"
+	}
+	if ws.Version != "" {
+		fmt.Fprintf(w, "# %s v%s workspace context (%s)\n", tool, ws.Version, ws.GeneratedAt.Format(time.RFC3339))
+	} else {
+		fmt.Fprintf(w, "# %s workspace context (%s)\n", tool, ws.GeneratedAt.Format(time.RFC3339))
+	}
+	if ws.Repository != "" {
+		fmt.Fprintf(w, "# %s\n", ws.Repository)
+	}
+	fmt.Fprintln(w)
 }
 
 func writeRepos(w io.Writer, repos []context.Repo) {
@@ -107,26 +129,79 @@ func writeRecent(w io.Writer, entries []context.Recent) {
 	if len(entries) == 0 {
 		return
 	}
-	nameW := 0
-	for _, e := range entries {
+	nameW, statusW, durationW := 0, 0, 0
+	statuses := make([]string, len(entries))
+	durations := make([]string, len(entries))
+	for i, e := range entries {
 		if len(e.Command) > nameW {
 			nameW = len(e.Command)
+		}
+		statuses[i] = recentStatusText(e)
+		if w := utf8.RuneCountInString(statuses[i]); w > statusW {
+			statusW = w
+		}
+		durations[i] = recentDuration(e)
+		if w := utf8.RuneCountInString(durations[i]); w > durationW {
+			durationW = w
 		}
 	}
 	fmt.Fprintf(w, "\nRecent (%d):\n", len(entries))
 	now := time.Now()
-	for _, e := range entries {
-		mark := "✓"
-		if e.ExitCode != 0 {
-			mark = "✗"
-		}
-		fmt.Fprintf(w, "  %s %-*s  %6s  %s\n",
-			mark,
+	for i, e := range entries {
+		fmt.Fprintf(w, "  %s %-*s  %s%s  %s%s  %s\n",
+			recentMark(e),
 			nameW, e.Command,
-			formatDuration(e.DurationMs),
+			statuses[i], padRunes(statuses[i], statusW),
+			durations[i], padRunes(durations[i], durationW),
 			relativeTime(now, e.StartedAt),
 		)
 	}
+}
+
+func recentStatusText(e context.Recent) string {
+	switch e.Status {
+	case context.RecentStatusInterrupted:
+		return "interrupted"
+	default:
+		if e.ExitCode != 0 {
+			return "failed"
+		}
+		return "ok"
+	}
+}
+
+// padRunes returns spaces needed to right-pad s to width visible runes. Used
+// instead of "%-*s" because that flag pads by byte count, which over-pads
+// non-ASCII content (e.g. the 3-byte em-dash placeholder).
+func padRunes(s string, width int) string {
+	n := width - utf8.RuneCountInString(s)
+	if n <= 0 {
+		return ""
+	}
+	pad := make([]byte, n)
+	for i := range pad {
+		pad[i] = ' '
+	}
+	return string(pad)
+}
+
+func recentMark(e context.Recent) string {
+	switch e.Status {
+	case context.RecentStatusInterrupted:
+		return "⊘"
+	default:
+		if e.ExitCode != 0 {
+			return "✗"
+		}
+		return "✓"
+	}
+}
+
+func recentDuration(e context.Recent) string {
+	if e.Status == context.RecentStatusInterrupted {
+		return "—"
+	}
+	return formatDuration(e.DurationMs)
 }
 
 func repoStatus(r context.Repo) string {

--- a/src/cmd/context/context_test.go
+++ b/src/cmd/context/context_test.go
@@ -10,6 +10,53 @@ import (
 	rctx "github.com/8bitalex/raid/src/raid/context"
 )
 
+func TestWritePretty_includesAgentHeader(t *testing.T) {
+	var buf bytes.Buffer
+	ws := rctx.Workspace{
+		Tool:       "raid",
+		Version:    "1.2.3",
+		Repository: "https://github.com/8bitalex/raid",
+		Profile:    "demo",
+		Repos:      []rctx.Repo{},
+	}
+	if err := writePretty(&buf, ws); err != nil {
+		t.Fatalf("writePretty: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"# raid", "v1.2.3", "workspace context", "https://github.com/8bitalex/raid"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("header missing %q\n--- output ---\n%s", want, out)
+		}
+	}
+}
+
+func TestWriteJSON_includesAgentHeader(t *testing.T) {
+	var buf bytes.Buffer
+	ws := rctx.Workspace{
+		Tool:       "raid",
+		Version:    "1.2.3",
+		Repository: "https://github.com/8bitalex/raid",
+		Profile:    "demo",
+		Repos:      []rctx.Repo{},
+	}
+	if err := writeJSON(&buf, ws); err != nil {
+		t.Fatalf("writeJSON: %v", err)
+	}
+	var decoded rctx.Workspace
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if decoded.Tool != "raid" {
+		t.Errorf("Tool = %q, want %q", decoded.Tool, "raid")
+	}
+	if decoded.Version != "1.2.3" {
+		t.Errorf("Version = %q, want %q", decoded.Version, "1.2.3")
+	}
+	if decoded.Repository != "https://github.com/8bitalex/raid" {
+		t.Errorf("Repository = %q, want canonical URL", decoded.Repository)
+	}
+}
+
 func TestWritePretty_noProfile(t *testing.T) {
 	var buf bytes.Buffer
 	if err := writePretty(&buf, rctx.Workspace{Repos: []rctx.Repo{}}); err != nil {
@@ -138,6 +185,25 @@ func TestWritePretty_commands(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("output missing %q\n--- output ---\n%s", want, out)
 		}
+	}
+}
+
+func TestRecentStatusText(t *testing.T) {
+	tests := []struct {
+		name string
+		in   rctx.Recent
+		want string
+	}{
+		{"completed ok", rctx.Recent{Status: rctx.RecentStatusCompleted, ExitCode: 0}, "ok"},
+		{"completed fail", rctx.Recent{Status: rctx.RecentStatusCompleted, ExitCode: 1}, "failed"},
+		{"interrupted", rctx.Recent{Status: rctx.RecentStatusInterrupted}, "interrupted"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := recentStatusText(tt.in); got != tt.want {
+				t.Errorf("recentStatusText = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/src/cmd/context/context_test.go
+++ b/src/cmd/context/context_test.go
@@ -1,0 +1,132 @@
+package context
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	rctx "github.com/8bitalex/raid/src/raid/context"
+)
+
+func TestWritePretty_noProfile(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writePretty(&buf, rctx.Workspace{Repos: []rctx.Repo{}}); err != nil {
+		t.Fatalf("writePretty: %v", err)
+	}
+	if !strings.Contains(buf.String(), "No active profile") {
+		t.Errorf("expected 'No active profile' message, got: %q", buf.String())
+	}
+}
+
+func TestWritePretty_noRepos(t *testing.T) {
+	var buf bytes.Buffer
+	ws := rctx.Workspace{
+		Profile: "demo",
+		Env:     "dev",
+		Repos:   []rctx.Repo{},
+	}
+	if err := writePretty(&buf, ws); err != nil {
+		t.Fatalf("writePretty: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Profile: demo") {
+		t.Errorf("missing profile line: %q", out)
+	}
+	if !strings.Contains(out, "Env:     dev") {
+		t.Errorf("missing env line: %q", out)
+	}
+	if !strings.Contains(out, "No repositories configured") {
+		t.Errorf("missing 'no repos' message: %q", out)
+	}
+}
+
+func TestWritePretty_repoStates(t *testing.T) {
+	var buf bytes.Buffer
+	ws := rctx.Workspace{
+		Profile: "demo",
+		Env:     "dev",
+		Repos: []rctx.Repo{
+			{Name: "api", Path: "~/dev/api", Cloned: true, Branch: "main"},
+			{Name: "frontend", Path: "~/dev/frontend", Cloned: true, Branch: "develop", Dirty: true},
+			{Name: "worker", Path: "~/dev/worker"},
+		},
+	}
+	if err := writePretty(&buf, ws); err != nil {
+		t.Fatalf("writePretty: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"api", "main", "clean",
+		"frontend", "develop", "dirty",
+		"worker", "not cloned",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\n--- output ---\n%s", want, out)
+		}
+	}
+}
+
+func TestWriteJSON_shape(t *testing.T) {
+	var buf bytes.Buffer
+	ws := rctx.Workspace{
+		Profile: "demo",
+		Env:     "dev",
+		Repos: []rctx.Repo{
+			{Name: "api", Path: "~/dev/api", Cloned: true, Branch: "main"},
+			{Name: "worker", Path: "~/dev/worker"},
+		},
+	}
+	if err := writeJSON(&buf, ws); err != nil {
+		t.Fatalf("writeJSON: %v", err)
+	}
+
+	var decoded rctx.Workspace
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("invalid JSON output: %v\n%s", err, buf.String())
+	}
+
+	if decoded.Profile != "demo" || decoded.Env != "dev" {
+		t.Errorf("decoded header = %+v", decoded)
+	}
+	if len(decoded.Repos) != 2 {
+		t.Fatalf("repos len = %d, want 2", len(decoded.Repos))
+	}
+	if decoded.Repos[0].Name != "api" || !decoded.Repos[0].Cloned || decoded.Repos[0].Branch != "main" {
+		t.Errorf("api repo = %+v", decoded.Repos[0])
+	}
+	if decoded.Repos[1].Name != "worker" || decoded.Repos[1].Cloned {
+		t.Errorf("worker repo = %+v (should be uncloned)", decoded.Repos[1])
+	}
+}
+
+func TestRepoStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		in   rctx.Repo
+		want string
+	}{
+		{"not cloned", rctx.Repo{}, "not cloned"},
+		{"clean", rctx.Repo{Cloned: true}, "clean"},
+		{"dirty", rctx.Repo{Cloned: true, Dirty: true}, "dirty"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := repoStatus(tt.in); got != tt.want {
+				t.Errorf("repoStatus = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommand_isWired(t *testing.T) {
+	if Command == nil {
+		t.Fatal("Command is nil")
+	}
+	if Command.Use != "context" {
+		t.Errorf("Use = %q, want %q", Command.Use, "context")
+	}
+	if Command.Flags().Lookup("json") == nil {
+		t.Error("--json flag not registered")
+	}
+}

--- a/src/cmd/context/context_test.go
+++ b/src/cmd/context/context_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	rctx "github.com/8bitalex/raid/src/raid/context"
+	"github.com/spf13/cobra"
 )
 
 func TestWritePretty_includesAgentHeader(t *testing.T) {
@@ -285,6 +286,69 @@ func TestRelativeTime(t *testing.T) {
 		then, _ := time.Parse(time.RFC3339, tt.then)
 		if got := relativeTime(now, then); got != tt.want {
 			t.Errorf("relativeTime(%s) = %q, want %q", tt.then, got, tt.want)
+		}
+	}
+}
+
+func TestCollectTools_filtersOutHelpCompletionAndUserCommands(t *testing.T) {
+	root := &cobra.Command{Use: "raid"}
+	// Built-in raid subcommands.
+	root.AddCommand(&cobra.Command{Use: "install", Short: "Install the active profile"})
+	root.AddCommand(&cobra.Command{Use: "env", Short: "Execute an environment"})
+	root.AddCommand(&cobra.Command{Use: "doctor", Short: "Check raid config"})
+	// Cobra-internal commands that should be filtered out.
+	root.AddCommand(&cobra.Command{Use: "help"})
+	root.AddCommand(&cobra.Command{Use: "completion"})
+	// User-defined command, mirrored on how registerUserCommands annotates them.
+	root.AddCommand(&cobra.Command{
+		Use:         "deploy",
+		Short:       "Deploy to production",
+		Annotations: map[string]string{cmdSourceAnnotation: cmdSourceUser},
+	})
+
+	tools := collectTools(root)
+
+	gotNames := make([]string, len(tools))
+	for i, tool := range tools {
+		gotNames[i] = tool.Name
+	}
+	wantNames := []string{"doctor", "env", "install"} // sorted alphabetically
+	if len(gotNames) != len(wantNames) {
+		t.Fatalf("collectTools = %v, want %v", gotNames, wantNames)
+	}
+	for i, want := range wantNames {
+		if gotNames[i] != want {
+			t.Errorf("tools[%d] = %q, want %q (full = %v)", i, gotNames[i], want, gotNames)
+		}
+	}
+}
+
+func TestCollectTools_keepsCobraShortAsDescription(t *testing.T) {
+	root := &cobra.Command{Use: "raid"}
+	root.AddCommand(&cobra.Command{Use: "install", Short: "Install the active profile"})
+	tools := collectTools(root)
+	if len(tools) != 1 || tools[0].Description != "Install the active profile" {
+		t.Errorf("description not propagated: %+v", tools)
+	}
+}
+
+func TestWritePretty_includesToolsSection(t *testing.T) {
+	var buf bytes.Buffer
+	ws := rctx.Workspace{
+		Profile: "demo",
+		Repos:   []rctx.Repo{},
+		Tools: []rctx.Tool{
+			{Name: "install", Description: "Install the active profile"},
+			{Name: "env", Description: "Execute an environment"},
+		},
+	}
+	if err := writePretty(&buf, ws); err != nil {
+		t.Fatalf("writePretty: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"Tools (2)", "install", "Install the active profile", "env"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\n--- output ---\n%s", want, out)
 		}
 	}
 }

--- a/src/cmd/context/context_test.go
+++ b/src/cmd/context/context_test.go
@@ -282,6 +282,50 @@ func TestWritePretty_commands(t *testing.T) {
 	}
 }
 
+// TestWritePretty_commandSteps confirms that commands with named tasks expose
+// numbered step rows under their main row, mirroring what the JSON output
+// emits via the steps[] array.
+func TestWritePretty_commandSteps(t *testing.T) {
+	var buf bytes.Buffer
+	ws := rctx.Snapshot{
+		Workspace: rctx.Workspace{
+			Profile: "demo",
+			Repos:   []rctx.Repo{},
+			Commands: []rctx.Command{
+				{
+					Name:        "release",
+					Description: "Cut a release",
+					Steps: []rctx.Step{
+						{Name: "Build artifact"},
+						{Name: "Push to registry"},
+						{Name: "Tag release"},
+					},
+				},
+				{Name: "lint", Description: "Lint everything"}, // no steps — must not render any
+			},
+		},
+	}
+	if err := writePretty(&buf, ws); err != nil {
+		t.Fatalf("writePretty: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"release",
+		"1. Build artifact",
+		"2. Push to registry",
+		"3. Tag release",
+		"lint",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\n--- output ---\n%s", want, out)
+		}
+	}
+	// Lint command has no steps; ensure no numbered lines snuck in for it.
+	if strings.Contains(out, "1. ") && strings.Count(out, "1. ") != 1 {
+		t.Errorf("expected exactly one '1.' step row (release's first step), got: %s", out)
+	}
+}
+
 func TestRecentStatusText(t *testing.T) {
 	tests := []struct {
 		name string

--- a/src/cmd/context/context_test.go
+++ b/src/cmd/context/context_test.go
@@ -13,12 +13,14 @@ import (
 
 func TestWritePretty_includesAgentHeader(t *testing.T) {
 	var buf bytes.Buffer
-	ws := rctx.Workspace{
-		Tool:       "raid",
+	ws := rctx.Snapshot{
+		Name:       "raid",
 		Version:    "1.2.3",
-		Repository: "https://github.com/8bitalex/raid",
-		Profile:    "demo",
-		Repos:      []rctx.Repo{},
+		WebsiteUrl: "https://github.com/8bitalex/raid",
+		Workspace: rctx.Workspace{
+			Profile: "demo",
+			Repos:   []rctx.Repo{},
+		},
 	}
 	if err := writePretty(&buf, ws); err != nil {
 		t.Fatalf("writePretty: %v", err)
@@ -33,34 +35,36 @@ func TestWritePretty_includesAgentHeader(t *testing.T) {
 
 func TestWriteJSON_includesAgentHeader(t *testing.T) {
 	var buf bytes.Buffer
-	ws := rctx.Workspace{
-		Tool:       "raid",
+	ws := rctx.Snapshot{
+		Name:       "raid",
 		Version:    "1.2.3",
-		Repository: "https://github.com/8bitalex/raid",
-		Profile:    "demo",
-		Repos:      []rctx.Repo{},
+		WebsiteUrl: "https://github.com/8bitalex/raid",
+		Workspace: rctx.Workspace{
+			Profile: "demo",
+			Repos:   []rctx.Repo{},
+		},
 	}
 	if err := writeJSON(&buf, ws); err != nil {
 		t.Fatalf("writeJSON: %v", err)
 	}
-	var decoded rctx.Workspace
+	var decoded rctx.Snapshot
 	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
 		t.Fatalf("invalid JSON: %v", err)
 	}
-	if decoded.Tool != "raid" {
-		t.Errorf("Tool = %q, want %q", decoded.Tool, "raid")
+	if decoded.Name != "raid" {
+		t.Errorf("Name = %q, want %q", decoded.Name, "raid")
 	}
 	if decoded.Version != "1.2.3" {
 		t.Errorf("Version = %q, want %q", decoded.Version, "1.2.3")
 	}
-	if decoded.Repository != "https://github.com/8bitalex/raid" {
-		t.Errorf("Repository = %q, want canonical URL", decoded.Repository)
+	if decoded.WebsiteUrl != "https://github.com/8bitalex/raid" {
+		t.Errorf("WebsiteUrl = %q, want canonical URL", decoded.WebsiteUrl)
 	}
 }
 
 func TestWritePretty_noProfile(t *testing.T) {
 	var buf bytes.Buffer
-	if err := writePretty(&buf, rctx.Workspace{Repos: []rctx.Repo{}}); err != nil {
+	if err := writePretty(&buf, rctx.Snapshot{Workspace: rctx.Workspace{Repos: []rctx.Repo{}}}); err != nil {
 		t.Fatalf("writePretty: %v", err)
 	}
 	if !strings.Contains(buf.String(), "No active profile") {
@@ -70,10 +74,12 @@ func TestWritePretty_noProfile(t *testing.T) {
 
 func TestWritePretty_noRepos(t *testing.T) {
 	var buf bytes.Buffer
-	ws := rctx.Workspace{
-		Profile: "demo",
-		Env:     "dev",
-		Repos:   []rctx.Repo{},
+	ws := rctx.Snapshot{
+		Workspace: rctx.Workspace{
+			Profile: "demo",
+			Env:     "dev",
+			Repos:   []rctx.Repo{},
+		},
 	}
 	if err := writePretty(&buf, ws); err != nil {
 		t.Fatalf("writePretty: %v", err)
@@ -92,13 +98,15 @@ func TestWritePretty_noRepos(t *testing.T) {
 
 func TestWritePretty_repoStates(t *testing.T) {
 	var buf bytes.Buffer
-	ws := rctx.Workspace{
-		Profile: "demo",
-		Env:     "dev",
-		Repos: []rctx.Repo{
-			{Name: "api", Path: "~/dev/api", Cloned: true, Branch: "main"},
-			{Name: "frontend", Path: "~/dev/frontend", Cloned: true, Branch: "develop", Dirty: true},
-			{Name: "worker", Path: "~/dev/worker"},
+	ws := rctx.Snapshot{
+		Workspace: rctx.Workspace{
+			Profile: "demo",
+			Env:     "dev",
+			Repos: []rctx.Repo{
+				{Name: "api", Path: "~/dev/api", Cloned: true, Branch: "main"},
+				{Name: "frontend", Path: "~/dev/frontend", Cloned: true, Branch: "develop", Dirty: true},
+				{Name: "worker", Path: "~/dev/worker"},
+			},
 		},
 	}
 	if err := writePretty(&buf, ws); err != nil {
@@ -118,34 +126,117 @@ func TestWritePretty_repoStates(t *testing.T) {
 
 func TestWriteJSON_shape(t *testing.T) {
 	var buf bytes.Buffer
-	ws := rctx.Workspace{
-		Profile: "demo",
-		Env:     "dev",
-		Repos: []rctx.Repo{
-			{Name: "api", Path: "~/dev/api", Cloned: true, Branch: "main"},
-			{Name: "worker", Path: "~/dev/worker"},
+	ws := rctx.Snapshot{
+		Workspace: rctx.Workspace{
+			Profile: "demo",
+			Env:     "dev",
+			Repos: []rctx.Repo{
+				{Name: "api", Path: "~/dev/api", Cloned: true, Branch: "main"},
+				{Name: "worker", Path: "~/dev/worker"},
+			},
 		},
 	}
 	if err := writeJSON(&buf, ws); err != nil {
 		t.Fatalf("writeJSON: %v", err)
 	}
 
-	var decoded rctx.Workspace
+	var decoded rctx.Snapshot
 	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
 		t.Fatalf("invalid JSON output: %v\n%s", err, buf.String())
 	}
 
-	if decoded.Profile != "demo" || decoded.Env != "dev" {
-		t.Errorf("decoded header = %+v", decoded)
+	if decoded.Workspace.Profile != "demo" || decoded.Workspace.Env != "dev" {
+		t.Errorf("decoded workspace = %+v", decoded.Workspace)
 	}
-	if len(decoded.Repos) != 2 {
-		t.Fatalf("repos len = %d, want 2", len(decoded.Repos))
+	if len(decoded.Workspace.Repos) != 2 {
+		t.Fatalf("repos len = %d, want 2", len(decoded.Workspace.Repos))
 	}
-	if decoded.Repos[0].Name != "api" || !decoded.Repos[0].Cloned || decoded.Repos[0].Branch != "main" {
-		t.Errorf("api repo = %+v", decoded.Repos[0])
+	if decoded.Workspace.Repos[0].Name != "api" || !decoded.Workspace.Repos[0].Cloned || decoded.Workspace.Repos[0].Branch != "main" {
+		t.Errorf("api repo = %+v", decoded.Workspace.Repos[0])
 	}
-	if decoded.Repos[1].Name != "worker" || decoded.Repos[1].Cloned {
-		t.Errorf("worker repo = %+v (should be uncloned)", decoded.Repos[1])
+	if decoded.Workspace.Repos[1].Name != "worker" || decoded.Workspace.Repos[1].Cloned {
+		t.Errorf("worker repo = %+v (should be uncloned)", decoded.Workspace.Repos[1])
+	}
+}
+
+// TestWriteJSON_workspaceIsNested guards the structural promise of step 1: the
+// workspace data must live under a single `workspace` key, with no leakage of
+// snake_case or flat top-level fields. A regression here defeats the whole
+// MCP-shape alignment.
+func TestWriteJSON_workspaceIsNested(t *testing.T) {
+	var buf bytes.Buffer
+	ws := rctx.Snapshot{
+		Name:       "raid",
+		Version:    "1.2.3",
+		WebsiteUrl: "https://github.com/8bitalex/raid",
+		Workspace: rctx.Workspace{
+			Profile: "demo",
+			Env:     "dev",
+			Repos:   []rctx.Repo{{Name: "api", Path: "~/dev/api"}},
+			Commands: []rctx.Command{{Name: "deploy"}},
+		},
+	}
+	if err := writeJSON(&buf, ws); err != nil {
+		t.Fatalf("writeJSON: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	// Top-level must NOT contain flat workspace keys or any snake_case names.
+	for _, forbidden := range []string{"profile", "env", "repos", "commands", "recent", "tool", "repository", "generated_at"} {
+		if _, present := decoded[forbidden]; present {
+			t.Errorf("top-level should not contain %q (workspace data must nest under 'workspace')", forbidden)
+		}
+	}
+	// Workspace key must exist and contain the data.
+	wsObj, ok := decoded["workspace"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected 'workspace' object, got: %T", decoded["workspace"])
+	}
+	for _, want := range []string{"profile", "env", "repos", "commands"} {
+		if _, present := wsObj[want]; !present {
+			t.Errorf("workspace missing key %q", want)
+		}
+	}
+}
+
+// TestWriteJSON_recentUsesCamelCase ensures the recent log fields are emitted
+// with MCP-aligned camelCase keys, not the prior snake_case form.
+func TestWriteJSON_recentUsesCamelCase(t *testing.T) {
+	var buf bytes.Buffer
+	ws := rctx.Snapshot{
+		Workspace: rctx.Workspace{
+			Profile: "demo",
+			Repos:   []rctx.Repo{},
+			Recent: []rctx.Recent{
+				{Command: "deploy", Status: rctx.RecentStatusCompleted, ExitCode: 0, DurationMs: 1234},
+			},
+		},
+	}
+	if err := writeJSON(&buf, ws); err != nil {
+		t.Fatalf("writeJSON: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	wsObj := decoded["workspace"].(map[string]any)
+	recent := wsObj["recent"].([]any)
+	first := recent[0].(map[string]any)
+
+	for _, camel := range []string{"exitCode", "startedAt", "durationMs"} {
+		if _, present := first[camel]; !present {
+			t.Errorf("recent entry missing camelCase key %q (got %v)", camel, first)
+		}
+	}
+	for _, snake := range []string{"exit_code", "started_at", "duration_ms"} {
+		if _, present := first[snake]; present {
+			t.Errorf("recent entry should not contain snake_case key %q", snake)
+		}
 	}
 }
 
@@ -170,12 +261,14 @@ func TestRepoStatus(t *testing.T) {
 
 func TestWritePretty_commands(t *testing.T) {
 	var buf bytes.Buffer
-	ws := rctx.Workspace{
-		Profile:  "demo",
-		Repos:    []rctx.Repo{},
-		Commands: []rctx.Command{
-			{Name: "deploy", Description: "Deploy to production"},
-			{Name: "test", Description: "Run tests"},
+	ws := rctx.Snapshot{
+		Workspace: rctx.Workspace{
+			Profile: "demo",
+			Repos:   []rctx.Repo{},
+			Commands: []rctx.Command{
+				{Name: "deploy", Description: "Deploy to production"},
+				{Name: "test", Description: "Run tests"},
+			},
 		},
 	}
 	if err := writePretty(&buf, ws); err != nil {
@@ -210,12 +303,14 @@ func TestRecentStatusText(t *testing.T) {
 
 func TestWritePretty_recent(t *testing.T) {
 	var buf bytes.Buffer
-	ws := rctx.Workspace{
-		Profile: "demo",
-		Repos:   []rctx.Repo{},
-		Recent: []rctx.Recent{
-			{Command: "deploy", ExitCode: 0, DurationMs: 12300},
-			{Command: "test", ExitCode: 1, DurationMs: 4500},
+	ws := rctx.Snapshot{
+		Workspace: rctx.Workspace{
+			Profile: "demo",
+			Repos:   []rctx.Repo{},
+			Recent: []rctx.Recent{
+				{Command: "deploy", ExitCode: 0, DurationMs: 12300},
+				{Command: "test", ExitCode: 1, DurationMs: 4500},
+			},
 		},
 	}
 	if err := writePretty(&buf, ws); err != nil {
@@ -231,25 +326,27 @@ func TestWritePretty_recent(t *testing.T) {
 
 func TestWriteJSON_includesAllSections(t *testing.T) {
 	var buf bytes.Buffer
-	ws := rctx.Workspace{
-		Profile:  "demo",
-		Env:      "dev",
-		Repos:    []rctx.Repo{{Name: "api", Path: "~/dev/api", Cloned: true, Branch: "main"}},
-		Commands: []rctx.Command{{Name: "deploy", Description: "Deploy"}},
-		Recent:   []rctx.Recent{{Command: "deploy", ExitCode: 0, DurationMs: 1234}},
+	ws := rctx.Snapshot{
+		Workspace: rctx.Workspace{
+			Profile:  "demo",
+			Env:      "dev",
+			Repos:    []rctx.Repo{{Name: "api", Path: "~/dev/api", Cloned: true, Branch: "main"}},
+			Commands: []rctx.Command{{Name: "deploy", Description: "Deploy"}},
+			Recent:   []rctx.Recent{{Command: "deploy", ExitCode: 0, DurationMs: 1234}},
+		},
 	}
 	if err := writeJSON(&buf, ws); err != nil {
 		t.Fatalf("writeJSON: %v", err)
 	}
-	var decoded rctx.Workspace
+	var decoded rctx.Snapshot
 	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
 		t.Fatalf("invalid JSON: %v", err)
 	}
-	if len(decoded.Commands) != 1 || decoded.Commands[0].Name != "deploy" {
-		t.Errorf("commands round-trip failed: %+v", decoded.Commands)
+	if len(decoded.Workspace.Commands) != 1 || decoded.Workspace.Commands[0].Name != "deploy" {
+		t.Errorf("commands round-trip failed: %+v", decoded.Workspace.Commands)
 	}
-	if len(decoded.Recent) != 1 || decoded.Recent[0].Command != "deploy" {
-		t.Errorf("recent round-trip failed: %+v", decoded.Recent)
+	if len(decoded.Workspace.Recent) != 1 || decoded.Workspace.Recent[0].Command != "deploy" {
+		t.Errorf("recent round-trip failed: %+v", decoded.Workspace.Recent)
 	}
 }
 
@@ -334,9 +431,11 @@ func TestCollectTools_keepsCobraShortAsDescription(t *testing.T) {
 
 func TestWritePretty_includesToolsSection(t *testing.T) {
 	var buf bytes.Buffer
-	ws := rctx.Workspace{
-		Profile: "demo",
-		Repos:   []rctx.Repo{},
+	ws := rctx.Snapshot{
+		Workspace: rctx.Workspace{
+			Profile: "demo",
+			Repos:   []rctx.Repo{},
+		},
 		Tools: []rctx.Tool{
 			{Name: "install", Description: "Install the active profile"},
 			{Name: "env", Description: "Execute an environment"},

--- a/src/cmd/context/context_test.go
+++ b/src/cmd/context/context_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	rctx "github.com/8bitalex/raid/src/raid/context"
 )
@@ -36,7 +37,7 @@ func TestWritePretty_noRepos(t *testing.T) {
 	if !strings.Contains(out, "Env:     dev") {
 		t.Errorf("missing env line: %q", out)
 	}
-	if !strings.Contains(out, "No repositories configured") {
+	if !strings.Contains(out, "Repos: none configured") {
 		t.Errorf("missing 'no repos' message: %q", out)
 	}
 }
@@ -116,6 +117,109 @@ func TestRepoStatus(t *testing.T) {
 				t.Errorf("repoStatus = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestWritePretty_commands(t *testing.T) {
+	var buf bytes.Buffer
+	ws := rctx.Workspace{
+		Profile:  "demo",
+		Repos:    []rctx.Repo{},
+		Commands: []rctx.Command{
+			{Name: "deploy", Description: "Deploy to production"},
+			{Name: "test", Description: "Run tests"},
+		},
+	}
+	if err := writePretty(&buf, ws); err != nil {
+		t.Fatalf("writePretty: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"Commands (2)", "deploy", "Deploy to production", "test", "Run tests"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\n--- output ---\n%s", want, out)
+		}
+	}
+}
+
+func TestWritePretty_recent(t *testing.T) {
+	var buf bytes.Buffer
+	ws := rctx.Workspace{
+		Profile: "demo",
+		Repos:   []rctx.Repo{},
+		Recent: []rctx.Recent{
+			{Command: "deploy", ExitCode: 0, DurationMs: 12300},
+			{Command: "test", ExitCode: 1, DurationMs: 4500},
+		},
+	}
+	if err := writePretty(&buf, ws); err != nil {
+		t.Fatalf("writePretty: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"Recent (2)", "deploy", "test", "✓", "✗"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\n--- output ---\n%s", want, out)
+		}
+	}
+}
+
+func TestWriteJSON_includesAllSections(t *testing.T) {
+	var buf bytes.Buffer
+	ws := rctx.Workspace{
+		Profile:  "demo",
+		Env:      "dev",
+		Repos:    []rctx.Repo{{Name: "api", Path: "~/dev/api", Cloned: true, Branch: "main"}},
+		Commands: []rctx.Command{{Name: "deploy", Description: "Deploy"}},
+		Recent:   []rctx.Recent{{Command: "deploy", ExitCode: 0, DurationMs: 1234}},
+	}
+	if err := writeJSON(&buf, ws); err != nil {
+		t.Fatalf("writeJSON: %v", err)
+	}
+	var decoded rctx.Workspace
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(decoded.Commands) != 1 || decoded.Commands[0].Name != "deploy" {
+		t.Errorf("commands round-trip failed: %+v", decoded.Commands)
+	}
+	if len(decoded.Recent) != 1 || decoded.Recent[0].Command != "deploy" {
+		t.Errorf("recent round-trip failed: %+v", decoded.Recent)
+	}
+}
+
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		ms   int64
+		want string
+	}{
+		{500, "500ms"},
+		{1500, "1.5s"},
+		{75000, "1m15s"},
+		{3700000, "1h01m"},
+	}
+	for _, tt := range tests {
+		if got := formatDuration(tt.ms); got != tt.want {
+			t.Errorf("formatDuration(%d) = %q, want %q", tt.ms, got, tt.want)
+		}
+	}
+}
+
+func TestRelativeTime(t *testing.T) {
+	now, _ := time.Parse(time.RFC3339, "2026-04-27T12:00:00Z")
+	tests := []struct {
+		then string
+		want string
+	}{
+		{"2026-04-27T11:59:55Z", "just now"},
+		{"2026-04-27T11:59:30Z", "30s ago"},
+		{"2026-04-27T11:55:00Z", "5m ago"},
+		{"2026-04-27T10:00:00Z", "2h ago"},
+		{"2026-04-25T12:00:00Z", "2d ago"},
+	}
+	for _, tt := range tests {
+		then, _ := time.Parse(time.RFC3339, tt.then)
+		if got := relativeTime(now, then); got != tt.want {
+			t.Errorf("relativeTime(%s) = %q, want %q", tt.then, got, tt.want)
+		}
 	}
 }
 

--- a/src/cmd/raid.go
+++ b/src/cmd/raid.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	contextcmd "github.com/8bitalex/raid/src/cmd/context"
 	"github.com/8bitalex/raid/src/cmd/doctor"
 	"github.com/8bitalex/raid/src/cmd/env"
 	"github.com/8bitalex/raid/src/cmd/install"
@@ -24,6 +25,7 @@ var reservedNames = map[string]bool{
 	"install":    true,
 	"env":        true,
 	"doctor":     true,
+	"context":    true,
 	"help":       true,
 	"version":    true,
 	"completion": true,
@@ -50,6 +52,7 @@ func init() {
 	rootCmd.AddCommand(install.Command)
 	rootCmd.AddCommand(env.Command)
 	rootCmd.AddCommand(doctor.Command)
+	rootCmd.AddCommand(contextcmd.Command)
 }
 
 // isInfoCommand reports whether the invocation is for a built-in informational

--- a/src/cmd/raid.go
+++ b/src/cmd/raid.go
@@ -166,6 +166,15 @@ func executeRoot(args []string) int {
 	return 0
 }
 
+// CommandSourceAnnotation tags a cobra.Command with how it was registered:
+// CommandSourceUser for profile-defined commands, absent for raid built-ins.
+// `raid context` reads this to keep its built-in tool list separate from the
+// user's commands.
+const (
+	CommandSourceAnnotation = "raid:source"
+	CommandSourceUser       = "user"
+)
+
 // registerUserCommands adds user-defined commands to root.
 // Reserved built-in names are skipped with a warning.
 func registerUserCommands(root *cobra.Command, cmds []lib.Command) {
@@ -176,8 +185,9 @@ func registerUserCommands(root *cobra.Command, cmds []lib.Command) {
 		}
 		name := cmd.Name
 		root.AddCommand(&cobra.Command{
-			Use:   name,
-			Short: cmd.Usage,
+			Use:         name,
+			Short:       cmd.Usage,
+			Annotations: map[string]string{CommandSourceAnnotation: CommandSourceUser},
 			RunE: func(c *cobra.Command, args []string) error {
 				return raid.ExecuteCommand(name, args)
 			},

--- a/src/cmd/raid_test.go
+++ b/src/cmd/raid_test.go
@@ -272,12 +272,17 @@ const (
 func setupTestConfig(t *testing.T) {
 	t.Helper()
 	dir := t.TempDir()
-	old := lib.CfgPath
+	oldCfg := lib.CfgPath
+	oldRecent := lib.RecentPathOverride
 	t.Cleanup(func() {
-		lib.CfgPath = old
+		lib.CfgPath = oldCfg
+		lib.RecentPathOverride = oldRecent
 		viper.Reset()
 	})
 	lib.CfgPath = filepath.Join(dir, "config.toml")
+	// Redirect the recent.json log so user-command tests don't pollute the
+	// developer's real ~/.raid/recent.json.
+	lib.RecentPathOverride = filepath.Join(dir, "recent.json")
 	if err := lib.InitConfig(); err != nil {
 		t.Fatalf("setupTestConfig: %v", err)
 	}
@@ -680,14 +685,17 @@ func TestExecute_inProcess_nonInfoCommand(t *testing.T) {
 // by registering a user command whose task exits with a non-zero code.
 func TestExecute_exitErrorPropagation(t *testing.T) {
 	oldCfg := lib.CfgPath
+	oldRecent := lib.RecentPathOverride
 	t.Cleanup(func() {
 		lib.CfgPath = oldCfg
+		lib.RecentPathOverride = oldRecent
 		lib.ResetContext()
 		viper.Reset()
 	})
 
 	dir := t.TempDir()
 	lib.CfgPath = filepath.Join(dir, "config.toml")
+	lib.RecentPathOverride = filepath.Join(dir, "recent.json")
 	lib.ResetContext()
 	if err := lib.InitConfig(); err != nil {
 		t.Fatalf("InitConfig: %v", err)

--- a/src/internal/lib/command.go
+++ b/src/internal/lib/command.go
@@ -64,7 +64,10 @@ func ExecuteCommand(name string, args []string) error {
 	startSession()
 	defer endSession()
 
-	return runCommand(found)
+	startedAt := recentNowFn()
+	err := runCommand(found)
+	RecordRecent(found.Name, err, startedAt)
+	return err
 }
 
 // clearRaidArgs unsets all RAID_ARG_* environment variables.

--- a/src/internal/lib/command.go
+++ b/src/internal/lib/command.go
@@ -64,9 +64,9 @@ func ExecuteCommand(name string, args []string) error {
 	startSession()
 	defer endSession()
 
-	startedAt := recentNowFn()
+	startedAt := RecordRecentStart(found.Name)
 	err := runCommand(found)
-	RecordRecent(found.Name, err, startedAt)
+	RecordRecentEnd(found.Name, err, startedAt)
 	return err
 }
 

--- a/src/internal/lib/config_test.go
+++ b/src/internal/lib/config_test.go
@@ -18,14 +18,19 @@ func setupTestConfig(t *testing.T) {
 
 	oldCfgPath := CfgPath
 	oldContext := context
+	oldRecent := RecentPathOverride
 	t.Cleanup(func() {
 		CfgPath = oldCfgPath
 		context = oldContext
+		RecentPathOverride = oldRecent
 		viper.Reset()
 	})
 
 	CfgPath = configPath
 	context = nil
+	// Redirect recent.json so tests that exercise ExecuteCommand don't
+	// pollute the developer's real ~/.raid/recent.json.
+	RecentPathOverride = filepath.Join(dir, "recent.json")
 
 	if err := InitConfig(); err != nil {
 		t.Fatalf("setupTestConfig: InitConfig() error: %v", err)

--- a/src/internal/lib/context.go
+++ b/src/internal/lib/context.go
@@ -11,9 +11,11 @@ import (
 // agent / `raid context` consumption. It is derived from the loaded session
 // context plus on-disk git state per repository.
 type WorkspaceContext struct {
-	Profile string          `json:"profile"`
-	Env     string          `json:"env,omitempty"`
-	Repos   []WorkspaceRepo `json:"repos"`
+	Profile  string             `json:"profile"`
+	Env      string             `json:"env,omitempty"`
+	Repos    []WorkspaceRepo    `json:"repos"`
+	Commands []WorkspaceCommand `json:"commands"`
+	Recent   []RecentEntry      `json:"recent,omitempty"`
 }
 
 // WorkspaceRepo describes a single repository in the active profile, as it
@@ -24,6 +26,14 @@ type WorkspaceRepo struct {
 	Cloned bool   `json:"cloned"`
 	Branch string `json:"branch,omitempty"`
 	Dirty  bool   `json:"dirty,omitempty"`
+}
+
+// WorkspaceCommand exposes a profile command's name and short description
+// only — the script bodies are intentionally excluded so the snapshot stays
+// token-efficient and free of secrets.
+type WorkspaceCommand struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
 }
 
 // runGitFn invokes git in dir with the given args and returns trimmed stdout.
@@ -37,9 +47,14 @@ var runGitFn = func(dir string, args ...string) (string, error) {
 
 // GetWorkspaceContext returns a snapshot of the active workspace. The session
 // context must already be loaded (Load / ForceLoad). If no profile is active
-// the returned WorkspaceContext has empty Profile and Repos slice.
+// the returned WorkspaceContext has empty Profile and empty Repos / Commands
+// slices.
 func GetWorkspaceContext() WorkspaceContext {
-	wc := WorkspaceContext{Repos: []WorkspaceRepo{}}
+	wc := WorkspaceContext{
+		Repos:    []WorkspaceRepo{},
+		Commands: []WorkspaceCommand{},
+		Recent:   ReadRecent(),
+	}
 	if context == nil {
 		return wc
 	}
@@ -54,6 +69,14 @@ func GetWorkspaceContext() WorkspaceContext {
 	wc.Repos = make([]WorkspaceRepo, 0, len(profile.Repositories))
 	for _, repo := range profile.Repositories {
 		wc.Repos = append(wc.Repos, describeRepo(repo))
+	}
+
+	wc.Commands = make([]WorkspaceCommand, 0, len(profile.Commands))
+	for _, cmd := range profile.Commands {
+		wc.Commands = append(wc.Commands, WorkspaceCommand{
+			Name:        cmd.Name,
+			Description: cmd.Usage,
+		})
 	}
 	return wc
 }

--- a/src/internal/lib/context.go
+++ b/src/internal/lib/context.go
@@ -3,19 +3,35 @@ package lib
 import (
 	"os/exec"
 	"strings"
+	"time"
 
 	sys "github.com/8bitalex/raid/src/internal/sys"
+	"github.com/8bitalex/raid/src/resources"
 )
+
+// raidRepository is the canonical source URL surfaced in WorkspaceContext so
+// agents have a discoverable entry point for additional documentation, issue
+// reporting, and source code search.
+const raidRepository = "https://github.com/8bitalex/raid"
 
 // WorkspaceContext is a condensed snapshot of the active workspace, intended for
 // agent / `raid context` consumption. It is derived from the loaded session
 // context plus on-disk git state per repository.
+//
+// The Tool / Version / Repository / GeneratedAt fields are emitted at the top
+// of the JSON output so an agent that picks up the snapshot in isolation can
+// identify the producer, find the project on GitHub for further context, infer
+// the schema version, and judge freshness without an external wrapper.
 type WorkspaceContext struct {
-	Profile  string             `json:"profile"`
-	Env      string             `json:"env,omitempty"`
-	Repos    []WorkspaceRepo    `json:"repos"`
-	Commands []WorkspaceCommand `json:"commands"`
-	Recent   []RecentEntry      `json:"recent,omitempty"`
+	Tool        string             `json:"tool"`
+	Version     string             `json:"version,omitempty"`
+	Repository  string             `json:"repository,omitempty"`
+	GeneratedAt time.Time          `json:"generated_at"`
+	Profile     string             `json:"profile"`
+	Env         string             `json:"env,omitempty"`
+	Repos       []WorkspaceRepo    `json:"repos"`
+	Commands    []WorkspaceCommand `json:"commands"`
+	Recent      []RecentEntry      `json:"recent,omitempty"`
 }
 
 // WorkspaceRepo describes a single repository in the active profile, as it
@@ -50,10 +66,15 @@ var runGitFn = func(dir string, args ...string) (string, error) {
 // the returned WorkspaceContext has empty Profile and empty Repos / Commands
 // slices.
 func GetWorkspaceContext() WorkspaceContext {
+	version, _ := resources.GetProperty(resources.PropertyVersion)
 	wc := WorkspaceContext{
-		Repos:    []WorkspaceRepo{},
-		Commands: []WorkspaceCommand{},
-		Recent:   ReadRecent(),
+		Tool:        "raid",
+		Version:     version,
+		Repository:  raidRepository,
+		GeneratedAt: recentNowFn().UTC().Truncate(time.Second),
+		Repos:       []WorkspaceRepo{},
+		Commands:    []WorkspaceCommand{},
+		Recent:      ReadRecent(),
 	}
 	if context == nil {
 		return wc

--- a/src/internal/lib/context.go
+++ b/src/internal/lib/context.go
@@ -64,12 +64,22 @@ type WorkspaceRepo struct {
 	Dirty  bool   `json:"dirty,omitempty"`
 }
 
-// WorkspaceCommand exposes a profile command's name and short description
-// only — the script bodies are intentionally excluded so the snapshot stays
-// token-efficient and free of secrets.
+// WorkspaceCommand exposes a profile command's name and short description.
+// Script bodies are intentionally excluded so the snapshot stays token-efficient
+// and free of secrets. If any of the command's tasks have a `name` field set,
+// they're surfaced in Steps as an outline of what the command does — also
+// without script bodies.
 type WorkspaceCommand struct {
-	Name        string `json:"name"`
-	Description string `json:"description,omitempty"`
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Steps       []WorkspaceStep `json:"steps,omitempty"`
+}
+
+// WorkspaceStep describes one named task inside a command's task sequence.
+// Only tasks with a populated TaskProps.Name appear here; unnamed tasks are
+// omitted to keep the snapshot focused on user-meaningful labels.
+type WorkspaceStep struct {
+	Name string `json:"name"`
 }
 
 // runGitFn invokes git in dir with the given args and returns trimmed stdout.
@@ -120,9 +130,24 @@ func GetWorkspaceContext() WorkspaceContext {
 		wc.Workspace.Commands = append(wc.Workspace.Commands, WorkspaceCommand{
 			Name:        cmd.Name,
 			Description: cmd.Usage,
+			Steps:       collectSteps(cmd.Tasks),
 		})
 	}
 	return wc
+}
+
+// collectSteps returns one WorkspaceStep per task in tasks that has a
+// populated Name. Unnamed tasks are skipped — the goal is an outline of
+// user-meaningful labels, not a full transcript of the task sequence.
+func collectSteps(tasks []Task) []WorkspaceStep {
+	var steps []WorkspaceStep
+	for _, t := range tasks {
+		if t.Name == "" {
+			continue
+		}
+		steps = append(steps, WorkspaceStep{Name: t.Name})
+	}
+	return steps
 }
 
 func describeRepo(repo Repo) WorkspaceRepo {

--- a/src/internal/lib/context.go
+++ b/src/internal/lib/context.go
@@ -27,11 +27,20 @@ type WorkspaceContext struct {
 	Version     string             `json:"version,omitempty"`
 	Repository  string             `json:"repository,omitempty"`
 	GeneratedAt time.Time          `json:"generated_at"`
+	Tools       []WorkspaceTool    `json:"tools,omitempty"`
 	Profile     string             `json:"profile"`
 	Env         string             `json:"env,omitempty"`
 	Repos       []WorkspaceRepo    `json:"repos"`
 	Commands    []WorkspaceCommand `json:"commands"`
 	Recent      []RecentEntry      `json:"recent,omitempty"`
+}
+
+// WorkspaceTool describes a built-in `raid` subcommand the agent can invoke
+// directly (e.g. `raid install`, `raid env`). User-defined commands live in
+// WorkspaceContext.Commands and are not duplicated here.
+type WorkspaceTool struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
 }
 
 // WorkspaceRepo describes a single repository in the active profile, as it

--- a/src/internal/lib/context.go
+++ b/src/internal/lib/context.go
@@ -9,35 +9,46 @@ import (
 	"github.com/8bitalex/raid/src/resources"
 )
 
-// raidRepository is the canonical source URL surfaced in WorkspaceContext so
+// raidWebsiteUrl is the canonical project URL surfaced in WorkspaceContext so
 // agents have a discoverable entry point for additional documentation, issue
 // reporting, and source code search.
-const raidRepository = "https://github.com/8bitalex/raid"
+const raidWebsiteUrl = "https://github.com/8bitalex/raid"
 
 // WorkspaceContext is a condensed snapshot of the active workspace, intended for
 // agent / `raid context` consumption. It is derived from the loaded session
 // context plus on-disk git state per repository.
 //
-// The Tool / Version / Repository / GeneratedAt fields are emitted at the top
-// of the JSON output so an agent that picks up the snapshot in isolation can
-// identify the producer, find the project on GitHub for further context, infer
-// the schema version, and judge freshness without an external wrapper.
+// The top-level Name / Version / WebsiteUrl / GeneratedAt fields identify the
+// producer so an agent that picks up the snapshot in isolation can find the
+// project on GitHub for further context and judge freshness. The Workspace
+// sub-object holds the actual workspace state.
+//
+// Field naming follows MCP (camelCase) so this shape can be lifted directly
+// into the future `raid context serve` MCP server responses with no further
+// translation.
 type WorkspaceContext struct {
-	Tool        string             `json:"tool"`
-	Version     string             `json:"version,omitempty"`
-	Repository  string             `json:"repository,omitempty"`
-	GeneratedAt time.Time          `json:"generated_at"`
-	Tools       []WorkspaceTool    `json:"tools,omitempty"`
-	Profile     string             `json:"profile"`
-	Env         string             `json:"env,omitempty"`
-	Repos       []WorkspaceRepo    `json:"repos"`
-	Commands    []WorkspaceCommand `json:"commands"`
-	Recent      []RecentEntry      `json:"recent,omitempty"`
+	Name        string          `json:"name"`
+	Title       string          `json:"title,omitempty"`
+	Version     string          `json:"version,omitempty"`
+	WebsiteUrl  string          `json:"websiteUrl,omitempty"`
+	GeneratedAt time.Time       `json:"generatedAt"`
+	Tools       []WorkspaceTool `json:"tools,omitempty"`
+	Workspace   Workspace       `json:"workspace"`
+}
+
+// Workspace is the inline workspace state — what would be served via
+// `resources/read` against a `raid://workspace/*` URI by an MCP server.
+type Workspace struct {
+	Profile  string             `json:"profile"`
+	Env      string             `json:"env,omitempty"`
+	Repos    []WorkspaceRepo    `json:"repos"`
+	Commands []WorkspaceCommand `json:"commands"`
+	Recent   []RecentEntry      `json:"recent,omitempty"`
 }
 
 // WorkspaceTool describes a built-in `raid` subcommand the agent can invoke
 // directly (e.g. `raid install`, `raid env`). User-defined commands live in
-// WorkspaceContext.Commands and are not duplicated here.
+// Workspace.Commands and are not duplicated here.
 type WorkspaceTool struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
@@ -72,38 +83,41 @@ var runGitFn = func(dir string, args ...string) (string, error) {
 
 // GetWorkspaceContext returns a snapshot of the active workspace. The session
 // context must already be loaded (Load / ForceLoad). If no profile is active
-// the returned WorkspaceContext has empty Profile and empty Repos / Commands
-// slices.
+// the returned WorkspaceContext has empty Workspace.Profile and empty Repos /
+// Commands slices.
 func GetWorkspaceContext() WorkspaceContext {
 	version, _ := resources.GetProperty(resources.PropertyVersion)
 	wc := WorkspaceContext{
-		Tool:        "raid",
+		Name:        "raid",
+		Title:       "Raid",
 		Version:     version,
-		Repository:  raidRepository,
+		WebsiteUrl:  raidWebsiteUrl,
 		GeneratedAt: recentNowFn().UTC().Truncate(time.Second),
-		Repos:       []WorkspaceRepo{},
-		Commands:    []WorkspaceCommand{},
-		Recent:      ReadRecent(),
+		Workspace: Workspace{
+			Repos:    []WorkspaceRepo{},
+			Commands: []WorkspaceCommand{},
+			Recent:   ReadRecent(),
+		},
 	}
 	if context == nil {
 		return wc
 	}
-	wc.Env = context.Env
+	wc.Workspace.Env = context.Env
 
 	profile := context.Profile
 	if profile.IsZero() {
 		return wc
 	}
-	wc.Profile = profile.Name
+	wc.Workspace.Profile = profile.Name
 
-	wc.Repos = make([]WorkspaceRepo, 0, len(profile.Repositories))
+	wc.Workspace.Repos = make([]WorkspaceRepo, 0, len(profile.Repositories))
 	for _, repo := range profile.Repositories {
-		wc.Repos = append(wc.Repos, describeRepo(repo))
+		wc.Workspace.Repos = append(wc.Workspace.Repos, describeRepo(repo))
 	}
 
-	wc.Commands = make([]WorkspaceCommand, 0, len(profile.Commands))
+	wc.Workspace.Commands = make([]WorkspaceCommand, 0, len(profile.Commands))
 	for _, cmd := range profile.Commands {
-		wc.Commands = append(wc.Commands, WorkspaceCommand{
+		wc.Workspace.Commands = append(wc.Workspace.Commands, WorkspaceCommand{
 			Name:        cmd.Name,
 			Description: cmd.Usage,
 		})

--- a/src/internal/lib/context.go
+++ b/src/internal/lib/context.go
@@ -1,0 +1,80 @@
+package lib
+
+import (
+	"os/exec"
+	"strings"
+
+	sys "github.com/8bitalex/raid/src/internal/sys"
+)
+
+// WorkspaceContext is a condensed snapshot of the active workspace, intended for
+// agent / `raid context` consumption. It is derived from the loaded session
+// context plus on-disk git state per repository.
+type WorkspaceContext struct {
+	Profile string          `json:"profile"`
+	Env     string          `json:"env,omitempty"`
+	Repos   []WorkspaceRepo `json:"repos"`
+}
+
+// WorkspaceRepo describes a single repository in the active profile, as it
+// exists on disk right now (not just as configured).
+type WorkspaceRepo struct {
+	Name   string `json:"name"`
+	Path   string `json:"path"`
+	Cloned bool   `json:"cloned"`
+	Branch string `json:"branch,omitempty"`
+	Dirty  bool   `json:"dirty,omitempty"`
+}
+
+// runGitFn invokes git in dir with the given args and returns trimmed stdout.
+// Overridable in tests.
+var runGitFn = func(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	return strings.TrimSpace(string(out)), err
+}
+
+// GetWorkspaceContext returns a snapshot of the active workspace. The session
+// context must already be loaded (Load / ForceLoad). If no profile is active
+// the returned WorkspaceContext has empty Profile and Repos slice.
+func GetWorkspaceContext() WorkspaceContext {
+	wc := WorkspaceContext{Repos: []WorkspaceRepo{}}
+	if context == nil {
+		return wc
+	}
+	wc.Env = context.Env
+
+	profile := context.Profile
+	if profile.IsZero() {
+		return wc
+	}
+	wc.Profile = profile.Name
+
+	wc.Repos = make([]WorkspaceRepo, 0, len(profile.Repositories))
+	for _, repo := range profile.Repositories {
+		wc.Repos = append(wc.Repos, describeRepo(repo))
+	}
+	return wc
+}
+
+func describeRepo(repo Repo) WorkspaceRepo {
+	wr := WorkspaceRepo{
+		Name: repo.Name,
+		Path: repo.Path,
+	}
+
+	expanded := sys.ExpandPath(repo.Path)
+	if !sys.FileExists(expanded) || !isGitRepository(expanded) {
+		return wr
+	}
+	wr.Cloned = true
+
+	if branch, err := runGitFn(expanded, "rev-parse", "--abbrev-ref", "HEAD"); err == nil {
+		wr.Branch = branch
+	}
+	if status, err := runGitFn(expanded, "status", "--porcelain"); err == nil {
+		wr.Dirty = strings.TrimSpace(status) != ""
+	}
+	return wr
+}

--- a/src/internal/lib/context_test.go
+++ b/src/internal/lib/context_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 )
 
 func resetWorkspaceContextState(t *testing.T) {
@@ -88,7 +87,8 @@ func TestGetWorkspaceContext_includesRecent(t *testing.T) {
 	resetWorkspaceContextState(t)
 	setupRecentTempPath(t)
 
-	RecordRecent("deploy", nil, time.Now())
+	started := RecordRecentStart("deploy")
+	RecordRecentEnd("deploy", nil, started)
 	context = &Context{
 		Profile: Profile{Name: "demo", Path: "/tmp/demo.raid.yaml"},
 	}
@@ -96,6 +96,9 @@ func TestGetWorkspaceContext_includesRecent(t *testing.T) {
 	got := GetWorkspaceContext()
 	if len(got.Recent) != 1 || got.Recent[0].Command != "deploy" {
 		t.Errorf("Recent = %+v, want one 'deploy' entry", got.Recent)
+	}
+	if got.Recent[0].Status != RecentStatusCompleted {
+		t.Errorf("Recent[0].Status = %q, want %q", got.Recent[0].Status, RecentStatusCompleted)
 	}
 }
 

--- a/src/internal/lib/context_test.go
+++ b/src/internal/lib/context_test.go
@@ -31,14 +31,14 @@ func TestGetWorkspaceContext_noContext(t *testing.T) {
 	resetWorkspaceContextState(t)
 
 	got := GetWorkspaceContext()
-	if got.Profile != "" {
-		t.Errorf("Profile = %q, want empty", got.Profile)
+	if got.Workspace.Profile != "" {
+		t.Errorf("Profile = %q, want empty", got.Workspace.Profile)
 	}
-	if got.Env != "" {
-		t.Errorf("Env = %q, want empty", got.Env)
+	if got.Workspace.Env != "" {
+		t.Errorf("Env = %q, want empty", got.Workspace.Env)
 	}
-	if len(got.Repos) != 0 {
-		t.Errorf("Repos len = %d, want 0", len(got.Repos))
+	if len(got.Workspace.Repos) != 0 {
+		t.Errorf("Repos len = %d, want 0", len(got.Workspace.Repos))
 	}
 }
 
@@ -47,17 +47,17 @@ func TestGetWorkspaceContext_zeroProfile(t *testing.T) {
 	context = &Context{Env: "dev"}
 
 	got := GetWorkspaceContext()
-	if got.Profile != "" {
-		t.Errorf("Profile = %q, want empty", got.Profile)
+	if got.Workspace.Profile != "" {
+		t.Errorf("Profile = %q, want empty", got.Workspace.Profile)
 	}
-	if got.Env != "dev" {
-		t.Errorf("Env = %q, want %q", got.Env, "dev")
+	if got.Workspace.Env != "dev" {
+		t.Errorf("Env = %q, want %q", got.Workspace.Env, "dev")
 	}
-	if len(got.Repos) != 0 {
-		t.Errorf("Repos len = %d, want 0", len(got.Repos))
+	if len(got.Workspace.Repos) != 0 {
+		t.Errorf("Repos len = %d, want 0", len(got.Workspace.Repos))
 	}
-	if len(got.Commands) != 0 {
-		t.Errorf("Commands len = %d, want 0", len(got.Commands))
+	if len(got.Workspace.Commands) != 0 {
+		t.Errorf("Commands len = %d, want 0", len(got.Workspace.Commands))
 	}
 }
 
@@ -75,11 +75,11 @@ func TestGetWorkspaceContext_includesCommands(t *testing.T) {
 	}
 
 	got := GetWorkspaceContext()
-	if len(got.Commands) != 2 {
-		t.Fatalf("Commands len = %d, want 2", len(got.Commands))
+	if len(got.Workspace.Commands) != 2 {
+		t.Fatalf("Commands len = %d, want 2", len(got.Workspace.Commands))
 	}
-	if got.Commands[0].Name != "deploy" || got.Commands[0].Description != "Deploy to production" {
-		t.Errorf("Commands[0] = %+v", got.Commands[0])
+	if got.Workspace.Commands[0].Name != "deploy" || got.Workspace.Commands[0].Description != "Deploy to production" {
+		t.Errorf("Commands[0] = %+v", got.Workspace.Commands[0])
 	}
 }
 
@@ -94,11 +94,11 @@ func TestGetWorkspaceContext_includesRecent(t *testing.T) {
 	}
 
 	got := GetWorkspaceContext()
-	if len(got.Recent) != 1 || got.Recent[0].Command != "deploy" {
-		t.Errorf("Recent = %+v, want one 'deploy' entry", got.Recent)
+	if len(got.Workspace.Recent) != 1 || got.Workspace.Recent[0].Command != "deploy" {
+		t.Errorf("Recent = %+v, want one 'deploy' entry", got.Workspace.Recent)
 	}
-	if got.Recent[0].Status != RecentStatusCompleted {
-		t.Errorf("Recent[0].Status = %q, want %q", got.Recent[0].Status, RecentStatusCompleted)
+	if got.Workspace.Recent[0].Status != RecentStatusCompleted {
+		t.Errorf("Recent[0].Status = %q, want %q", got.Workspace.Recent[0].Status, RecentStatusCompleted)
 	}
 }
 
@@ -116,13 +116,13 @@ func TestGetWorkspaceContext_repoNotCloned(t *testing.T) {
 	}
 
 	got := GetWorkspaceContext()
-	if got.Profile != "demo" {
-		t.Errorf("Profile = %q, want %q", got.Profile, "demo")
+	if got.Workspace.Profile != "demo" {
+		t.Errorf("Profile = %q, want %q", got.Workspace.Profile, "demo")
 	}
-	if len(got.Repos) != 1 {
-		t.Fatalf("Repos len = %d, want 1", len(got.Repos))
+	if len(got.Workspace.Repos) != 1 {
+		t.Fatalf("Repos len = %d, want 1", len(got.Workspace.Repos))
 	}
-	r := got.Repos[0]
+	r := got.Workspace.Repos[0]
 	if r.Cloned {
 		t.Errorf("Cloned = true, want false")
 	}
@@ -163,10 +163,10 @@ func TestGetWorkspaceContext_repoClean(t *testing.T) {
 	}
 
 	got := GetWorkspaceContext()
-	if len(got.Repos) != 1 {
-		t.Fatalf("Repos len = %d, want 1", len(got.Repos))
+	if len(got.Workspace.Repos) != 1 {
+		t.Fatalf("Repos len = %d, want 1", len(got.Workspace.Repos))
 	}
-	r := got.Repos[0]
+	r := got.Workspace.Repos[0]
 	if !r.Cloned {
 		t.Errorf("Cloned = false, want true")
 	}
@@ -206,7 +206,7 @@ func TestGetWorkspaceContext_repoDirty(t *testing.T) {
 	}
 
 	got := GetWorkspaceContext()
-	r := got.Repos[0]
+	r := got.Workspace.Repos[0]
 	if !r.Cloned {
 		t.Errorf("Cloned = false, want true")
 	}
@@ -239,7 +239,7 @@ func TestGetWorkspaceContext_directoryWithoutGit(t *testing.T) {
 	}
 
 	got := GetWorkspaceContext()
-	r := got.Repos[0]
+	r := got.Workspace.Repos[0]
 	if r.Cloned {
 		t.Errorf("Cloned = true, want false (no .git dir)")
 	}
@@ -264,7 +264,7 @@ func TestGetWorkspaceContext_gitErrorsLeaveFieldsZeroed(t *testing.T) {
 	}
 
 	got := GetWorkspaceContext()
-	r := got.Repos[0]
+	r := got.Workspace.Repos[0]
 	if !r.Cloned {
 		t.Errorf("Cloned = false, want true (.git dir present even if git failed)")
 	}

--- a/src/internal/lib/context_test.go
+++ b/src/internal/lib/context_test.go
@@ -83,6 +83,77 @@ func TestGetWorkspaceContext_includesCommands(t *testing.T) {
 	}
 }
 
+// TestGetWorkspaceContext_commandStepsOnlyNamedTasks verifies that named tasks
+// surface as steps and unnamed tasks are skipped, preserving the original
+// task order.
+func TestGetWorkspaceContext_commandStepsOnlyNamedTasks(t *testing.T) {
+	resetWorkspaceContextState(t)
+	context = &Context{
+		Profile: Profile{
+			Name: "demo",
+			Path: "/tmp/demo.raid.yaml",
+			Commands: []Command{
+				{
+					Name:  "release",
+					Usage: "Cut a release",
+					Tasks: []Task{
+						{TaskProps: TaskProps{Name: "Build artifact"}, Type: Shell, Cmd: "make build"},
+						{Type: Shell, Cmd: "echo unnamed setup"}, // unnamed: skipped
+						{TaskProps: TaskProps{Name: "Push to registry"}, Type: Shell, Cmd: "docker push"},
+						{TaskProps: TaskProps{Name: "Tag release"}, Type: Git, Op: "checkout"},
+					},
+				},
+			},
+		},
+	}
+
+	got := GetWorkspaceContext()
+	if len(got.Workspace.Commands) != 1 {
+		t.Fatalf("Commands len = %d, want 1", len(got.Workspace.Commands))
+	}
+	steps := got.Workspace.Commands[0].Steps
+	if len(steps) != 3 {
+		t.Fatalf("Steps len = %d, want 3 (named tasks only)", len(steps))
+	}
+	wantNames := []string{"Build artifact", "Push to registry", "Tag release"}
+	for i, want := range wantNames {
+		if steps[i].Name != want {
+			t.Errorf("Steps[%d] = %q, want %q", i, steps[i].Name, want)
+		}
+	}
+}
+
+// TestGetWorkspaceContext_commandStepsOmittedWhenNoneNamed confirms that a
+// command with zero named tasks emits no Steps array (omitempty), keeping the
+// JSON tight.
+func TestGetWorkspaceContext_commandStepsOmittedWhenNoneNamed(t *testing.T) {
+	resetWorkspaceContextState(t)
+	context = &Context{
+		Profile: Profile{
+			Name: "demo",
+			Path: "/tmp/demo.raid.yaml",
+			Commands: []Command{
+				{
+					Name:  "lint",
+					Usage: "Lint everything",
+					Tasks: []Task{
+						{Type: Shell, Cmd: "go vet ./..."},
+						{Type: Shell, Cmd: "golangci-lint run"},
+					},
+				},
+			},
+		},
+	}
+
+	got := GetWorkspaceContext()
+	if len(got.Workspace.Commands) != 1 {
+		t.Fatalf("Commands len = %d, want 1", len(got.Workspace.Commands))
+	}
+	if got.Workspace.Commands[0].Steps != nil {
+		t.Errorf("Steps = %+v, want nil (no named tasks)", got.Workspace.Commands[0].Steps)
+	}
+}
+
 func TestGetWorkspaceContext_includesRecent(t *testing.T) {
 	resetWorkspaceContextState(t)
 	setupRecentTempPath(t)

--- a/src/internal/lib/context_test.go
+++ b/src/internal/lib/context_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func resetWorkspaceContextState(t *testing.T) {
@@ -55,6 +56,46 @@ func TestGetWorkspaceContext_zeroProfile(t *testing.T) {
 	}
 	if len(got.Repos) != 0 {
 		t.Errorf("Repos len = %d, want 0", len(got.Repos))
+	}
+	if len(got.Commands) != 0 {
+		t.Errorf("Commands len = %d, want 0", len(got.Commands))
+	}
+}
+
+func TestGetWorkspaceContext_includesCommands(t *testing.T) {
+	resetWorkspaceContextState(t)
+	context = &Context{
+		Profile: Profile{
+			Name: "demo",
+			Path: "/tmp/demo.raid.yaml",
+			Commands: []Command{
+				{Name: "deploy", Usage: "Deploy to production"},
+				{Name: "test", Usage: "Run tests"},
+			},
+		},
+	}
+
+	got := GetWorkspaceContext()
+	if len(got.Commands) != 2 {
+		t.Fatalf("Commands len = %d, want 2", len(got.Commands))
+	}
+	if got.Commands[0].Name != "deploy" || got.Commands[0].Description != "Deploy to production" {
+		t.Errorf("Commands[0] = %+v", got.Commands[0])
+	}
+}
+
+func TestGetWorkspaceContext_includesRecent(t *testing.T) {
+	resetWorkspaceContextState(t)
+	setupRecentTempPath(t)
+
+	RecordRecent("deploy", nil, time.Now())
+	context = &Context{
+		Profile: Profile{Name: "demo", Path: "/tmp/demo.raid.yaml"},
+	}
+
+	got := GetWorkspaceContext()
+	if len(got.Recent) != 1 || got.Recent[0].Command != "deploy" {
+		t.Errorf("Recent = %+v, want one 'deploy' entry", got.Recent)
 	}
 }
 

--- a/src/internal/lib/context_test.go
+++ b/src/internal/lib/context_test.go
@@ -1,0 +1,233 @@
+package lib
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func resetWorkspaceContextState(t *testing.T) {
+	t.Helper()
+	prevCtx := context
+	prevGit := runGitFn
+	t.Cleanup(func() {
+		context = prevCtx
+		runGitFn = prevGit
+	})
+	context = nil
+}
+
+// makeFakeGitDir creates a directory with a `.git` subdirectory so isGitRepository returns true.
+func makeFakeGitDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0755); err != nil {
+		t.Fatalf("makeFakeGitDir: %v", err)
+	}
+	return dir
+}
+
+func TestGetWorkspaceContext_noContext(t *testing.T) {
+	resetWorkspaceContextState(t)
+
+	got := GetWorkspaceContext()
+	if got.Profile != "" {
+		t.Errorf("Profile = %q, want empty", got.Profile)
+	}
+	if got.Env != "" {
+		t.Errorf("Env = %q, want empty", got.Env)
+	}
+	if len(got.Repos) != 0 {
+		t.Errorf("Repos len = %d, want 0", len(got.Repos))
+	}
+}
+
+func TestGetWorkspaceContext_zeroProfile(t *testing.T) {
+	resetWorkspaceContextState(t)
+	context = &Context{Env: "dev"}
+
+	got := GetWorkspaceContext()
+	if got.Profile != "" {
+		t.Errorf("Profile = %q, want empty", got.Profile)
+	}
+	if got.Env != "dev" {
+		t.Errorf("Env = %q, want %q", got.Env, "dev")
+	}
+	if len(got.Repos) != 0 {
+		t.Errorf("Repos len = %d, want 0", len(got.Repos))
+	}
+}
+
+func TestGetWorkspaceContext_repoNotCloned(t *testing.T) {
+	resetWorkspaceContextState(t)
+	context = &Context{
+		Env: "dev",
+		Profile: Profile{
+			Name: "demo",
+			Path: "/tmp/demo.raid.yaml",
+			Repositories: []Repo{
+				{Name: "missing", Path: "/nonexistent/path/abc123", URL: "https://example.com/r.git"},
+			},
+		},
+	}
+
+	got := GetWorkspaceContext()
+	if got.Profile != "demo" {
+		t.Errorf("Profile = %q, want %q", got.Profile, "demo")
+	}
+	if len(got.Repos) != 1 {
+		t.Fatalf("Repos len = %d, want 1", len(got.Repos))
+	}
+	r := got.Repos[0]
+	if r.Cloned {
+		t.Errorf("Cloned = true, want false")
+	}
+	if r.Branch != "" {
+		t.Errorf("Branch = %q, want empty", r.Branch)
+	}
+	if r.Dirty {
+		t.Errorf("Dirty = true, want false")
+	}
+}
+
+func TestGetWorkspaceContext_repoClean(t *testing.T) {
+	resetWorkspaceContextState(t)
+	dir := makeFakeGitDir(t)
+
+	gitCalls := 0
+	runGitFn = func(_ string, args ...string) (string, error) {
+		gitCalls++
+		switch args[0] {
+		case "rev-parse":
+			return "main", nil
+		case "status":
+			return "", nil
+		}
+		t.Fatalf("unexpected git call: %v", args)
+		return "", nil
+	}
+
+	context = &Context{
+		Env: "dev",
+		Profile: Profile{
+			Name: "demo",
+			Path: "/tmp/demo.raid.yaml",
+			Repositories: []Repo{
+				{Name: "api", Path: dir, URL: "https://example.com/api.git"},
+			},
+		},
+	}
+
+	got := GetWorkspaceContext()
+	if len(got.Repos) != 1 {
+		t.Fatalf("Repos len = %d, want 1", len(got.Repos))
+	}
+	r := got.Repos[0]
+	if !r.Cloned {
+		t.Errorf("Cloned = false, want true")
+	}
+	if r.Branch != "main" {
+		t.Errorf("Branch = %q, want %q", r.Branch, "main")
+	}
+	if r.Dirty {
+		t.Errorf("Dirty = true, want false")
+	}
+	if gitCalls != 2 {
+		t.Errorf("git calls = %d, want 2", gitCalls)
+	}
+}
+
+func TestGetWorkspaceContext_repoDirty(t *testing.T) {
+	resetWorkspaceContextState(t)
+	dir := makeFakeGitDir(t)
+
+	runGitFn = func(_ string, args ...string) (string, error) {
+		switch args[0] {
+		case "rev-parse":
+			return "feature/x", nil
+		case "status":
+			return " M README.md\n?? new.txt\n", nil
+		}
+		return "", nil
+	}
+
+	context = &Context{
+		Profile: Profile{
+			Name: "demo",
+			Path: "/tmp/demo.raid.yaml",
+			Repositories: []Repo{
+				{Name: "api", Path: dir, URL: "https://example.com/api.git"},
+			},
+		},
+	}
+
+	got := GetWorkspaceContext()
+	r := got.Repos[0]
+	if !r.Cloned {
+		t.Errorf("Cloned = false, want true")
+	}
+	if r.Branch != "feature/x" {
+		t.Errorf("Branch = %q, want %q", r.Branch, "feature/x")
+	}
+	if !r.Dirty {
+		t.Errorf("Dirty = false, want true")
+	}
+}
+
+func TestGetWorkspaceContext_directoryWithoutGit(t *testing.T) {
+	resetWorkspaceContextState(t)
+	// A real directory but no .git inside.
+	dir := t.TempDir()
+
+	runGitFn = func(_ string, _ ...string) (string, error) {
+		t.Fatal("git should not be invoked for non-git directory")
+		return "", nil
+	}
+
+	context = &Context{
+		Profile: Profile{
+			Name: "demo",
+			Path: "/tmp/demo.raid.yaml",
+			Repositories: []Repo{
+				{Name: "scratch", Path: dir, URL: "https://example.com/s.git"},
+			},
+		},
+	}
+
+	got := GetWorkspaceContext()
+	r := got.Repos[0]
+	if r.Cloned {
+		t.Errorf("Cloned = true, want false (no .git dir)")
+	}
+}
+
+func TestGetWorkspaceContext_gitErrorsLeaveFieldsZeroed(t *testing.T) {
+	resetWorkspaceContextState(t)
+	dir := makeFakeGitDir(t)
+
+	runGitFn = func(_ string, args ...string) (string, error) {
+		return "", os.ErrNotExist
+	}
+
+	context = &Context{
+		Profile: Profile{
+			Name: "demo",
+			Path: "/tmp/demo.raid.yaml",
+			Repositories: []Repo{
+				{Name: "broken", Path: dir, URL: "https://example.com/b.git"},
+			},
+		},
+	}
+
+	got := GetWorkspaceContext()
+	r := got.Repos[0]
+	if !r.Cloned {
+		t.Errorf("Cloned = false, want true (.git dir present even if git failed)")
+	}
+	if r.Branch != "" {
+		t.Errorf("Branch = %q, want empty after git error", r.Branch)
+	}
+	if r.Dirty {
+		t.Errorf("Dirty = true, want false after git error")
+	}
+}

--- a/src/internal/lib/profile_test.go
+++ b/src/internal/lib/profile_test.go
@@ -412,7 +412,9 @@ install:
       concurrent: true
       cmd: echo hi
 `
-	os.WriteFile(path, []byte(body), 0644)
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		t.Fatalf("setup: write profile: %v", err)
+	}
 	if err := ValidateProfile(path); err != nil {
 		t.Fatalf("ValidateProfile() unexpected error: %v", err)
 	}
@@ -432,7 +434,9 @@ install:
       cmd: echo hi
       bogusfield: nope
 `
-	os.WriteFile(path, []byte(body), 0644)
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		t.Fatalf("setup: write profile: %v", err)
+	}
 	if err := ValidateProfile(path); err == nil {
 		t.Fatal("ValidateProfile() expected error for unknown task field")
 	}

--- a/src/internal/lib/profile_test.go
+++ b/src/internal/lib/profile_test.go
@@ -396,6 +396,48 @@ func TestValidateProfile_schemaViolation(t *testing.T) {
 	}
 }
 
+// TestValidateProfile_taskAcceptsSharedAndVariantFields verifies that the
+// allOf+taskCommon schema refactor still permits both shared task properties
+// (name, concurrent, condition) and variant-specific ones (cmd) on the same
+// task. A regression here would mean unevaluatedProperties:false isn't
+// recognising the inherited shared properties.
+func TestValidateProfile_taskAcceptsSharedAndVariantFields(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "profile.yaml")
+	body := `name: test
+install:
+  tasks:
+    - type: Shell
+      name: hello
+      concurrent: true
+      cmd: echo hi
+`
+	os.WriteFile(path, []byte(body), 0644)
+	if err := ValidateProfile(path); err != nil {
+		t.Fatalf("ValidateProfile() unexpected error: %v", err)
+	}
+}
+
+// TestValidateProfile_taskRejectsUnknownField verifies that an unknown
+// property on a task is still rejected after the schema was refactored to use
+// allOf + unevaluatedProperties:false instead of additionalProperties:false on
+// each variant.
+func TestValidateProfile_taskRejectsUnknownField(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "profile.yaml")
+	body := `name: test
+install:
+  tasks:
+    - type: Shell
+      cmd: echo hi
+      bogusfield: nope
+`
+	os.WriteFile(path, []byte(body), 0644)
+	if err := ValidateProfile(path); err == nil {
+		t.Fatal("ValidateProfile() expected error for unknown task field")
+	}
+}
+
 // --- WriteProfileFile ---
 
 func TestWriteProfileFile_createsFile(t *testing.T) {

--- a/src/internal/lib/recent.go
+++ b/src/internal/lib/recent.go
@@ -98,8 +98,13 @@ func readRecentRaw() []RecentEntry {
 // log and returns the moment recording began. Pass the same value to
 // RecordRecentEnd once the command has finished. Errors writing the log are
 // silenced — recording history must never break command execution.
+//
+// The returned time keeps full nanosecond precision so it can be used as an
+// unambiguous key by RecordRecentEnd: two commands started in the same second
+// would alias if we truncated. Display formatters can re-truncate at render
+// time when a coarser granularity is desired.
 func RecordRecentStart(command string) time.Time {
-	started := recentNowFn().UTC().Truncate(time.Second)
+	started := recentNowFn().UTC()
 	entry := RecentEntry{
 		Command:   command,
 		Status:    recentStatusRunning,
@@ -139,21 +144,58 @@ func RecordRecentEnd(command string, runErr error, startedAt time.Time) {
 	writeRecent(entries)
 }
 
-// writeRecent atomically replaces the recent log file. Caller holds recentMu.
+// writeRecent atomically replaces the recent log file. Caller holds recentMu
+// inside this process; the unique temp file (via os.CreateTemp) plus a
+// remove-then-rename fallback make the swap safe across raid processes and on
+// Windows (where os.Rename will not replace an existing destination).
+//
+// All errors are silenced — recording history must never break command
+// execution. On any failure the temp file is cleaned up.
 func writeRecent(entries []RecentEntry) {
 	path := recentPath()
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
 		return
 	}
 	data, err := json.MarshalIndent(entries, "", "  ")
 	if err != nil {
 		return
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0644); err != nil {
+
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".*.tmp")
+	if err != nil {
 		return
 	}
-	_ = os.Rename(tmp, path)
+	tmpPath := tmp.Name()
+	swapped := false
+	defer func() {
+		if !swapped {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return
+	}
+	if err := tmp.Close(); err != nil {
+		return
+	}
+
+	// POSIX: rename atomically replaces. Windows: rename fails if destination
+	// exists, so fall back to remove+rename. Either way, any failure leaves
+	// the previous file intact.
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(path)
+		if err := os.Rename(tmpPath, path); err != nil {
+			return
+		}
+	}
+	swapped = true
 }
 
 func exitCodeFromError(err error) int {

--- a/src/internal/lib/recent.go
+++ b/src/internal/lib/recent.go
@@ -13,18 +13,34 @@ import (
 )
 
 const (
-	recentFileName  = "recent.json"
+	recentFileName   = "recent.json"
 	recentMaxEntries = 10
 )
 
-// RecentEntry records a single completed `raid <command>` invocation. The log
-// is intentionally per-command (not per-task) — agents asking "what did the
+// Recent statuses surfaced via ReadRecent. "running" only ever appears on disk
+// while a command is in flight; ReadRecent rewrites it to RecentStatusInterrupted
+// so consumers always see one of these two terminal states.
+const (
+	RecentStatusCompleted   = "completed"
+	RecentStatusInterrupted = "interrupted"
+
+	recentStatusRunning = "running"
+)
+
+// RecentEntry records a single `raid <command>` invocation. The log is
+// intentionally per-command (not per-task) — agents asking "what did the
 // developer just run?" want a high-level history, not every Shell step.
+//
+// Lifecycle: an entry is first written on command start with Status="running",
+// then updated to Status="completed" once the command exits normally. If the
+// process is killed (SIGINT/SIGTERM/SIGKILL), the running entry survives on
+// disk and ReadRecent reports it as Status="interrupted".
 type RecentEntry struct {
 	Command    string    `json:"command"`
+	Status     string    `json:"status"`
 	ExitCode   int       `json:"exit_code"`
 	StartedAt  time.Time `json:"started_at"`
-	DurationMs int64     `json:"duration_ms"`
+	DurationMs int64     `json:"duration_ms,omitempty"`
 }
 
 // RecentPathOverride redirects the recent.json log path. Intended only for
@@ -48,7 +64,24 @@ func recentPath() string {
 // ReadRecent returns the most-recent-first list of recorded command runs.
 // Returns nil if the log file does not exist or cannot be parsed; callers
 // should treat absence as "no history yet".
+//
+// Any entry still in the on-disk "running" state is rewritten to
+// RecentStatusInterrupted before returning, so callers always see a terminal
+// status. Concurrent in-flight invocations will be misreported, but that's an
+// acceptable trade-off for a tool that is overwhelmingly run sequentially.
 func ReadRecent() []RecentEntry {
+	entries := readRecentRaw()
+	for i := range entries {
+		if entries[i].Status == recentStatusRunning {
+			entries[i].Status = RecentStatusInterrupted
+		}
+	}
+	return entries
+}
+
+// readRecentRaw reads the file without rewriting the running→interrupted
+// status, so internal updaters can find their own placeholder entry.
+func readRecentRaw() []RecentEntry {
 	path := recentPath()
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -61,26 +94,53 @@ func ReadRecent() []RecentEntry {
 	return entries
 }
 
-// RecordRecent prepends a new entry to the recent log, capping the file at
-// recentMaxEntries. Errors writing the log are silenced — recording history
-// must never break command execution.
-func RecordRecent(command string, runErr error, startedAt time.Time) {
+// RecordRecentStart prepends a placeholder entry for command in the recent
+// log and returns the moment recording began. Pass the same value to
+// RecordRecentEnd once the command has finished. Errors writing the log are
+// silenced — recording history must never break command execution.
+func RecordRecentStart(command string) time.Time {
+	started := recentNowFn().UTC().Truncate(time.Second)
 	entry := RecentEntry{
-		Command:    command,
-		ExitCode:   exitCodeFromError(runErr),
-		StartedAt:  startedAt.UTC().Truncate(time.Second),
-		DurationMs: recentNowFn().Sub(startedAt).Milliseconds(),
+		Command:   command,
+		Status:    recentStatusRunning,
+		StartedAt: started,
 	}
 
 	recentMu.Lock()
 	defer recentMu.Unlock()
 
-	entries := ReadRecent()
+	entries := readRecentRaw()
 	entries = append([]RecentEntry{entry}, entries...)
 	if len(entries) > recentMaxEntries {
 		entries = entries[:recentMaxEntries]
 	}
+	writeRecent(entries)
+	return started
+}
 
+// RecordRecentEnd updates the placeholder entry written by RecordRecentStart
+// with the command's exit code and total duration. If the matching entry has
+// fallen off the cap, no update is recorded.
+func RecordRecentEnd(command string, runErr error, startedAt time.Time) {
+	now := recentNowFn()
+
+	recentMu.Lock()
+	defer recentMu.Unlock()
+
+	entries := readRecentRaw()
+	for i := range entries {
+		if entries[i].Command == command && entries[i].StartedAt.Equal(startedAt) {
+			entries[i].Status = RecentStatusCompleted
+			entries[i].ExitCode = exitCodeFromError(runErr)
+			entries[i].DurationMs = now.Sub(startedAt).Milliseconds()
+			break
+		}
+	}
+	writeRecent(entries)
+}
+
+// writeRecent atomically replaces the recent log file. Caller holds recentMu.
+func writeRecent(entries []RecentEntry) {
 	path := recentPath()
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return

--- a/src/internal/lib/recent.go
+++ b/src/internal/lib/recent.go
@@ -38,9 +38,9 @@ const (
 type RecentEntry struct {
 	Command    string    `json:"command"`
 	Status     string    `json:"status"`
-	ExitCode   int       `json:"exit_code"`
-	StartedAt  time.Time `json:"started_at"`
-	DurationMs int64     `json:"duration_ms,omitempty"`
+	ExitCode   int       `json:"exitCode"`
+	StartedAt  time.Time `json:"startedAt"`
+	DurationMs int64     `json:"durationMs,omitempty"`
 }
 
 // RecentPathOverride redirects the recent.json log path. Intended only for

--- a/src/internal/lib/recent.go
+++ b/src/internal/lib/recent.go
@@ -1,0 +1,108 @@
+package lib
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"time"
+
+	sys "github.com/8bitalex/raid/src/internal/sys"
+)
+
+const (
+	recentFileName  = "recent.json"
+	recentMaxEntries = 10
+)
+
+// RecentEntry records a single completed `raid <command>` invocation. The log
+// is intentionally per-command (not per-task) — agents asking "what did the
+// developer just run?" want a high-level history, not every Shell step.
+type RecentEntry struct {
+	Command    string    `json:"command"`
+	ExitCode   int       `json:"exit_code"`
+	StartedAt  time.Time `json:"started_at"`
+	DurationMs int64     `json:"duration_ms"`
+}
+
+// RecentPathOverride redirects the recent.json log path. Intended only for
+// tests that exercise ExecuteCommand so they do not pollute the developer's
+// real ~/.raid/recent.json.
+var RecentPathOverride string
+
+// Overridable in tests.
+var (
+	recentNowFn = time.Now
+	recentMu    sync.Mutex
+)
+
+func recentPath() string {
+	if RecentPathOverride != "" {
+		return RecentPathOverride
+	}
+	return filepath.Join(sys.GetHomeDir(), ConfigDirName, recentFileName)
+}
+
+// ReadRecent returns the most-recent-first list of recorded command runs.
+// Returns nil if the log file does not exist or cannot be parsed; callers
+// should treat absence as "no history yet".
+func ReadRecent() []RecentEntry {
+	path := recentPath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var entries []RecentEntry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return nil
+	}
+	return entries
+}
+
+// RecordRecent prepends a new entry to the recent log, capping the file at
+// recentMaxEntries. Errors writing the log are silenced — recording history
+// must never break command execution.
+func RecordRecent(command string, runErr error, startedAt time.Time) {
+	entry := RecentEntry{
+		Command:    command,
+		ExitCode:   exitCodeFromError(runErr),
+		StartedAt:  startedAt.UTC().Truncate(time.Second),
+		DurationMs: recentNowFn().Sub(startedAt).Milliseconds(),
+	}
+
+	recentMu.Lock()
+	defer recentMu.Unlock()
+
+	entries := ReadRecent()
+	entries = append([]RecentEntry{entry}, entries...)
+	if len(entries) > recentMaxEntries {
+		entries = entries[:recentMaxEntries]
+	}
+
+	path := recentPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return
+	}
+	data, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0644); err != nil {
+		return
+	}
+	_ = os.Rename(tmp, path)
+}
+
+func exitCodeFromError(err error) int {
+	if err == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return 1
+}

--- a/src/internal/lib/recent_test.go
+++ b/src/internal/lib/recent_test.go
@@ -1,0 +1,107 @@
+package lib
+
+import (
+	"errors"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func setupRecentTempPath(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "recent.json")
+	old := RecentPathOverride
+	t.Cleanup(func() { RecentPathOverride = old })
+	RecentPathOverride = path
+	return path
+}
+
+func TestReadRecent_missingFileReturnsNil(t *testing.T) {
+	setupRecentTempPath(t)
+	if got := ReadRecent(); got != nil {
+		t.Errorf("ReadRecent() = %v, want nil", got)
+	}
+}
+
+func TestRecordRecent_writesEntry(t *testing.T) {
+	setupRecentTempPath(t)
+
+	now := time.Date(2026, 4, 27, 12, 0, 5, 0, time.UTC)
+	oldNow := recentNowFn
+	t.Cleanup(func() { recentNowFn = oldNow })
+	recentNowFn = func() time.Time { return now }
+
+	start := now.Add(-2 * time.Second)
+	RecordRecent("deploy", nil, start)
+
+	entries := ReadRecent()
+	if len(entries) != 1 {
+		t.Fatalf("entries len = %d, want 1", len(entries))
+	}
+	e := entries[0]
+	if e.Command != "deploy" {
+		t.Errorf("Command = %q, want %q", e.Command, "deploy")
+	}
+	if e.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0", e.ExitCode)
+	}
+	if e.DurationMs != 2000 {
+		t.Errorf("DurationMs = %d, want 2000", e.DurationMs)
+	}
+}
+
+func TestRecordRecent_capturesExitCodeFromError(t *testing.T) {
+	setupRecentTempPath(t)
+	RecordRecent("test", errors.New("boom"), time.Now())
+
+	entries := ReadRecent()
+	if len(entries) != 1 || entries[0].ExitCode != 1 {
+		t.Errorf("expected exit_code=1 from generic error, got: %+v", entries)
+	}
+}
+
+func TestRecordRecent_prependsAndCaps(t *testing.T) {
+	setupRecentTempPath(t)
+
+	for i := 0; i < recentMaxEntries+5; i++ {
+		RecordRecent("cmd", nil, time.Now())
+	}
+
+	entries := ReadRecent()
+	if len(entries) != recentMaxEntries {
+		t.Errorf("entries len = %d, want %d", len(entries), recentMaxEntries)
+	}
+}
+
+func TestRecordRecent_mostRecentFirst(t *testing.T) {
+	setupRecentTempPath(t)
+
+	RecordRecent("first", nil, time.Now())
+	RecordRecent("second", nil, time.Now())
+	RecordRecent("third", nil, time.Now())
+
+	entries := ReadRecent()
+	if len(entries) != 3 {
+		t.Fatalf("entries len = %d, want 3", len(entries))
+	}
+	if entries[0].Command != "third" || entries[2].Command != "first" {
+		t.Errorf("order wrong: %+v", entries)
+	}
+}
+
+func TestExitCodeFromError(t *testing.T) {
+	if got := exitCodeFromError(nil); got != 0 {
+		t.Errorf("nil error = %d, want 0", got)
+	}
+	if got := exitCodeFromError(errors.New("plain")); got != 1 {
+		t.Errorf("plain error = %d, want 1", got)
+	}
+	// Synthesise an *exec.ExitError by running a command that exits non-zero.
+	cmd := exec.Command("sh", "-c", "exit 42")
+	err := cmd.Run()
+	if got := exitCodeFromError(err); got != 42 {
+		t.Errorf("exec.ExitError(42) = %d, want 42", got)
+	}
+}

--- a/src/internal/lib/recent_test.go
+++ b/src/internal/lib/recent_test.go
@@ -174,6 +174,60 @@ func TestRecordRecentEnd_interleavedRuns(t *testing.T) {
 	}
 }
 
+// TestRecordRecentEnd_distinguishesSubSecondStarts guards the precision fix:
+// RecordRecentStart returns full-precision timestamps so two starts within
+// the same wall-clock second can still be matched unambiguously by End.
+// Earlier code truncated to whole seconds and would alias.
+func TestRecordRecentEnd_distinguishesSubSecondStarts(t *testing.T) {
+	setupRecentTempPath(t)
+
+	now := time.Date(2026, 4, 27, 12, 0, 5, 100_000_000, time.UTC) // .100s
+	oldNow := recentNowFn
+	t.Cleanup(func() { recentNowFn = oldNow })
+
+	// Drive recentNowFn through a sequence: two Starts in the same second,
+	// then two Ends a moment later.
+	calls := 0
+	timeline := []time.Time{
+		now,                                         // start A
+		now.Add(200 * time.Millisecond),             // start B (same second, different ns)
+		now.Add(time.Second),                        // end A
+		now.Add(time.Second + 100*time.Millisecond), // end B
+	}
+	recentNowFn = func() time.Time {
+		t := timeline[calls]
+		calls++
+		return t
+	}
+
+	startA := RecordRecentStart("alpha")
+	startB := RecordRecentStart("beta")
+
+	// Both starts share a wall-clock second but must remain distinguishable.
+	if startA.Second() != startB.Second() {
+		t.Fatalf("test fixture broken: starts must share a second; got %v / %v", startA, startB)
+	}
+	if startA.Equal(startB) {
+		t.Fatalf("StartedAt timestamps must keep sub-second precision; both = %v", startA)
+	}
+
+	RecordRecentEnd("alpha", nil, startA)
+	RecordRecentEnd("beta", errors.New("boom"), startB)
+
+	entries := ReadRecent()
+	if len(entries) != 2 {
+		t.Fatalf("entries len = %d, want 2", len(entries))
+	}
+	// Most recent first: beta then alpha. Each must be marked completed —
+	// proving End found its own placeholder rather than aliasing the other.
+	if entries[0].Command != "beta" || entries[0].Status != RecentStatusCompleted || entries[0].ExitCode != 1 {
+		t.Errorf("beta entry wrong: %+v", entries[0])
+	}
+	if entries[1].Command != "alpha" || entries[1].Status != RecentStatusCompleted || entries[1].ExitCode != 0 {
+		t.Errorf("alpha entry wrong: %+v", entries[1])
+	}
+}
+
 func TestExitCodeFromError(t *testing.T) {
 	if got := exitCodeFromError(nil); got != 0 {
 		t.Errorf("nil error = %d, want 0", got)

--- a/src/internal/lib/recent_test.go
+++ b/src/internal/lib/recent_test.go
@@ -18,6 +18,12 @@ func setupRecentTempPath(t *testing.T) string {
 	return path
 }
 
+// recordCompleted runs the full Start→End lifecycle for a single command.
+func recordCompleted(command string, runErr error) {
+	started := RecordRecentStart(command)
+	RecordRecentEnd(command, runErr, started)
+}
+
 func TestReadRecent_missingFileReturnsNil(t *testing.T) {
 	setupRecentTempPath(t)
 	if got := ReadRecent(); got != nil {
@@ -25,16 +31,24 @@ func TestReadRecent_missingFileReturnsNil(t *testing.T) {
 	}
 }
 
-func TestRecordRecent_writesEntry(t *testing.T) {
+func TestRecordRecent_writesCompletedEntry(t *testing.T) {
 	setupRecentTempPath(t)
 
 	now := time.Date(2026, 4, 27, 12, 0, 5, 0, time.UTC)
 	oldNow := recentNowFn
 	t.Cleanup(func() { recentNowFn = oldNow })
-	recentNowFn = func() time.Time { return now }
 
-	start := now.Add(-2 * time.Second)
-	RecordRecent("deploy", nil, start)
+	tickCount := 0
+	recentNowFn = func() time.Time {
+		tickCount++
+		// First call (Start) returns t0; second call (End) returns t0 + 2s.
+		if tickCount == 1 {
+			return now
+		}
+		return now.Add(2 * time.Second)
+	}
+
+	recordCompleted("deploy", nil)
 
 	entries := ReadRecent()
 	if len(entries) != 1 {
@@ -43,6 +57,9 @@ func TestRecordRecent_writesEntry(t *testing.T) {
 	e := entries[0]
 	if e.Command != "deploy" {
 		t.Errorf("Command = %q, want %q", e.Command, "deploy")
+	}
+	if e.Status != RecentStatusCompleted {
+		t.Errorf("Status = %q, want %q", e.Status, RecentStatusCompleted)
 	}
 	if e.ExitCode != 0 {
 		t.Errorf("ExitCode = %d, want 0", e.ExitCode)
@@ -54,11 +71,14 @@ func TestRecordRecent_writesEntry(t *testing.T) {
 
 func TestRecordRecent_capturesExitCodeFromError(t *testing.T) {
 	setupRecentTempPath(t)
-	RecordRecent("test", errors.New("boom"), time.Now())
+	recordCompleted("test", errors.New("boom"))
 
 	entries := ReadRecent()
 	if len(entries) != 1 || entries[0].ExitCode != 1 {
 		t.Errorf("expected exit_code=1 from generic error, got: %+v", entries)
+	}
+	if entries[0].Status != RecentStatusCompleted {
+		t.Errorf("Status = %q, want completed", entries[0].Status)
 	}
 }
 
@@ -66,7 +86,7 @@ func TestRecordRecent_prependsAndCaps(t *testing.T) {
 	setupRecentTempPath(t)
 
 	for i := 0; i < recentMaxEntries+5; i++ {
-		RecordRecent("cmd", nil, time.Now())
+		recordCompleted("cmd", nil)
 	}
 
 	entries := ReadRecent()
@@ -78,9 +98,9 @@ func TestRecordRecent_prependsAndCaps(t *testing.T) {
 func TestRecordRecent_mostRecentFirst(t *testing.T) {
 	setupRecentTempPath(t)
 
-	RecordRecent("first", nil, time.Now())
-	RecordRecent("second", nil, time.Now())
-	RecordRecent("third", nil, time.Now())
+	recordCompleted("first", nil)
+	recordCompleted("second", nil)
+	recordCompleted("third", nil)
 
 	entries := ReadRecent()
 	if len(entries) != 3 {
@@ -91,6 +111,69 @@ func TestRecordRecent_mostRecentFirst(t *testing.T) {
 	}
 }
 
+// TestReadRecent_runningEntryReportedAsInterrupted simulates a process that
+// was killed mid-command: it called RecordRecentStart but never reached
+// RecordRecentEnd. ReadRecent should rewrite the surviving "running" entry to
+// "interrupted" so callers see a terminal state.
+func TestReadRecent_runningEntryReportedAsInterrupted(t *testing.T) {
+	setupRecentTempPath(t)
+
+	RecordRecentStart("deploy") // no matching End
+
+	entries := ReadRecent()
+	if len(entries) != 1 {
+		t.Fatalf("entries len = %d, want 1", len(entries))
+	}
+	if entries[0].Status != RecentStatusInterrupted {
+		t.Errorf("Status = %q, want %q", entries[0].Status, RecentStatusInterrupted)
+	}
+}
+
+// TestRecordRecentEnd_updatesMatchingEntry confirms that when a command runs
+// to completion, the placeholder pre-recorded by Start is upgraded in place,
+// not duplicated.
+func TestRecordRecentEnd_updatesMatchingEntry(t *testing.T) {
+	setupRecentTempPath(t)
+
+	started := RecordRecentStart("deploy")
+	RecordRecentEnd("deploy", nil, started)
+
+	entries := ReadRecent()
+	if len(entries) != 1 {
+		t.Fatalf("entries len = %d, want 1 (no duplicates)", len(entries))
+	}
+	if entries[0].Status != RecentStatusCompleted {
+		t.Errorf("Status = %q, want completed", entries[0].Status)
+	}
+}
+
+// TestRecordRecentEnd_interleavedRuns ensures End updates the matching Start
+// even when an unrelated command runs in between (the entry is identified by
+// command name + StartedAt, not by position).
+func TestRecordRecentEnd_interleavedRuns(t *testing.T) {
+	setupRecentTempPath(t)
+
+	deployStart := RecordRecentStart("deploy")
+	recordCompleted("test", nil)
+	RecordRecentEnd("deploy", errors.New("oops"), deployStart)
+
+	entries := ReadRecent()
+	if len(entries) != 2 {
+		t.Fatalf("entries len = %d, want 2", len(entries))
+	}
+	// Entries are most-recent first, so test (the second Start) is index 0,
+	// deploy (the first Start) is index 1.
+	if entries[1].Command != "deploy" {
+		t.Fatalf("expected deploy at index 1, got: %+v", entries[1])
+	}
+	if entries[1].Status != RecentStatusCompleted {
+		t.Errorf("deploy Status = %q, want completed", entries[1].Status)
+	}
+	if entries[1].ExitCode != 1 {
+		t.Errorf("deploy ExitCode = %d, want 1", entries[1].ExitCode)
+	}
+}
+
 func TestExitCodeFromError(t *testing.T) {
 	if got := exitCodeFromError(nil); got != 0 {
 		t.Errorf("nil error = %d, want 0", got)
@@ -98,7 +181,6 @@ func TestExitCodeFromError(t *testing.T) {
 	if got := exitCodeFromError(errors.New("plain")); got != 1 {
 		t.Errorf("plain error = %d, want 1", got)
 	}
-	// Synthesise an *exec.ExitError by running a command that exits non-zero.
 	cmd := exec.Command("sh", "-c", "exit 42")
 	err := cmd.Run()
 	if got := exitCodeFromError(err); got != 42 {

--- a/src/internal/lib/task.go
+++ b/src/internal/lib/task.go
@@ -18,8 +18,18 @@ func (c Condition) IsZero() bool {
 	return c.Platform == "" && c.Exists == "" && c.Cmd == ""
 }
 
+// TaskProps holds properties shared by every task type. It is embedded into
+// Task so the fields below appear at the top level of a task's YAML/JSON
+// representation, and remain accessible via field promotion (e.g. `task.Name`).
+type TaskProps struct {
+	// Name is an optional human-readable label for the task, surfaced in logs
+	// and agent-facing output. It does not affect execution.
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+}
+
 // Task represents a single unit of work in a task sequence.
 type Task struct {
+	TaskProps  `yaml:",inline"`
 	Type       TaskType   `json:"type"`
 	Concurrent bool       `json:"concurrent,omitempty"`
 	Condition  *Condition `json:"condition,omitempty"`
@@ -65,6 +75,7 @@ func (t Task) IsZero() bool {
 // Expand returns a copy of the task with all string fields passed through environment variable expansion.
 func (t Task) Expand() Task {
 	return Task{
+		TaskProps:  t.TaskProps,
 		Type:       t.Type,
 		Concurrent: t.Concurrent,
 		Condition:  t.Condition,

--- a/src/internal/lib/task_test.go
+++ b/src/internal/lib/task_test.go
@@ -1,9 +1,12 @@
 package lib
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestTaskIsZero(t *testing.T) {
@@ -116,4 +119,110 @@ func TestTaskExpand_doesNotMutateOriginal(t *testing.T) {
 	if original.Cmd != "echo $RAID_TEST_ORIG" {
 		t.Errorf("Expand() mutated original: Cmd = %q", original.Cmd)
 	}
+}
+
+// --- TaskProps ---
+
+func TestTaskProps_namePromotedAndSet(t *testing.T) {
+	task := Task{TaskProps: TaskProps{Name: "build app"}, Type: Shell, Cmd: "make"}
+	if task.Name != "build app" {
+		t.Errorf("task.Name (promoted) = %q, want %q", task.Name, "build app")
+	}
+	if task.TaskProps.Name != "build app" {
+		t.Errorf("task.TaskProps.Name = %q, want %q", task.TaskProps.Name, "build app")
+	}
+}
+
+func TestTaskExpand_preservesName(t *testing.T) {
+	task := Task{TaskProps: TaskProps{Name: "build app"}, Type: Shell, Cmd: "echo hi"}
+	got := task.Expand()
+	if got.Name != "build app" {
+		t.Errorf("Expand().Name = %q, want %q", got.Name, "build app")
+	}
+}
+
+func TestTaskProps_yamlRoundTrip(t *testing.T) {
+	src := []byte("name: build app\ntype: Shell\ncmd: make\n")
+	var task Task
+	if err := yaml.Unmarshal(src, &task); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if task.Name != "build app" {
+		t.Errorf("Name after YAML unmarshal = %q, want %q", task.Name, "build app")
+	}
+	if task.Type != "Shell" || task.Cmd != "make" {
+		t.Errorf("other fields lost: type=%q cmd=%q", task.Type, task.Cmd)
+	}
+
+	out, err := yaml.Marshal(task)
+	if err != nil {
+		t.Fatalf("yaml.Marshal: %v", err)
+	}
+	if !containsLine(out, "name: build app") {
+		t.Errorf("re-marshalled YAML missing 'name' line:\n%s", out)
+	}
+}
+
+func TestTaskProps_jsonRoundTrip(t *testing.T) {
+	src := []byte(`{"name":"build app","type":"Shell","cmd":"make"}`)
+	var task Task
+	if err := json.Unmarshal(src, &task); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if task.Name != "build app" {
+		t.Errorf("Name after JSON unmarshal = %q, want %q", task.Name, "build app")
+	}
+
+	out, err := json.Marshal(task)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(out, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal of marshalled output: %v", err)
+	}
+	if decoded["name"] != "build app" {
+		t.Errorf("re-marshalled JSON missing or wrong 'name': %v", decoded["name"])
+	}
+}
+
+func TestTaskProps_omittedWhenEmpty(t *testing.T) {
+	task := Task{Type: Shell, Cmd: "echo hi"}
+	out, err := json.Marshal(task)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(out, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if _, present := decoded["name"]; present {
+		t.Errorf("expected 'name' to be omitted when empty, got: %v", decoded)
+	}
+}
+
+// containsLine reports whether buf contains line as a complete line (between newlines or at edges).
+func containsLine(buf []byte, line string) bool {
+	s := string(buf)
+	for _, l := range splitLines(s) {
+		if l == line {
+			return true
+		}
+	}
+	return false
+}
+
+func splitLines(s string) []string {
+	var out []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			out = append(out, s[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		out = append(out, s[start:])
+	}
+	return out
 }

--- a/src/raid/context/context.go
+++ b/src/raid/context/context.go
@@ -14,8 +14,12 @@ type Workspace = lib.Workspace
 // Repo describes a single repository in the workspace snapshot.
 type Repo = lib.WorkspaceRepo
 
-// Command is a profile command, exposed as name + short description only.
+// Command is a profile command, exposed as name + short description, plus an
+// optional Steps outline derived from named tasks.
 type Command = lib.WorkspaceCommand
+
+// Step describes one named task inside a command's task sequence.
+type Step = lib.WorkspaceStep
 
 // Tool is a built-in `raid` subcommand exposed for agent discovery.
 type Tool = lib.WorkspaceTool

--- a/src/raid/context/context.go
+++ b/src/raid/context/context.go
@@ -12,6 +12,9 @@ type Repo = lib.WorkspaceRepo
 // Command is a profile command, exposed as name + short description only.
 type Command = lib.WorkspaceCommand
 
+// Tool is a built-in `raid` subcommand exposed for agent discovery.
+type Tool = lib.WorkspaceTool
+
 // Recent describes a previously executed `raid <command>` invocation.
 type Recent = lib.RecentEntry
 

--- a/src/raid/context/context.go
+++ b/src/raid/context/context.go
@@ -15,6 +15,12 @@ type Command = lib.WorkspaceCommand
 // Recent describes a previously executed `raid <command>` invocation.
 type Recent = lib.RecentEntry
 
+// Recent status values surfaced via Workspace.Recent.
+const (
+	RecentStatusCompleted   = lib.RecentStatusCompleted
+	RecentStatusInterrupted = lib.RecentStatusInterrupted
+)
+
 // Get returns a snapshot of the currently loaded workspace context.
 func Get() Workspace {
 	return lib.GetWorkspaceContext()

--- a/src/raid/context/context.go
+++ b/src/raid/context/context.go
@@ -3,8 +3,13 @@ package context
 
 import "github.com/8bitalex/raid/src/internal/lib"
 
-// Workspace is a snapshot of the active profile, environment, and repositories.
-type Workspace = lib.WorkspaceContext
+// Snapshot is the full `raid context` payload — producer identity (name,
+// version, websiteUrl, generatedAt) plus the inline Workspace state.
+type Snapshot = lib.WorkspaceContext
+
+// Workspace is the inline workspace state nested inside a Snapshot: profile,
+// environment, repositories, user commands, and recent runs.
+type Workspace = lib.Workspace
 
 // Repo describes a single repository in the workspace snapshot.
 type Repo = lib.WorkspaceRepo
@@ -25,6 +30,6 @@ const (
 )
 
 // Get returns a snapshot of the currently loaded workspace context.
-func Get() Workspace {
+func Get() Snapshot {
 	return lib.GetWorkspaceContext()
 }

--- a/src/raid/context/context.go
+++ b/src/raid/context/context.go
@@ -9,6 +9,12 @@ type Workspace = lib.WorkspaceContext
 // Repo describes a single repository in the workspace snapshot.
 type Repo = lib.WorkspaceRepo
 
+// Command is a profile command, exposed as name + short description only.
+type Command = lib.WorkspaceCommand
+
+// Recent describes a previously executed `raid <command>` invocation.
+type Recent = lib.RecentEntry
+
 // Get returns a snapshot of the currently loaded workspace context.
 func Get() Workspace {
 	return lib.GetWorkspaceContext()

--- a/src/raid/context/context.go
+++ b/src/raid/context/context.go
@@ -1,0 +1,15 @@
+// Snapshot the active raid workspace for agent / `raid context` consumption.
+package context
+
+import "github.com/8bitalex/raid/src/internal/lib"
+
+// Workspace is a snapshot of the active profile, environment, and repositories.
+type Workspace = lib.WorkspaceContext
+
+// Repo describes a single repository in the workspace snapshot.
+type Repo = lib.WorkspaceRepo
+
+// Get returns a snapshot of the currently loaded workspace context.
+func Get() Workspace {
+	return lib.GetWorkspaceContext()
+}

--- a/src/raid/context/context_test.go
+++ b/src/raid/context/context_test.go
@@ -4,10 +4,10 @@ import "testing"
 
 // Get is a thin wrapper around lib.GetWorkspaceContext, which is fully
 // exercised in src/internal/lib/context_test.go. This test just guards the
-// wiring so the wrapper keeps returning a usable Workspace value.
-func TestGet_returnsWorkspace(t *testing.T) {
+// wiring so the wrapper keeps returning a usable Snapshot value.
+func TestGet_returnsSnapshot(t *testing.T) {
 	ws := Get()
-	if ws.Repos == nil {
-		t.Errorf("Get().Repos = nil, want non-nil slice")
+	if ws.Workspace.Repos == nil {
+		t.Errorf("Get().Workspace.Repos = nil, want non-nil slice")
 	}
 }

--- a/src/raid/context/context_test.go
+++ b/src/raid/context/context_test.go
@@ -1,0 +1,13 @@
+package context
+
+import "testing"
+
+// Get is a thin wrapper around lib.GetWorkspaceContext, which is fully
+// exercised in src/internal/lib/context_test.go. This test just guards the
+// wiring so the wrapper keeps returning a usable Workspace value.
+func TestGet_returnsWorkspace(t *testing.T) {
+	ws := Get()
+	if ws.Repos == nil {
+		t.Errorf("Get().Repos = nil, want non-nil slice")
+	}
+}

--- a/src/resources/app.properties
+++ b/src/resources/app.properties
@@ -1,2 +1,2 @@
-version=0.5.3-beta
+version=0.6.0-beta
 environment=development


### PR DESCRIPTION
This pull request introduces the new `raid context` command, which emits a concise, self-describing snapshot of the active workspace, and updates the documentation and schema to support this feature. It also improves test isolation for recent command logs and adds support for optional human-readable task names in the schema.

**Major features and documentation:**

* Added the `raid context` subcommand, which prints a condensed summary of the current workspace—including profile, environment, repository git state, available tools, user commands, and recent command runs—in both human-readable and JSON formats. This output is designed to be token-efficient and suitable for use by chat agents or other tools. (`src/cmd/context/context.go`, `src/cmd/raid.go`) [[1]](diffhunk://#diff-fd31306d61e4cdbad02eb207713f93e5ee4424a17ed0097d3d60071891076eacR1-R309) [[2]](diffhunk://#diff-bc1a602d899d85223ee4050edb87f38c5cfd25193a2c17213e647819c7442ee9R11) [[3]](diffhunk://#diff-bc1a602d899d85223ee4050edb87f38c5cfd25193a2c17213e647819c7442ee9R28) [[4]](diffhunk://#diff-bc1a602d899d85223ee4050edb87f38c5cfd25193a2c17213e647819c7442ee9R55)
* Documented the new `raid context` command and its output, including pretty and JSON examples, in the user and reference documentation. (`site/docs/usage/context.mdx`, `site/docs/references/commands.mdx`) [[1]](diffhunk://#diff-5a7daaa7573b9e76b0fe50599773667bc4461fe55c8aea665480d0669384dfaaR1-R166) [[2]](diffhunk://#diff-fd3105dca40453615b4e8a949eda6ffb44bbc640807440d08c9ab8ef5c51d363R95-R113)

**Schema and configuration improvements:**

* Added an optional `name` field to task definitions, allowing human-readable labels for tasks that are surfaced in logs and agent output without affecting execution. This is reflected in both the schema and feature documentation. (`site/docs/features/tasks.mdx`, `site/docs/references/schema.mdx`, `profile.raid.yml`) [[1]](diffhunk://#diff-b3ca4aacb9e3d8bad7f720f66d708e6f8e1e736d23e42cd2eaa2243809357c7dR16) [[2]](diffhunk://#diff-ca1721afa88ffee071bb1911603e7300416bc78200ff173d3bfdd144fdf52251R186) [[3]](diffhunk://#diff-9833deb1452e2f9489bc7f0df048d55c95b3ddd5cdba86904193112de057cac5R21)

**Testing and reliability:**

* Updated test setup to redirect the recent command log (`recent.json`) to temporary directories, preventing tests from polluting the user's real command history. (`src/cmd/raid_test.go`, `src/internal/lib/config_test.go`) [[1]](diffhunk://#diff-1b091f4d31f31bc79712c1afdecb2ffc23fea6562f256271d10d45d27f1ae8a8L275-R285) [[2]](diffhunk://#diff-1b091f4d31f31bc79712c1afdecb2ffc23fea6562f256271d10d45d27f1ae8a8R688-R698) [[3]](diffhunk://#diff-05fe58987bcbb4ae622d127f704218291dcb6253a73da749f1dbbde4e8adfd76R21-R33)

**Command execution tracking:**

* Enhanced command execution to record start and end times of user commands, enabling accurate logging of recent command runs for the `raid context` output. (`src/internal/lib/command.go`)

**Internal consistency:**

* Ensured user-defined commands are properly annotated so that `raid context` can distinguish them from built-in tools. (`src/cmd/raid.go`) [[1]](diffhunk://#diff-bc1a602d899d85223ee4050edb87f38c5cfd25193a2c17213e647819c7442ee9R169-R177) [[2]](diffhunk://#diff-bc1a602d899d85223ee4050edb87f38c5cfd25193a2c17213e647819c7442ee9R190)

These changes together provide a robust foundation for workspace introspection, improved agent integration, and better developer experience.