### PR TITLE
Add JSON output support for commands and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ Print a condensed snapshot of the active workspace — profile, environment, rep
 
 Check the current configuration for issues and get suggestions for fixing them. Useful after initial setup or when something isn't working as expected.
 
+### JSON output for read commands
+
+Read commands accept `--json` for scriptable, machine-readable output: `raid profile list`, `raid env`, `raid env list`, `raid doctor`, and `raid context`. Output shapes are stable; severity strings in `doctor` are one of `ok`, `warn`, `error`.
+
 ### `raid <command>`
 
 Run a custom command defined in the active profile or any of its repositories.

--- a/site/docs/usage/doctor.mdx
+++ b/site/docs/usage/doctor.mdx
@@ -42,3 +42,23 @@ raid doctor
 ```
 
 If everything is configured correctly you'll see all `OK` entries. Any `ERROR` entries need to be resolved before the affected features will work.
+
+## JSON output
+
+Pass `--json` to get a structured report — useful in CI checks or agent workflows. The exit code is unchanged: `1` when any finding has severity `error`, `0` otherwise.
+
+```bash
+raid doctor --json
+```
+
+```json
+{
+  "findings": [
+    { "severity": "ok", "check": "git", "message": "installed" },
+    { "severity": "warn", "check": "repo/api", "message": "not cloned at ~/dev/api", "suggestion": "Run `raid install api`" }
+  ],
+  "summary": { "ok": 1, "warnings": 1, "errors": 0 }
+}
+```
+
+Severity is one of `ok`, `warn`, or `error`. The `suggestion` field is omitted when empty.

--- a/site/docs/usage/env.mdx
+++ b/site/docs/usage/env.mdx
@@ -47,6 +47,26 @@ When you run `raid env <name>`, raid:
 
 This happens across all repositories at once. Switching contexts — local to staging, staging to production — is a single command.
 
+## JSON output
+
+`raid env` (no args) and `raid env list` both accept `--json` for scriptable output.
+
+`raid env --json` returns a single entry with the same `{name, active}` shape used by `raid env list --json`. When no environment is loaded, `name` is empty and `active` is `false`.
+
+```bash
+raid env --json
+# { "name": "staging", "active": true }
+
+raid env list --json
+# [
+#   { "name": "local",   "active": false },
+#   { "name": "staging", "active": true  },
+#   { "name": "prod",    "active": false }
+# ]
+```
+
+`raid env <name>` (the mutating form) does not accept `--json` — apply mode is interactive by design.
+
 ## Defining environments
 
 Environments are defined in your profile and in individual repository `raid.yaml` files. See [Environments](/docs/features/environments) for the full format.

--- a/site/docs/usage/profile.mdx
+++ b/site/docs/usage/profile.mdx
@@ -58,6 +58,21 @@ Remove a profile:
 raid profile remove my-team
 ```
 
+## JSON output
+
+`raid profile list` accepts `--json` for scriptable, machine-readable output. The result is an array of objects with `name`, `path`, and a boolean `active` flag for the currently selected profile.
+
+```bash
+raid profile list --json
+```
+
+```json
+[
+  { "name": "team", "path": "/Users/me/team.raid.yaml", "active": true },
+  { "name": "personal", "path": "/Users/me/personal.raid.yaml", "active": false }
+]
+```
+
 ## Profile files
 
 A profile is a YAML file describing repositories, environments, install tasks, and custom commands. See [Profile Configuration](/docs/features/profiles) for the full format.

--- a/site/docs/whats-new.mdx
+++ b/site/docs/whats-new.mdx
@@ -17,6 +17,8 @@ User-visible changes per release, latest first. For full commit history see the 
 
 **Repo metadata as variables.** Every repository in the active profile is now auto-exposed as `RAID_REPO_<NAME>_URL`, `RAID_REPO_<NAME>_PATH`, and `RAID_REPO_<NAME>_BRANCH`, so tasks can reference repo URLs, paths, and branches without hardcoding them. Names are uppercased with non-alphanumerics replaced by `_` (so `my-api` becomes `RAID_REPO_MY_API_URL`).
 
+**`--json` on read commands.** `raid profile list`, `raid env`, `raid env list`, and `raid doctor` accept `--json` for scriptable, machine-readable output. `raid context --json` already shipped in 0.6.0; this rounds out per-command JSON for shell pipelines and CI checks. Output shapes are stable; doctor severities are encoded as `ok`/`warn`/`error` strings.
+
 **Cross-process mutation lock.** A `flock`-backed lock at `~/.raid/.lock` serializes mutating operations across any combination of CLI usage and MCP-driven tool calls — concurrent installs or env switches from two raid processes now wait for one another instead of racing on `~/.raid/config.toml` or repository state. Read paths are unaffected.
 
 ## 0.6.0 — upcoming

