### PR TITLE
Add repository metadata handling and update documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,5 +22,5 @@ CI: .github/workflows/ — build.yml (build+test), deploy.yml (release), preview
 
 Every change must:
 1. Include full-coverage tests — unit tests for new/changed functions, edge cases, and error paths. Run `go test ./...` and confirm all pass before finishing.
-2. Update documentation — if the change affects user-facing behavior, update the relevant docsite pages under site/docs/ (features, usage, references, examples) and the README if applicable. Run `npm run build` in site/ to verify no broken links.
+2. Update documentation — if the change affects user-facing behavior, update the relevant docsite pages under site/docs/ (features, usage, references, examples), the README, and site/docs/whats-new.mdx (under the upcoming version section). Run `npm run build` in site/ to verify no broken links.
 3. Keep the docsite build green — never leave broken cross-references or missing pages.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ When a developer runs any raid command, it executes against the right repo, in t
 - **Consistent environments** — define local, staging, and production environments once. `raid env staging` applies the right variables and tasks across every repo in a single command.
 - **Full system orchestration** — manage any number of repos as a single unit. Clone, configure, and run them together or individually.
 - **Rich task runner** — 11 built-in task types: shell commands, scripts, HTTP downloads, git operations, health checks, template rendering, prompts, confirmations, and more.
+- **AI-ready context** — `raid context` emits an MCP-shaped snapshot of the workspace, and `raid context serve` runs raid as an MCP server so AI agents can read repo state and invoke commands directly.
 - **Portable** — config is just YAML in the repo. Works on macOS, Linux, and Windows.
 
 ---
@@ -163,6 +164,14 @@ Clones run concurrently. Use `-t` to cap the number of concurrent clone threads.
 - `raid env <name>` — apply a named environment: writes `.env` files into each repo and runs environment tasks
 - `raid env` — show the currently active environment
 - `raid env list` — list available environments
