### PR TITLE
Enhance variable handling for Shell and Script tasks

### DIFF
--- a/site/docs/features/variables.mdx
+++ b/site/docs/features/variables.mdx
@@ -121,6 +121,27 @@ environments:
         value: "http://localhost:$API_PORT"
 ```
 
+### Inside Script and Shell subprocesses
+
+Raid variables are also exported as environment variables to the subprocesses that Shell and Script tasks spawn. A `Set` task earlier in the sequence is visible inside the script's source as `$VAR`:
+
+```yaml
+tasks:
+  - type: Set
+    var: "DEPLOY_ENV"
+    value: "staging"
+  - type: Script
+    path: "./scripts/deploy.sh"   # can reference $DEPLOY_ENV directly
+```
+
+```sh
+# scripts/deploy.sh
+echo "deploying to $DEPLOY_ENV"
+kubectl apply -f "manifests/$DEPLOY_ENV/"
+```
+
+The same applies to a child process spawned from a Shell task — the child inherits the shell's env, which includes raid variables. When a raid variable name collides with one already in the OS environment, the raid value wins (matching the precedence used by raid's own field-level expansion).
+
 ## Shell pass-through
 
 When raid expands variables for a Shell task, unknown variables are passed through to the shell intact. This means shell-local variables and parameter expansions work as expected:

--- a/src/internal/lib/task_runner.go
+++ b/src/internal/lib/task_runner.go
@@ -220,6 +220,7 @@ func execShell(task Task) error {
 	if task.Path != "" {
 		cmd.Dir = sys.ExpandPath(task.Path)
 	}
+	cmd.Env = buildSubprocessEnv()
 	setCmdOutput(cmd)
 
 	runErr := cmd.Run()
@@ -319,6 +320,7 @@ func execScript(task Task) error {
 		cmd = exec.Command(task.Path)
 	}
 
+	cmd.Env = buildSubprocessEnv()
 	setCmdOutput(cmd)
 
 	err := cmd.Run()
@@ -333,6 +335,34 @@ func setCmdOutput(cmd *exec.Cmd) {
 	cmd.Stdout = commandStdout
 	cmd.Stderr = commandStderr
 	cmd.Stdin = os.Stdin
+}
+
+// buildSubprocessEnv returns the OS environment merged with the current
+// commandSession exports and raidVars (Set tasks). Order matters: exec.Cmd
+// uses the LAST occurrence of a duplicate key, so we append in increasing
+// priority — OS env first, session next, raidVars last so they win on
+// collision. Mirrors the lookup order used by expandRaid.
+//
+// Applied to Shell and Script tasks so a `Set FOO bar` task earlier in the
+// sequence is visible to the spawned process (and any children it spawns)
+// as $FOO. Without this, raidVars only resolved via raid's pre-expansion of
+// the cmd string — which couldn't reach into a Script's source or into a
+// child process spawned from inside a Shell command.
+func buildSubprocessEnv() []string {
+	env := os.Environ()
+	if commandSession != nil {
+		commandSession.mu.RLock()
+		for k, v := range commandSession.vars {
+			env = append(env, k+"="+v)
+		}
+		commandSession.mu.RUnlock()
+	}
+	raidVarsMu.RLock()
+	for k, v := range raidVars {
+		env = append(env, k+"="+v)
+	}
+	raidVarsMu.RUnlock()
+	return env
 }
 
 func execHTTP(task Task) error {

--- a/src/internal/lib/task_runner.go
+++ b/src/internal/lib/task_runner.go
@@ -348,21 +348,47 @@ func setCmdOutput(cmd *exec.Cmd) {
 // as $FOO. Without this, raidVars only resolved via raid's pre-expansion of
 // the cmd string — which couldn't reach into a Script's source or into a
 // child process spawned from inside a Shell command.
+//
+// Entries with empty keys or with NUL / "=" bytes in the key (or NUL bytes
+// in the value) are silently dropped — those would either be re-parsed as
+// a different key at exec time or get rejected outright by the OS.
+// Defensive guard since Set / Prompt task input isn't yet schema-constrained.
 func buildSubprocessEnv() []string {
 	env := os.Environ()
 	if commandSession != nil {
 		commandSession.mu.RLock()
 		for k, v := range commandSession.vars {
-			env = append(env, k+"="+v)
+			if validEnvPair(k, v) {
+				env = append(env, k+"="+v)
+			}
 		}
 		commandSession.mu.RUnlock()
 	}
 	raidVarsMu.RLock()
 	for k, v := range raidVars {
-		env = append(env, k+"="+v)
+		if validEnvPair(k, v) {
+			env = append(env, k+"="+v)
+		}
 	}
 	raidVarsMu.RUnlock()
 	return env
+}
+
+// validEnvPair reports whether (key, value) is safe to inject into a
+// subprocess environment. NUL bytes terminate C strings and would corrupt
+// the entry; "=" in the key would be re-split into a different key by
+// exec at process-start time.
+func validEnvPair(key, value string) bool {
+	if key == "" {
+		return false
+	}
+	if strings.ContainsAny(key, "=\x00") {
+		return false
+	}
+	if strings.ContainsRune(value, '\x00') {
+		return false
+	}
+	return true
 }
 
 func execHTTP(task Task) error {

--- a/src/internal/lib/task_runner_test.go
+++ b/src/internal/lib/task_runner_test.go
@@ -1316,6 +1316,9 @@ func captureCommandStdout(t *testing.T) func() string {
 // variable must be visible in the env of a subsequent Script task's
 // subprocess.
 func TestExecScript_inheritsRaidVar(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("direct .sh execution not supported on Windows")
+	}
 	withRaidVar(t, "ISSUE20_FOO", "from-raid-var")
 	getOut := captureCommandStdout(t)
 
@@ -1333,6 +1336,9 @@ func TestExecScript_inheritsRaidVar(t *testing.T) {
 // expandRaid: raidVars beat OS env when names collide. The fix appends
 // raidVars last in cmd.Env so exec's last-occurrence-wins rule honors that.
 func TestExecScript_raidVarOverridesOSEnv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("direct .sh execution not supported on Windows")
+	}
 	const key = "ISSUE20_OVERRIDE"
 	t.Setenv(key, "from-os")
 	withRaidVar(t, key, "from-raid")
@@ -1354,6 +1360,9 @@ func TestExecScript_raidVarOverridesOSEnv(t *testing.T) {
 // `literal: true` skips raid's pre-expansion so resolution happens at the
 // child level instead.
 func TestExecShell_passesRaidVarToChildScript(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("direct .sh execution not supported on Windows")
+	}
 	withRaidVar(t, "ISSUE20_BAR", "from-raid-bar")
 	getOut := captureCommandStdout(t)
 

--- a/src/internal/lib/task_runner_test.go
+++ b/src/internal/lib/task_runner_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"bytes"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -1276,4 +1277,126 @@ func writeTempScript(t *testing.T, content string) string {
 		t.Fatalf("failed to write temp script: %v", err)
 	}
 	return path
+}
+
+// withRaidVar sets a raid variable for the duration of the test, restoring
+// the previous raidVars map on cleanup.
+func withRaidVar(t *testing.T, key, value string) {
+	t.Helper()
+	raidVarsMu.Lock()
+	prev := raidVars
+	raidVars = make(map[string]string, len(prev)+1)
+	for k, v := range prev {
+		raidVars[k] = v
+	}
+	raidVars[key] = value
+	raidVarsMu.Unlock()
+	t.Cleanup(func() {
+		raidVarsMu.Lock()
+		raidVars = prev
+		raidVarsMu.Unlock()
+	})
+}
+
+// captureCommandStdout swaps commandStdout for a buffer, returning a getter
+// that returns the captured text and restores the previous writer on
+// cleanup.
+func captureCommandStdout(t *testing.T) func() string {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := commandStdout
+	commandStdout = &buf
+	t.Cleanup(func() { commandStdout = prev })
+	return func() string { return buf.String() }
+}
+
+// --- Issue #20: Set variables reach Script + Shell subprocess env ---------
+
+// TestExecScript_inheritsRaidVar guards the issue-#20 fix: a Set task's
+// variable must be visible in the env of a subsequent Script task's
+// subprocess.
+func TestExecScript_inheritsRaidVar(t *testing.T) {
+	withRaidVar(t, "ISSUE20_FOO", "from-raid-var")
+	getOut := captureCommandStdout(t)
+
+	scriptPath := writeTempScript(t, "#!/bin/sh\nprintf 'got=%s' \"$ISSUE20_FOO\"\n")
+
+	if err := execScript(Task{Type: Script, Path: scriptPath}); err != nil {
+		t.Fatalf("execScript: %v", err)
+	}
+	if got := strings.TrimSpace(getOut()); got != "got=from-raid-var" {
+		t.Errorf("script saw $ISSUE20_FOO = %q, want %q", got, "got=from-raid-var")
+	}
+}
+
+// TestExecScript_raidVarOverridesOSEnv confirms the precedence promised by
+// expandRaid: raidVars beat OS env when names collide. The fix appends
+// raidVars last in cmd.Env so exec's last-occurrence-wins rule honors that.
+func TestExecScript_raidVarOverridesOSEnv(t *testing.T) {
+	const key = "ISSUE20_OVERRIDE"
+	t.Setenv(key, "from-os")
+	withRaidVar(t, key, "from-raid")
+	getOut := captureCommandStdout(t)
+
+	scriptPath := writeTempScript(t, "#!/bin/sh\nprintf 'got=%s' \"$ISSUE20_OVERRIDE\"\n")
+
+	if err := execScript(Task{Type: Script, Path: scriptPath}); err != nil {
+		t.Fatalf("execScript: %v", err)
+	}
+	if got := strings.TrimSpace(getOut()); got != "got=from-raid" {
+		t.Errorf("script saw collision = %q, want raidVar to win (got=from-raid)", got)
+	}
+}
+
+// TestExecShell_passesRaidVarToChildScript ensures the same fix applies to
+// Shell tasks: a child process spawned by the shell (e.g. another script)
+// sees the raidVar even though the shell itself didn't pre-expand it.
+// `literal: true` skips raid's pre-expansion so resolution happens at the
+// child level instead.
+func TestExecShell_passesRaidVarToChildScript(t *testing.T) {
+	withRaidVar(t, "ISSUE20_BAR", "from-raid-bar")
+	getOut := captureCommandStdout(t)
+
+	dir := t.TempDir()
+	childPath := filepath.Join(dir, "child.sh")
+	if err := os.WriteFile(childPath, []byte("#!/bin/sh\nprintf 'child=%s' \"$ISSUE20_BAR\"\n"), 0755); err != nil {
+		t.Fatalf("write child: %v", err)
+	}
+
+	task := Task{Type: Shell, Cmd: childPath, Literal: true}
+	if err := execShell(task); err != nil {
+		t.Fatalf("execShell: %v", err)
+	}
+	if got := strings.TrimSpace(getOut()); got != "child=from-raid-bar" {
+		t.Errorf("child saw $ISSUE20_BAR = %q, want %q", got, "child=from-raid-bar")
+	}
+}
+
+// TestBuildSubprocessEnv_orderRaidVarsLast directly exercises the helper to
+// guard the precedence wiring (raidVars must appear AFTER OS env so exec's
+// duplicate-key resolution gives them priority).
+func TestBuildSubprocessEnv_orderRaidVarsLast(t *testing.T) {
+	const key = "ISSUE20_BUILD_ENV"
+	t.Setenv(key, "os-value")
+	withRaidVar(t, key, "raid-value")
+
+	env := buildSubprocessEnv()
+	osIdx, raidIdx := -1, -1
+	for i, kv := range env {
+		switch kv {
+		case key + "=os-value":
+			osIdx = i
+		case key + "=raid-value":
+			raidIdx = i
+		}
+	}
+	if osIdx < 0 {
+		t.Fatalf("buildSubprocessEnv missing OS-set %q", key)
+	}
+	if raidIdx < 0 {
+		t.Fatalf("buildSubprocessEnv missing raid-set %q", key)
+	}
+	if raidIdx < osIdx {
+		t.Errorf("raid-set entry at %d came before OS entry at %d; exec uses last-occurrence so raidVar must come last", raidIdx, osIdx)
+	}
 }

--- a/src/resources/app.properties
+++ b/src/resources/app.properties
@@ -1,2 +1,2 @@
-version=0.7.0-beta
+version=0.7.1-beta
 environment=development


### PR DESCRIPTION
This pull request ensures that variables set by `Set` tasks ("raid variables") are exported as environment variables to subprocesses spawned by `Script` and `Shell` tasks. This allows scripts and child processes to access these variables directly via `$VAR`, and guarantees that raid variables override any OS environment variable with the same name. The implementation includes a new helper to merge environments in the correct order and comprehensive tests to validate the behavior.

The most important changes include:

**Environment Variable Handling for Subprocesses:**

* Added a new `buildSubprocessEnv` helper function in `task_runner.go` to merge the OS environment, session variables, and raid variables, ensuring raid variables take precedence when names collide. This function is now used for all `Script` and `Shell` subprocesses. [[1]](diffhunk://#diff-48e07e0e139ed7669546b48951e65f2da713c15e862113ab68517e1f477f2fc0R340-R367) [[2]](diffhunk://#diff-48e07e0e139ed7669546b48951e65f2da713c15e862113ab68517e1f477f2fc0R223) [[3]](diffhunk://#diff-48e07e0e139ed7669546b48951e65f2da713c15e862113ab68517e1f477f2fc0R323)
* Updated documentation in `variables.mdx` to explain that raid variables are available in the environment of subprocesses spawned by `Script` and `Shell` tasks, and that raid variables override OS environment variables with the same name.

**Testing and Validation:**

* Added new helper functions and tests in `task_runner_test.go` to verify that raid variables are correctly exported to subprocess environments, that they override OS variables, and that the environment order is correct. [[1]](diffhunk://#diff-adb013329303480a38f1a8df1199a684ec23dd14766fa64f9efeb7926ff535bdR1281-R1402) [[2]](diffhunk://#diff-adb013329303480a38f1a8df1199a684ec23dd14766fa64f9efeb7926ff535bdR4)

These changes ensure more predictable and powerful scripting capabilities when using raid tasks.…riables are accessible in subprocesses and maintain precedence over OS environment variables