--- a/src/cmd/doctor/doctor.go
+++ b/src/cmd/doctor/doctor.go
@@ -1,12 +1,19 @@
 package doctor
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 
 	"github.com/8bitalex/raid/src/raid"
 	"github.com/spf13/cobra"
 )
+
+var jsonOutput bool
+
+func init() {
+	Command.Flags().BoolVar(&jsonOutput, "json", false, "Emit machine-readable JSON output")
+}
 
 // Command is the doctor subcommand that checks the raid configuration for issues.
 var Command = &cobra.Command{
@@ -16,22 +23,87 @@ var Command = &cobra.Command{
 	Run:   runDoctor,
 }
 
-func runDoctor(_ *cobra.Command, _ []string) {
+// findingJSON is the stable JSON shape for a single doctor finding. Severity
+// is encoded as a string ("ok" | "warn" | "error") so the JSON output is
+// self-describing without consulting documentation.
+type findingJSON struct {
+	Severity   string `json:"severity"`
+	Check      string `json:"check"`
+	Message    string `json:"message"`
+	Suggestion string `json:"suggestion,omitempty"`
+}
+
+type doctorSummary struct {
+	OK       int `json:"ok"`
+	Warnings int `json:"warnings"`
+	Errors   int `json:"errors"`
+}
+
+type doctorOutput struct {
+	Findings []findingJSON `json:"findings"`
+	Summary  doctorSummary `json:"summary"`
+}
+
+func severityString(s raid.Severity) string {
+	switch s {
+	case raid.SeverityOK:
+		return "ok"
+	case raid.SeverityWarn:
+		return "warn"
+	case raid.SeverityError:
+		return "error"
+	default:
+		return "unknown"
+	}
+}
+
+func runDoctor(cmd *cobra.Command, _ []string) {
 	findings := raid.Doctor()
 
-	warnings, errors := 0, 0
+	oks, warnings, errors := 0, 0, 0
+	for _, f := range findings {
+		switch f.Severity {
+		case raid.SeverityOK:
+			oks++
+		case raid.SeverityWarn:
+			warnings++
+		case raid.SeverityError:
+			errors++
+		}
+	}
+
+	if jsonOutput {
+		out := doctorOutput{
+			Findings: make([]findingJSON, 0, len(findings)),
+			Summary:  doctorSummary{OK: oks, Warnings: warnings, Errors: errors},
+		}
+		for _, f := range findings {
+			out.Findings = append(out.Findings, findingJSON{
+				Severity:   severityString(f.Severity),
+				Check:      f.Check,
+				Message:    f.Message,
+				Suggestion: f.Suggestion,
+			})
+		}
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(out)
+		if errors > 0 {
+			os.Exit(1)
+		}
+		return
+	}
+
 	for _, f := range findings {
 		switch f.Severity {
 		case raid.SeverityOK:
 			fmt.Printf("  [ok]    %s: %s\n", f.Check, f.Message)
 		case raid.SeverityWarn:
-			warnings++
 			fmt.Printf("  [warn]  %s: %s\n", f.Check, f.Message)
 			if f.Suggestion != "" {
 				fmt.Printf("          → %s\n", f.Suggestion)
 			}
 		case raid.SeverityError:
-			errors++
 			fmt.Printf("  [error] %s: %s\n", f.Check, f.Message)
 			if f.Suggestion != "" {
 				fmt.Printf("          → %s\n", f.Suggestion)

--- a/src/cmd/doctor/doctor.go
+++ b/src/cmd/doctor/doctor.go
@@ -87,7 +87,10 @@ func runDoctor(cmd *cobra.Command, _ []string) {
 		}
 		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")
-		_ = enc.Encode(out)
+		if err := enc.Encode(out); err != nil {
+			fmt.Fprintln(os.Stderr, "raid:", err)
+			os.Exit(1)
+		}
 		if errors > 0 {
 			os.Exit(1)
 		}

--- a/src/cmd/doctor/doctor_test.go
+++ b/src/cmd/doctor/doctor_test.go
@@ -2,6 +2,7 @@ package doctor
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -203,6 +204,141 @@ func TestRunDoctor_warningsOnly(t *testing.T) {
 	// Should show the suggestion arrow
 	if !strings.Contains(got, "→") {
 		t.Errorf("runDoctor warnings: expected suggestion arrow '→' in output, got %q", got)
+	}
+}
+
+// TestRunDoctor_jsonAllOK exercises --json output on a clean profile so no
+// os.Exit fires; asserts the encoded shape matches the documented contract.
+func TestRunDoctor_jsonAllOK(t *testing.T) {
+	dir := t.TempDir()
+	old := lib.CfgPath
+	t.Cleanup(func() {
+		lib.CfgPath = old
+		lib.ResetContext()
+		viper.Reset()
+		jsonOutput = false
+	})
+	lib.CfgPath = filepath.Join(dir, "config.toml")
+	lib.ResetContext()
+	if err := lib.InitConfig(); err != nil {
+		t.Fatalf("InitConfig: %v", err)
+	}
+
+	repoDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repoDir, ".git"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	profilePath := filepath.Join(dir, "ok.raid.yaml")
+	content := fmt.Sprintf("name: ok\nrepositories:\n  - name: repo1\n    url: https://example.com/repo.git\n    path: %s\n", repoDir)
+	if err := os.WriteFile(profilePath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := lib.AddProfile(lib.Profile{Name: "ok", Path: profilePath}); err != nil {
+		t.Fatal(err)
+	}
+	if err := lib.SetProfile("ok"); err != nil {
+		t.Fatal(err)
+	}
+	if err := lib.ForceLoad(); err != nil {
+		t.Fatalf("ForceLoad: %v", err)
+	}
+
+	jsonOutput = true
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buf)
+	runDoctor(cmd, nil)
+
+	var got doctorOutput
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("json.Unmarshal(%q): %v", buf.String(), err)
+	}
+	if len(got.Findings) == 0 {
+		t.Fatal("expected at least one finding")
+	}
+	if got.Summary.Errors != 0 {
+		t.Errorf("Summary.Errors = %d, want 0", got.Summary.Errors)
+	}
+	if got.Summary.OK == 0 {
+		t.Errorf("Summary.OK = 0, want >0")
+	}
+	for _, f := range got.Findings {
+		switch f.Severity {
+		case "ok", "warn", "error":
+		default:
+			t.Errorf("finding %+v has unexpected severity string %q", f, f.Severity)
+		}
+	}
+}
+
+// TestRunDoctor_jsonWarningSurfacesSuggestion ensures warning findings carry
+// their suggestion field through to the JSON encoding.
+func TestRunDoctor_jsonWarningSurfacesSuggestion(t *testing.T) {
+	dir := t.TempDir()
+	old := lib.CfgPath
+	t.Cleanup(func() {
+		lib.CfgPath = old
+		lib.ResetContext()
+		viper.Reset()
+		jsonOutput = false
+	})
+	lib.CfgPath = filepath.Join(dir, "config.toml")
+	lib.ResetContext()
+	if err := lib.InitConfig(); err != nil {
+		t.Fatalf("InitConfig: %v", err)
+	}
+
+	profilePath := filepath.Join(dir, "warn.raid.yaml")
+	content := "name: warn\nrepositories:\n  - name: missing-repo\n    url: https://example.com/repo.git\n    path: /tmp/nonexistent-path-raid-test-67890\n"
+	if err := os.WriteFile(profilePath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := lib.AddProfile(lib.Profile{Name: "warn", Path: profilePath}); err != nil {
+		t.Fatal(err)
+	}
+	if err := lib.SetProfile("warn"); err != nil {
+		t.Fatal(err)
+	}
+	if err := lib.ForceLoad(); err != nil {
+		t.Fatalf("ForceLoad: %v", err)
+	}
+
+	jsonOutput = true
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buf)
+	runDoctor(cmd, nil)
+
+	var got doctorOutput
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("json.Unmarshal(%q): %v", buf.String(), err)
+	}
+	if got.Summary.Warnings == 0 {
+		t.Fatalf("Summary.Warnings = 0, want >0; output: %q", buf.String())
+	}
+	hasSuggestion := false
+	for _, f := range got.Findings {
+		if f.Severity == "warn" && f.Suggestion != "" {
+			hasSuggestion = true
+			break
+		}
+	}
+	if !hasSuggestion {
+		t.Errorf("expected at least one warn finding with non-empty suggestion; got %+v", got.Findings)
+	}
+}
+
+func TestSeverityString(t *testing.T) {
+	cases := map[lib.Severity]string{
+		lib.SeverityOK:    "ok",
+		lib.SeverityWarn:  "warn",
+		lib.SeverityError: "error",
+		lib.Severity(99):  "unknown",
+	}
+	for in, want := range cases {
+		if got := severityString(in); got != want {
+			t.Errorf("severityString(%v) = %q, want %q", in, got, want)
+		}
 	}
 }
 

--- a/src/cmd/doctor/doctor_test.go
+++ b/src/cmd/doctor/doctor_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 const subprocEnv = "RAID_TEST_DOCTOR_SUBPROCESS"
+const subprocJSONEnv = "RAID_TEST_DOCTOR_JSON_SUBPROCESS"
 
 func setupConfig(t *testing.T) {
 	t.Helper()
@@ -63,6 +64,75 @@ func TestRunDoctor_subprocess(t *testing.T) {
 	}
 	if exitErr.ExitCode() != 1 {
 		t.Errorf("runDoctor exit code = %d, want 1", exitErr.ExitCode())
+	}
+}
+
+const subprocEncodeErrEnv = "RAID_TEST_DOCTOR_ENCODE_ERR"
+
+// failingWriter implements io.Writer and always returns an error, used to
+// force enc.Encode to fail and exercise the broken-pipe branch.
+type failingWriter struct{}
+
+func (failingWriter) Write(p []byte) (int, error) { return 0, fmt.Errorf("simulated write failure") }
+
+// TestRunDoctor_jsonEncodeError exercises the os.Exit(1) branch when the
+// JSON encoder fails to write (e.g. broken pipe). Runs in a subprocess so
+// os.Exit doesn't terminate the test runner.
+func TestRunDoctor_jsonEncodeError(t *testing.T) {
+	if os.Getenv(subprocEncodeErrEnv) == "1" {
+		setupConfig(t)
+		jsonOutput = true
+		cmd := &cobra.Command{}
+		cmd.SetOut(failingWriter{})
+		cmd.SetErr(os.Stderr)
+		runDoctor(cmd, nil)
+		return
+	}
+
+	proc := exec.Command(os.Args[0], "-test.run=TestRunDoctor_jsonEncodeError", "-test.v")
+	proc.Env = append(os.Environ(), subprocEncodeErrEnv+"=1")
+	out, err := proc.CombinedOutput()
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("expected *exec.ExitError, got: %T %v\noutput: %s", err, err, out)
+	}
+	if exitErr.ExitCode() != 1 {
+		t.Errorf("runDoctor encode-error exit code = %d, want 1", exitErr.ExitCode())
+	}
+	if !strings.Contains(string(out), "simulated write failure") {
+		t.Errorf("subprocess stderr missing simulated failure message; got: %s", out)
+	}
+}
+
+// TestRunDoctor_jsonSubprocess exercises the os.Exit(1) branch in --json mode
+// when error findings are present. Runs in a subprocess so os.Exit doesn't
+// terminate the test runner.
+func TestRunDoctor_jsonSubprocess(t *testing.T) {
+	if os.Getenv(subprocJSONEnv) == "1" {
+		setupConfig(t)
+		jsonOutput = true
+		cmd := &cobra.Command{}
+		cmd.SetOut(os.Stdout)
+		cmd.SetErr(os.Stderr)
+		runDoctor(cmd, nil)
+		return
+	}
+
+	proc := exec.Command(os.Args[0], "-test.run=TestRunDoctor_jsonSubprocess", "-test.v")
+	proc.Env = append(os.Environ(), subprocJSONEnv+"=1")
+	out, err := proc.CombinedOutput()
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("expected *exec.ExitError, got: %T %v\noutput: %s", err, err, out)
+	}
+	if exitErr.ExitCode() != 1 {
+		t.Errorf("runDoctor --json exit code = %d, want 1", exitErr.ExitCode())
+	}
+	// Subprocess output is test runner noise + the JSON object; just confirm
+	// we got the JSON shape with a non-zero error count (proving the JSON
+	// branch was taken before os.Exit).
+	if !strings.Contains(string(out), "\"errors\"") {
+		t.Errorf("subprocess output missing JSON 'errors' field; got: %s", out)
 	}
 }
 

--- a/src/cmd/env/env.go
+++ b/src/cmd/env/env.go
@@ -2,6 +2,7 @@ package env
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/8bitalex/raid/src/raid"
 	"github.com/8bitalex/raid/src/raid/env"
@@ -20,27 +21,29 @@ var Command = &cobra.Command{
 	Short: "Execute an environment",
 	Long:  "Execute an environment by name. The environment will be searched for in the active profile and all repository configurations. Tasks are executed concurrently and environment variables are set globally.",
 	Args:  cobra.RangeArgs(0, 1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if showJSON && len(args) > 0 {
+			return fmt.Errorf("--json is only valid without an environment argument")
+		}
 		if len(args) == 0 {
 			active := env.Get()
 			if showJSON {
 				enc := json.NewEncoder(cmd.OutOrStdout())
 				enc.SetIndent("", "  ")
-				_ = enc.Encode(envEntry{Name: active, Active: active != ""})
-				return
+				return enc.Encode(envEntry{Name: active, Active: active != ""})
 			}
 			if active == "" {
 				cmd.PrintErrln("No active environment set.")
 			} else {
 				cmd.Println("Active environment:", active)
 			}
-			return
+			return nil
 		}
 
 		name := args[0]
 		if !env.Contains(name) {
 			cmd.PrintErrln("Environment not found:", name)
-			return
+			return nil
 		}
 
 		cmd.Println("Setting up environment:", name)
@@ -60,8 +63,9 @@ var Command = &cobra.Command{
 			return nil
 		})
 		if err != nil {
-			return
+			return nil
 		}
 		cmd.Println("Environment executed successfully.")
+		return nil
 	},
 }

--- a/src/cmd/env/env.go
+++ b/src/cmd/env/env.go
@@ -1,13 +1,18 @@
 package env
 
 import (
+	"encoding/json"
+
 	"github.com/8bitalex/raid/src/raid"
 	"github.com/8bitalex/raid/src/raid/env"
 	"github.com/spf13/cobra"
 )
 
+var showJSON bool
+
 func init() {
 	Command.AddCommand(ListEnvCmd)
+	Command.Flags().BoolVar(&showJSON, "json", false, "Emit machine-readable JSON output (only valid without an environment argument)")
 }
 
 var Command = &cobra.Command{
@@ -18,6 +23,12 @@ var Command = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			active := env.Get()
+			if showJSON {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				_ = enc.Encode(envEntry{Name: active, Active: active != ""})
+				return
+			}
 			if active == "" {
 				cmd.PrintErrln("No active environment set.")
 			} else {

--- a/src/cmd/env/env_test.go
+++ b/src/cmd/env/env_test.go
@@ -2,6 +2,7 @@ package env
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -88,6 +89,70 @@ func TestCommand_noArgs_noActiveEnv(t *testing.T) {
 	got := buf.String()
 	if !strings.Contains(got, "No active environment set") {
 		t.Errorf("Command with no args: got %q, want 'No active environment set.'", got)
+	}
+}
+
+func TestCommand_noArgs_jsonNoActive(t *testing.T) {
+	setupConfig(t)
+	t.Cleanup(func() { showJSON = false })
+
+	var buf bytes.Buffer
+	root := &cobra.Command{Use: "raid"}
+	root.AddCommand(Command)
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"env", "--json"})
+	_ = root.Execute()
+
+	var got envEntry
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("json.Unmarshal(%q): %v", buf.String(), err)
+	}
+	if got.Name != "" || got.Active {
+		t.Errorf("got = %+v, want zero envEntry when no env set", got)
+	}
+}
+
+func TestCommand_noArgs_jsonWithActive(t *testing.T) {
+	setupConfig(t)
+	t.Cleanup(func() { showJSON = false })
+	viper.Set("env", "staging")
+
+	var buf bytes.Buffer
+	root := &cobra.Command{Use: "raid"}
+	root.AddCommand(Command)
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"env", "--json"})
+	_ = root.Execute()
+
+	var got envEntry
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("json.Unmarshal(%q): %v", buf.String(), err)
+	}
+	if got.Name != "staging" || !got.Active {
+		t.Errorf("got = %+v, want {Name:staging Active:true}", got)
+	}
+}
+
+func TestListEnvCmd_jsonEmpty(t *testing.T) {
+	setupConfig(t)
+	t.Cleanup(func() { listJSON = false })
+
+	var buf bytes.Buffer
+	root := &cobra.Command{Use: "raid"}
+	root.AddCommand(ListEnvCmd)
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"list", "--json"})
+	_ = root.Execute()
+
+	var got []envEntry
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("json.Unmarshal(%q): %v", buf.String(), err)
+	}
+	if len(got) != 0 {
+		t.Errorf("len(got) = %d, want 0", len(got))
 	}
 }
 