+
+### `raid context`
+
+Print a condensed snapshot of the active workspace — profile, environment, repos with live git state, custom commands, and recent command-run history.
+
+- `raid context` — human-readable summary
+- `raid context --json` — MCP-shaped JSON for AI agents
+- `raid context serve` — run raid as a [Model Context Protocol](https://modelcontextprotocol.io) server over stdio, exposing workspace state as resources and raid actions (`raid_install`, `raid_env_switch`, `raid_run_task`, …) as tools
 
 ### `raid doctor`
 
@@ -529,6 +538,14 @@ commands:
 ```
 ```bash
 raid deploy staging v1.2.3   # $RAID_ARG_1=staging, $RAID_ARG_2=v1.2.3
+```
+
+**Repo metadata** — every repository in the active profile is auto-exposed as `RAID_REPO_<NAME>_URL`, `RAID_REPO_<NAME>_PATH`, and `RAID_REPO_<NAME>_BRANCH`. The name is uppercased with non-alphanumerics replaced by `_` (so `my-api` becomes `RAID_REPO_MY_API_URL`).
+
+```yaml
+- type: Shell
+  cmd: gh pr create --repo $RAID_REPO_MY_API_URL --base $RAID_REPO_MY_API_BRANCH
+  path: $RAID_REPO_MY_API_PATH
 ```
 
 ---

--- a/site/docs/features/variables.mdx
+++ b/site/docs/features/variables.mdx
@@ -209,6 +209,30 @@ commands:
         message: "Deploying to $RAID_ARG_1 in $RAID_ARG_2"
 ```
 
+### Repo metadata
+
+Each repository in the active profile is exposed as three auto-populated variables: `RAID_REPO_<NAME>_URL`, `RAID_REPO_<NAME>_PATH`, and `RAID_REPO_<NAME>_BRANCH`. The name is uppercased and any non-alphanumeric characters become underscores (so `my-api` → `MY_API`). `PATH` is the expanded absolute path.
+
+```yaml
+# profile.raid.yml
+repositories:
+  - name: my-api
+    path: ~/dev/api
+    url: https://github.com/example/api.git
+    branch: main
+```
+
+```yaml
+commands:
+  - name: "open-api-pr"
+    tasks:
+      - type: Shell
+        cmd: "gh pr create --repo $RAID_REPO_MY_API_URL --base $RAID_REPO_MY_API_BRANCH"
+        path: "$RAID_REPO_MY_API_PATH"
+```
+
+These are seeded when the profile loads, so `Set` tasks with the same name override them for the rest of the command session.
+
 ## Case sensitivity
 
 Variable names set via `Set` tasks are resolved case-insensitively. `$MY_VAR`, `$my_var`, and `$My_Var` all resolve to the same value. Shell exports and OS environment variables follow the platform's native case rules (case-sensitive on macOS/Linux).

--- a/site/docs/whats-new.mdx
+++ b/site/docs/whats-new.mdx
@@ -15,6 +15,8 @@ User-visible changes per release, latest first. For full commit history see the 
 
 **Set variables reach subprocesses.** Variables defined by a `Set` task are now exported as environment variables to Script and Shell task subprocesses, so a script's source can reference `$VAR` directly without raid pre-expanding the script body. Raid values take precedence over OS-environment variables of the same name.
 
+**Repo metadata as variables.** Every repository in the active profile is now auto-exposed as `RAID_REPO_<NAME>_URL`, `RAID_REPO_<NAME>_PATH`, and `RAID_REPO_<NAME>_BRANCH`, so tasks can reference repo URLs, paths, and branches without hardcoding them. Names are uppercased with non-alphanumerics replaced by `_` (so `my-api` becomes `RAID_REPO_MY_API_URL`).
+
 **Cross-process mutation lock.** A `flock`-backed lock at `~/.raid/.lock` serializes mutating operations across any combination of CLI usage and MCP-driven tool calls — concurrent installs or env switches from two raid processes now wait for one another instead of racing on `~/.raid/config.toml` or repository state. Read paths are unaffected.
 
 ## 0.6.0 — upcoming

--- a/src/internal/lib/lib.go
+++ b/src/internal/lib/lib.go
@@ -238,15 +238,30 @@ func ForceLoad() error {
 // path. Repos with empty fields contribute empty values; URL/BRANCH entries
 // are still defined so unset references don't fall through to the OS env.
 // Profile values overwrite anything from the persisted vars file — the
-// profile is canonical.
+// profile is canonical, so any stale RAID_REPO_* keys (from a removed or
+// renamed repo persisted to ~/.raid/vars) are pruned first. Sanitized-name
+// collisions between repos (e.g. "my-api" and "my_api" both → MY_API) are
+// reported to stderr; the last repo wins so behavior is deterministic.
 func setRepoVars(repos []Repo) {
 	raidVarsMu.Lock()
 	defer raidVarsMu.Unlock()
+	for k := range raidVars {
+		if strings.HasPrefix(k, "RAID_REPO_") {
+			delete(raidVars, k)
+		}
+	}
+	seen := make(map[string]string, len(repos))
 	for _, repo := range repos {
 		key := sanitizeRepoVarName(repo.Name)
 		if key == "" {
 			continue
 		}
+		if prev, ok := seen[key]; ok && prev != repo.Name {
+			fmt.Fprintf(os.Stderr,
+				"raid: warning: repos %q and %q both map to RAID_REPO_%s_*; %q wins\n",
+				prev, repo.Name, key, repo.Name)
+		}
+		seen[key] = repo.Name
 		raidVars["RAID_REPO_"+key+"_URL"] = repo.URL
 		raidVars["RAID_REPO_"+key+"_PATH"] = sys.ExpandPath(repo.Path)
 		raidVars["RAID_REPO_"+key+"_BRANCH"] = repo.Branch

--- a/src/internal/lib/lib.go
+++ b/src/internal/lib/lib.go
@@ -223,11 +223,58 @@ func ForceLoad() error {
 		profile.Commands = mergeCommands(profile.Commands, repo.Commands)
 	}
 
+	setRepoVars(profile.Repositories)
+
 	context = &Context{
 		Profile: profile,
 		Env:     GetEnv(),
 	}
 	return nil
+}
+
+// setRepoVars seeds raidVars with RAID_REPO_<NAME>_{URL,PATH,BRANCH} entries
+// for every repo in the active profile, so tasks and subprocesses can
+// reference them as $RAID_REPO_API_URL, etc. PATH is the expanded absolute
+// path. Repos with empty fields contribute empty values; URL/BRANCH entries
+// are still defined so unset references don't fall through to the OS env.
+// Profile values overwrite anything from the persisted vars file — the
+// profile is canonical.
+func setRepoVars(repos []Repo) {
+	raidVarsMu.Lock()
+	defer raidVarsMu.Unlock()
+	for _, repo := range repos {
+		key := sanitizeRepoVarName(repo.Name)
+		if key == "" {
+			continue
+		}
+		raidVars["RAID_REPO_"+key+"_URL"] = repo.URL
+		raidVars["RAID_REPO_"+key+"_PATH"] = sys.ExpandPath(repo.Path)
+		raidVars["RAID_REPO_"+key+"_BRANCH"] = repo.Branch
+	}
+}
+
+// sanitizeRepoVarName converts a repo name into the uppercase identifier
+// fragment used in RAID_REPO_<NAME>_* var names. Non-alphanumerics become
+// underscores so names like "my-api" or "frontend.web" produce valid env
+// var keys. Returns "" if the name has no usable characters.
+func sanitizeRepoVarName(name string) string {
+	var b strings.Builder
+	b.Grow(len(name))
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r - ('a' - 'A'))
+		case (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+	out := b.String()
+	if strings.Trim(out, "_") == "" {
+		return ""
+	}
+	return out
 }
 
 // installRepo clones a single repository and runs its install tasks.

--- a/src/internal/lib/lib_test.go
+++ b/src/internal/lib/lib_test.go
@@ -977,3 +977,153 @@ func TestInstallRepo_installTaskError(t *testing.T) {
 		t.Errorf("error %q should mention install task failure", err.Error())
 	}
 }
+
+func TestSanitizeRepoVarName(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"api", "API"},
+		{"my-api", "MY_API"},
+		{"frontend.web", "FRONTEND_WEB"},
+		{"Foo Bar", "FOO_BAR"},
+		{"svc1", "SVC1"},
+		{"_leading", "_LEADING"},
+		{"", ""},
+		{"---", ""},
+	}
+	for _, c := range cases {
+		if got := sanitizeRepoVarName(c.in); got != c.want {
+			t.Errorf("sanitizeRepoVarName(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// withCleanRaidVars resets raidVars for the duration of the test so the
+// caller can assert on entries seeded during the test in isolation.
+func withCleanRaidVars(t *testing.T) {
+	t.Helper()
+	raidVarsMu.Lock()
+	prev := raidVars
+	raidVars = map[string]string{}
+	raidVarsMu.Unlock()
+	t.Cleanup(func() {
+		raidVarsMu.Lock()
+		raidVars = prev
+		raidVarsMu.Unlock()
+	})
+}
+
+func TestSetRepoVars_populatesAllFields(t *testing.T) {
+	withCleanRaidVars(t)
+
+	setRepoVars([]Repo{
+		{Name: "api", Path: "/tmp/api", URL: "https://github.com/example/api.git", Branch: "main"},
+		{Name: "my-web", Path: "/tmp/web", URL: "git@github.com:example/web.git", Branch: ""},
+	})
+
+	raidVarsMu.RLock()
+	defer raidVarsMu.RUnlock()
+	checks := map[string]string{
+		"RAID_REPO_API_URL":       "https://github.com/example/api.git",
+		"RAID_REPO_API_PATH":      "/tmp/api",
+		"RAID_REPO_API_BRANCH":    "main",
+		"RAID_REPO_MY_WEB_URL":    "git@github.com:example/web.git",
+		"RAID_REPO_MY_WEB_PATH":   "/tmp/web",
+		"RAID_REPO_MY_WEB_BRANCH": "",
+	}
+	for k, want := range checks {
+		got, ok := raidVars[k]
+		if !ok {
+			t.Errorf("raidVars missing %q", k)
+			continue
+		}
+		if got != want {
+			t.Errorf("raidVars[%q] = %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestSetRepoVars_skipsEmptyOrInvalidName(t *testing.T) {
+	withCleanRaidVars(t)
+
+	setRepoVars([]Repo{
+		{Name: "", Path: "/tmp/x", URL: "u"},
+		{Name: "---", Path: "/tmp/y", URL: "u"},
+	})
+
+	raidVarsMu.RLock()
+	defer raidVarsMu.RUnlock()
+	for k := range raidVars {
+		if strings.HasPrefix(k, "RAID_REPO_") {
+			t.Errorf("raidVars unexpectedly contains %q for empty/invalid repo name", k)
+		}
+	}
+}
+
+func TestSetRepoVars_overwritesPriorEntries(t *testing.T) {
+	// Profile values are canonical: a stale RAID_REPO_API_URL from the
+	// persisted vars file must be replaced when the profile is loaded.
+	withCleanRaidVars(t)
+	raidVarsMu.Lock()
+	raidVars["RAID_REPO_API_URL"] = "stale"
+	raidVarsMu.Unlock()
+
+	setRepoVars([]Repo{{Name: "api", Path: "/tmp/api", URL: "fresh"}})
+
+	raidVarsMu.RLock()
+	got := raidVars["RAID_REPO_API_URL"]
+	raidVarsMu.RUnlock()
+	if got != "fresh" {
+		t.Errorf("RAID_REPO_API_URL = %q after setRepoVars, want %q", got, "fresh")
+	}
+}
+
+func TestForceLoad_seedsRepoVars(t *testing.T) {
+	root := repoRoot(t)
+	setupTestConfig(t)
+
+	// Redirect the persisted vars file so the user's real ~/.raid/vars
+	// doesn't bleed into this test.
+	oldVarsPath := raidVarsOverridePath
+	t.Cleanup(func() { raidVarsOverridePath = oldVarsPath })
+	raidVarsOverridePath = filepath.Join(t.TempDir(), "vars")
+
+	dir := t.TempDir()
+	repoDir := filepath.Join(dir, "myrepo")
+	os.MkdirAll(filepath.Join(repoDir, ".git"), 0755)
+
+	profilePath := filepath.Join(dir, "profile.yaml")
+	content := "name: testprofile\nrepositories:\n  - name: my-api\n    path: " + repoDir + "\n    url: https://example.com/repo.git\n    branch: main\n"
+	if err := os.WriteFile(profilePath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	wd, _ := os.Getwd()
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(wd)
+
+	if err := AddProfile(Profile{Name: "testprofile", Path: profilePath}); err != nil {
+		t.Fatal(err)
+	}
+	if err := SetProfile("testprofile"); err != nil {
+		t.Fatal(err)
+	}
+	if err := ForceLoad(); err != nil {
+		t.Fatalf("ForceLoad: %v", err)
+	}
+
+	raidVarsMu.RLock()
+	defer raidVarsMu.RUnlock()
+	checks := map[string]string{
+		"RAID_REPO_MY_API_URL":    "https://example.com/repo.git",
+		"RAID_REPO_MY_API_PATH":   repoDir,
+		"RAID_REPO_MY_API_BRANCH": "main",
+	}
+	for k, want := range checks {
+		if got := raidVars[k]; got != want {
+			t.Errorf("raidVars[%q] after ForceLoad = %q, want %q", k, got, want)
+		}
+	}
+}

--- a/src/internal/lib/lib_test.go
+++ b/src/internal/lib/lib_test.go
@@ -1060,6 +1060,70 @@ func TestSetRepoVars_skipsEmptyOrInvalidName(t *testing.T) {
 	}
 }
 
+func TestSetRepoVars_prunesStaleRepoEntries(t *testing.T) {
+	// Stale RAID_REPO_* keys (loaded from the persisted vars file or left
+	// over from a renamed/removed repo) must be pruned so they don't leak
+	// into tasks after the profile changes. Non-RAID_REPO entries stay.
+	withCleanRaidVars(t)
+	raidVarsMu.Lock()
+	raidVars["RAID_REPO_OLD_URL"] = "stale"
+	raidVars["RAID_REPO_OLD_PATH"] = "/old"
+	raidVars["RAID_REPO_OLD_BRANCH"] = "old-branch"
+	raidVars["MY_USER_VAR"] = "keep"
+	raidVarsMu.Unlock()
+
+	setRepoVars([]Repo{{Name: "api", Path: "/tmp/api", URL: "u"}})
+
+	raidVarsMu.RLock()
+	defer raidVarsMu.RUnlock()
+	for _, k := range []string{"RAID_REPO_OLD_URL", "RAID_REPO_OLD_PATH", "RAID_REPO_OLD_BRANCH"} {
+		if _, ok := raidVars[k]; ok {
+			t.Errorf("stale %q not pruned by setRepoVars", k)
+		}
+	}
+	if got, ok := raidVars["MY_USER_VAR"]; !ok || got != "keep" {
+		t.Errorf("non-RAID_REPO_ entry MY_USER_VAR = %q (ok=%v), want kept", got, ok)
+	}
+	if _, ok := raidVars["RAID_REPO_API_URL"]; !ok {
+		t.Error("new RAID_REPO_API_URL missing after prune+seed")
+	}
+}
+
+func TestSetRepoVars_warnsOnSanitizedNameCollision(t *testing.T) {
+	withCleanRaidVars(t)
+
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = origStderr })
+
+	setRepoVars([]Repo{
+		{Name: "my-api", Path: "/a", URL: "first"},
+		{Name: "my_api", Path: "/b", URL: "second"},
+	})
+	w.Close()
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	out := string(buf[:n])
+	for _, want := range []string{"my-api", "my_api", "MY_API"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("collision warning %q missing %q", out, want)
+		}
+	}
+
+	// Last repo in the list wins so behavior is deterministic.
+	raidVarsMu.RLock()
+	got := raidVars["RAID_REPO_MY_API_URL"]
+	raidVarsMu.RUnlock()
+	if got != "second" {
+		t.Errorf("RAID_REPO_MY_API_URL = %q, want last-wins value %q", got, "second")
+	}
+}
+
 func TestSetRepoVars_overwritesPriorEntries(t *testing.T) {
 	// Profile values are canonical: a stale RAID_REPO_API_URL from the
 	// persisted vars file must be replaced when the profile is loaded.

--- a/src/resources/app.properties
+++ b/src/resources/app.properties
@@ -1,2 +1,2 @@
-version=0.7.1-beta
+version=0.7.2-beta
 environment=development


### PR DESCRIPTION
This pull request introduces a new feature that automatically exposes metadata about each repository in the active profile as environment variables, making it easier to reference repo URLs, paths, and branches in tasks and scripts. The implementation includes robust test coverage and updates to documentation and release notes.

The most important changes are:

**New Feature: Automatic Repo Metadata Variables**
* Every repository in the active profile is now auto-exposed as `RAID_REPO_<NAME>_URL`, `RAID_REPO_<NAME>_PATH`, and `RAID_REPO_<NAME>_BRANCH` variables. The repo name is uppercased and non-alphanumerics are replaced with underscores (e.g., `my-api` → `RAID_REPO_MY_API_URL`). These variables are available to all tasks and subprocesses, and profile values always take precedence. (`src/internal/lib/lib.go`, `src/internal/lib/lib_test.go`, `README.md`, `site/docs/features/variables.mdx`, `site/docs/whats-new.mdx`) [[1]](diffhunk://#diff-c7d99b5a8cccee220ac156e6bfbfd3b058f22a87ce4fbfe64723769a49ca3776R226-R279) [[2]](diffhunk://#diff-495d5cde9b2a40e311dc5daadf1c12365b3fd51cf60a98c6ff6512c34caf37a4R980-R1129) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R543-R550) [[4]](diffhunk://#diff-5a6dcd8353bb736ed990e8a59911c7ad51711a0226878f0f9d6d8ec3e566fe8fR212-R235) [[5]](diffhunk://#diff-1bd8d9a03e07abf9afca5851d7d66b451dc7ab6750fc61e3267fc20b31640256R18-R19)

**Implementation and Test Coverage**
* Added the `setRepoVars` function to seed the new variables, and `sanitizeRepoVarName` to ensure variable names are valid. Comprehensive unit tests ensure correct variable population, handling of edge cases, and precedence over previously set values. (`src/internal/lib/lib.go`, `src/internal/lib/lib_test.go`) [[1]](diffhunk://#diff-c7d99b5a8cccee220ac156e6bfbfd3b058f22a87ce4fbfe64723769a49ca3776R226-R279) [[2]](diffhunk://#diff-495d5cde9b2a40e311dc5daadf1c12365b3fd51cf60a98c6ff6512c34caf37a4R980-R1129)

**Documentation Updates**
* Updated the feature documentation and examples to describe and demonstrate the new repo metadata variables. (`README.md`, `site/docs/features/variables.mdx`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R543-R550) [[2]](diffhunk://#diff-5a6dcd8353bb736ed990e8a59911c7ad51711a0226878f0f9d6d8ec3e566fe8fR212-R235)
* Added a release note about the new feature in the "What's New" section. (`site/docs/whats-new.mdx`)
* Updated the contribution checklist to require updating the "What's New" doc for user-visible changes. (`CLAUDE.md`)

**Other Minor Enhancements**
* Added documentation for the new `raid context` command, which provides workspace state for AI agents. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R60) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R168-R175)

Closes #43 