--- a/src/cmd/env/env_test.go
+++ b/src/cmd/env/env_test.go
@@ -156,6 +156,25 @@ func TestListEnvCmd_jsonEmpty(t *testing.T) {
 	}
 }
 
+func TestCommand_jsonWithArgument_isError(t *testing.T) {
+	setupConfig(t)
+	t.Cleanup(func() { showJSON = false })
+
+	var buf bytes.Buffer
+	root := &cobra.Command{Use: "raid"}
+	root.SilenceErrors = true
+	root.SilenceUsage = true
+	root.AddCommand(Command)
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"env", "anything", "--json"})
+	if err := root.Execute(); err == nil {
+		t.Fatal("expected error when --json is combined with an argument, got nil")
+	} else if !strings.Contains(err.Error(), "--json") {
+		t.Errorf("error %q should mention --json", err.Error())
+	}
+}
+
 func TestCommand_envNotFound(t *testing.T) {
 	setupConfig(t)
 
@@ -183,7 +202,7 @@ func TestCommand_noArgs_withActiveEnv(t *testing.T) {
 	fakeCmd := &cobra.Command{}
 	fakeCmd.SetOut(&buf)
 	fakeCmd.SetErr(&buf)
-	Command.Run(fakeCmd, []string{})
+	_ = Command.RunE(fakeCmd, []string{})
 
 	got := buf.String()
 	if !strings.Contains(got, "Active environment") {
@@ -303,6 +322,39 @@ func TestListEnvCmd_withEnvironments(t *testing.T) {
 	}
 }
 
+func TestListEnvCmd_jsonWithEnvironments(t *testing.T) {
+	setupConfigWithEnv(t, "list-json-profile", "staging")
+	t.Cleanup(func() { listJSON = false })
+
+	var buf bytes.Buffer
+	root := &cobra.Command{Use: "raid"}
+	root.AddCommand(ListEnvCmd)
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"list", "--json"})
+	_ = root.Execute()
+
+	var got []envEntry
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("json.Unmarshal(%q): %v", buf.String(), err)
+	}
+	if len(got) == 0 {
+		t.Fatalf("got 0 entries, want >=1; output=%q", buf.String())
+	}
+	found := false
+	for _, e := range got {
+		if e.Name == "staging" {
+			found = true
+			if e.Active {
+				t.Errorf("staging entry Active = true, want false (env not loaded)")
+			}
+		}
+	}
+	if !found {
+		t.Errorf("staging missing from %+v", got)
+	}
+}
+
 func TestCommand_envFound_fullSuccess(t *testing.T) {
 	setupConfigWithEnv(t, "success-profile", "prod")
 
@@ -310,7 +362,7 @@ func TestCommand_envFound_fullSuccess(t *testing.T) {
 	fakeCmd := &cobra.Command{}
 	fakeCmd.SetOut(&buf)
 	fakeCmd.SetErr(&buf)
-	Command.Run(fakeCmd, []string{"prod"})
+	_ = Command.RunE(fakeCmd, []string{"prod"})
 
 	got := buf.String()
 	if !strings.Contains(got, "Environment executed successfully") {
@@ -332,7 +384,7 @@ func TestCommand_envFound_forceLoadError(t *testing.T) {
 	fakeCmd := &cobra.Command{}
 	fakeCmd.SetOut(&buf)
 	fakeCmd.SetErr(&buf)
-	Command.Run(fakeCmd, []string{"failing"})
+	_ = Command.RunE(fakeCmd, []string{"failing"})
 
 	got := buf.String()
 	if !strings.Contains(got, "Failed to reload profile") {
@@ -393,7 +445,7 @@ func TestCommand_envFound_executeError(t *testing.T) {
 	fakeCmd := &cobra.Command{}
 	fakeCmd.SetOut(&buf)
 	fakeCmd.SetErr(&buf)
-	Command.Run(fakeCmd, []string{"badenv"})
+	_ = Command.RunE(fakeCmd, []string{"badenv"})
 
 	got := buf.String()
 	if !strings.Contains(got, "Failed to execute environment") {
@@ -422,7 +474,7 @@ func TestCommand_envSetError(t *testing.T) {
 	fakeCmd := &cobra.Command{}
 	fakeCmd.SetOut(&buf)
 	fakeCmd.SetErr(&buf)
-	Command.Run(fakeCmd, []string{"dev"})
+	_ = Command.RunE(fakeCmd, []string{"dev"})
 
 	got := buf.String()
 	if !strings.Contains(got, "Failed to switch environment") {

--- a/src/cmd/env/list.go
+++ b/src/cmd/env/list.go
@@ -1,24 +1,50 @@
 package env
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/8bitalex/raid/src/raid/env"
 	"github.com/spf13/cobra"
 )
 
+var listJSON bool
+
+func init() {
+	ListEnvCmd.Flags().BoolVar(&listJSON, "json", false, "Emit machine-readable JSON output")
+}
+
+// envEntry is the stable JSON shape for a single environment in `env list --json`.
+type envEntry struct {
+	Name   string `json:"name"`
+	Active bool   `json:"active"`
+}
+
 var ListEnvCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List environments",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		envs := env.ListAll()
+		active := env.Get()
+
+		if listJSON {
+			out := make([]envEntry, 0, len(envs))
+			for _, name := range envs {
+				out = append(out, envEntry{Name: name, Active: name == active})
+			}
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode(out)
+		}
+
 		if len(envs) == 0 {
-			fmt.Println("No environments found.")
-			return
+			fmt.Fprintln(cmd.OutOrStdout(), "No environments found.")
+			return nil
 		}
-		fmt.Println("Available environments:")
-		for _, env := range envs {
-			fmt.Printf("\t%s\n", env)
+		fmt.Fprintln(cmd.OutOrStdout(), "Available environments:")
+		for _, name := range envs {
+			fmt.Fprintf(cmd.OutOrStdout(), "\t%s\n", name)
 		}
+		return nil
 	},
 }

--- a/src/cmd/profile/list.go
+++ b/src/cmd/profile/list.go
@@ -1,31 +1,61 @@
 package profile
 
 import (
+	"encoding/json"
 	"fmt"
 
 	pro "github.com/8bitalex/raid/src/raid/profile"
 	"github.com/spf13/cobra"
 )
 
+var listJSON bool
+
+func init() {
+	ListProfileCmd.Flags().BoolVar(&listJSON, "json", false, "Emit machine-readable JSON output")
+}
+
+// profileEntry is the stable JSON shape for a single profile in `--json` mode.
+// Field names and types are part of the public CLI contract.
+type profileEntry struct {
+	Name   string `json:"name"`
+	Path   string `json:"path"`
+	Active bool   `json:"active"`
+}
+
 var ListProfileCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List profiles",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		profiles := pro.ListAll()
 		activeProfile := pro.Get()
 
-		if len(profiles) == 0 {
-			fmt.Println("No profiles found.")
-			return
+		if listJSON {
+			out := make([]profileEntry, 0, len(profiles))
+			for _, p := range profiles {
+				out = append(out, profileEntry{
+					Name:   p.Name,
+					Path:   p.Path,
+					Active: p.Name == activeProfile.Name,
+				})
+			}
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode(out)
 		}
 
-		fmt.Println("Available profiles:")
+		if len(profiles) == 0 {
+			fmt.Fprintln(cmd.OutOrStdout(), "No profiles found.")
+			return nil
+		}
+
+		fmt.Fprintln(cmd.OutOrStdout(), "Available profiles:")
 		for _, profile := range profiles {
 			activeIndicator := ""
 			if profile.Name == activeProfile.Name {
 				activeIndicator = " (active)"
 			}
-			fmt.Printf("\t%s%s\t%s\n", profile.Name, activeIndicator, profile.Path)
+			fmt.Fprintf(cmd.OutOrStdout(), "\t%s%s\t%s\n", profile.Name, activeIndicator, profile.Path)
 		}
+		return nil
 	},
 }

--- a/src/cmd/profile/profile_test.go
+++ b/src/cmd/profile/profile_test.go
@@ -3,6 +3,7 @@ package profile
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -131,6 +132,61 @@ func TestListProfileCmd_withProfiles(t *testing.T) {
 	})
 	if !strings.Contains(out, "listed") {
 		t.Errorf("ListProfileCmd with profiles: got %q, want 'listed'", out)
+	}
+}
+
+func TestListProfileCmd_jsonEmpty(t *testing.T) {
+	setupConfig(t)
+	t.Cleanup(func() { listJSON = false })
+	out := captureStdout(t, func() {
+		root := &cobra.Command{Use: "raid"}
+		root.AddCommand(ListProfileCmd)
+		root.SetArgs([]string{"list", "--json"})
+		_ = root.Execute()
+	})
+	var got []profileEntry
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("json.Unmarshal(%q): %v", out, err)
+	}
+	if len(got) != 0 {
+		t.Errorf("len(got) = %d, want 0", len(got))
+	}
+}
+
+func TestListProfileCmd_jsonWithProfiles(t *testing.T) {
+	setupConfig(t)
+	t.Cleanup(func() { listJSON = false })
+	if err := lib.AddProfile(lib.Profile{Name: "alpha", Path: "/a"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := lib.AddProfile(lib.Profile{Name: "beta", Path: "/b"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := lib.SetProfile("beta"); err != nil {
+		t.Fatal(err)
+	}
+	out := captureStdout(t, func() {
+		root := &cobra.Command{Use: "raid"}
+		root.AddCommand(ListProfileCmd)
+		root.SetArgs([]string{"list", "--json"})
+		_ = root.Execute()
+	})
+	var got []profileEntry
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("json.Unmarshal(%q): %v", out, err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d, want 2", len(got))
+	}
+	byName := map[string]profileEntry{}
+	for _, e := range got {
+		byName[e.Name] = e
+	}
+	if e := byName["beta"]; !e.Active || e.Path != "/b" {
+		t.Errorf("beta entry = %+v, want active with path /b", e)
+	}
+	if e := byName["alpha"]; e.Active || e.Path != "/a" {
+		t.Errorf("alpha entry = %+v, want inactive with path /a", e)
 	}
 }
 

--- a/src/resources/app.properties
+++ b/src/resources/app.properties
@@ -1,2 +1,2 @@
-version=0.7.2-beta
+version=0.7.3-beta
 environment=development


### PR DESCRIPTION
This pull request adds stable, machine-readable JSON output support to several key "read" commands in the CLI, making it easier to script against `raid` in CI pipelines and automation. The implementation ensures that output shapes are consistent and documented, and includes comprehensive tests for the new output modes. Documentation is updated to reflect the new `--json` options and output contracts.

**JSON Output Support for Read Commands**

* Added a `--json` flag to `raid profile list`, `raid env`, `raid env list`, and `raid doctor` commands, emitting stable JSON output suitable for scripting and CI. Output shapes and field names are now part of the public CLI contract. [[1]](diffhunk://#diff-683ad39999ddedffd027c614092037a2755fc196ff9fc05539deb058d5b8a5b6R4-R17) [[2]](diffhunk://#diff-2783db6f10cc0bace92f26651d52d7526cf35713a795d9d12e520c1ddc02473fR4-R15) [[3]](diffhunk://#diff-dce7ac76aea4c497c8495f30bb6b2f088e35ea915466e22c0e65347a68f2610cR4-R48) [[4]](diffhunk://#diff-a1066d57813112de391f44d4d880886019e1c67fd92cfadb43ebdb7da708c2b5R4-R59)
* Implemented JSON output for `raid doctor` with a summary of findings and encoded severity strings (`ok`, `warn`, `error`), and ensured proper exit codes for errors.
* Implemented JSON output for environment commands: `raid env --json` returns the active environment, and `raid env list --json` returns all environments with their active status. [[1]](diffhunk://#diff-2783db6f10cc0bace92f26651d52d7526cf35713a795d9d12e520c1ddc02473fR26-R31) [[2]](diffhunk://#diff-dce7ac76aea4c497c8495f30bb6b2f088e35ea915466e22c0e65347a68f2610cR4-R48)
* Implemented JSON output for `raid profile list --json`, returning all profiles with their names, paths, and active status.

**Documentation Updates**

* Updated documentation and the changelog to describe the new `--json` flags, output shapes, and usage examples for all supported commands. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R180-R183) [[2]](diffhunk://#diff-17e6752c0d6b26f62456ab112d692799d60cf174834957429aa2fded47b4d31cR45-R64) [[3]](diffhunk://#diff-bc07f7cca71539856fcbf7110e8a5bb2e862283005917ece72d4c01b3c71e3f6R50-R69) [[4]](diffhunk://#diff-8ac39a067439a8b13268d4101c1a9a88b9d402c3f038b88a2ee23c7f0c33652eR61-R75) [[5]](diffhunk://#diff-1bd8d9a03e07abf9afca5851d7d66b451dc7ab6750fc61e3267fc20b31640256R20-R21)

**Testing**

* Added comprehensive tests for all new JSON output modes, including validation of output shapes, field values, and edge cases (e.g., no active environment/profile). [[1]](diffhunk://#diff-b763a941a6c1997327f21eb104a137651edc69f719fb92d34e684bb979cb6d4eR210-R344) [[2]](diffhunk://#diff-dcedfa7c9360820ff70e3724815d6376c2cea7ec6ad746a8c4fa4713bc442ba4R95-R158) [[3]](diffhunk://#diff-f8f59ff7afd62ffeb1734a4dc6e071db0df6c8e3f5091ab4f2e21ed1e5585792R138-R192)

**Miscellaneous**

* Bumped the application version to `0.7.3-beta`.

These changes significantly improve the scriptability and automation-friendliness of the CLI, and ensure that output contracts are well-documented and tested.- Implemented `--json` flag for `raid doctor`, `raid env`, `raid env list`, and `raid profile list` commands to provide machine-readable output.
- Updated README and usage documentation to reflect new JSON output capabilities.
- Enhanced tests to validate JSON output for commands.
- Bumped version to 0.7.3-beta.

Closes #46  