### PR TITLE
feat(cmd): add repo-scoped commands — `raid <repo> <command>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,17 @@ raid deploy staging v1.2.3   # $RAID_ARG_1=staging, $RAID_ARG_2=v1.2.3
 
 Custom commands appear alongside built-in commands in `raid --help`. Commands defined in a profile take priority over same-named commands from repositories.
 
+### `raid <repo> <command>`
+
+Run a command defined in a specific repository's `raid.yaml`. This is useful when a repo defines a command with the same name as a profile-level command — `raid <repo> <command>` always targets the repo's version.
+
+```bash
+raid backend test     # run the "test" command from the backend repo
+raid frontend build   # run the "build" command from the frontend repo
+```
+
+Each repository that defines commands appears as a subcommand in `raid --help`. Run `raid <repo> --help` to see available commands for that repo.
+
 ---
 
 ## Configuration

--- a/site/docs/examples/custom-commands.mdx
+++ b/site/docs/examples/custom-commands.mdx
@@ -200,3 +200,10 @@ raid migrate
 
 raid seed
 ```
+
+These commands are also accessible explicitly via `raid <repo> <command>`:
+
+```bash
+raid api migrate    # run the "migrate" command from the api repo
+raid api seed       # run the "seed" command from the api repo
+```

--- a/site/docs/features/repo-config.mdx
+++ b/site/docs/features/repo-config.mdx
@@ -89,7 +89,14 @@ commands:
         cmd: "go test ./..."
 ```
 
-Command names must be unique across the profile and all repos. They cannot shadow built-in names: `profile`, `install`, `env`, `doctor`.
+When a profile-level command has the same name as a repo command, the profile version wins for `raid <name>`. To explicitly run the repo's version, use `raid <repo-name> <command>`:
+
+```bash
+raid api api-test          # explicitly run the api repo's "api-test" command
+raid api api-dev           # explicitly run the api repo's "api-dev" command
+```
+
+Command names cannot shadow built-in names: `profile`, `install`, `env`, `doctor`, `context`.
 
 ## Environments
 

--- a/site/docs/features/repo-config.mdx
+++ b/site/docs/features/repo-config.mdx
@@ -96,7 +96,7 @@ raid api api-test          # explicitly run the api repo's "api-test" command
 raid api api-dev           # explicitly run the api repo's "api-dev" command
 ```
 
-Command names cannot shadow built-in names: `profile`, `install`, `env`, `doctor`, `context`.
+Command names cannot shadow built-in names: `profile`, `install`, `env`, `doctor`, `context`, `help`, `version`, `completion`.
 
 ## Environments
 

--- a/site/docs/references/commands.mdx
+++ b/site/docs/references/commands.mdx
@@ -131,6 +131,19 @@ raid test-all
 
 Custom commands are defined in `commands` sections of the profile or in individual repository `raid.yaml` files. Run `raid --help` to see all available commands.
 
-Custom command names cannot shadow built-in names (`profile`, `install`, `env`, `doctor`).
+Custom command names cannot shadow built-in names (`profile`, `install`, `env`, `doctor`, `context`).
+
+To run a command from a specific repository (e.g. when profiles shadow a repo command with the same name):
+
+```bash
+raid <repo-name> <command>
+```
+
+```bash
+raid backend test     # run the "test" command from the backend repo
+raid frontend build   # run the "build" command from the frontend repo
+```
+
+Each repo with commands appears as a subcommand in `raid --help`. Run `raid <repo> --help` to list that repo's commands.
 
 For more details, see [Custom Commands](/docs/usage/custom).

--- a/site/docs/references/commands.mdx
+++ b/site/docs/references/commands.mdx
@@ -131,7 +131,7 @@ raid test-all
 
 Custom commands are defined in `commands` sections of the profile or in individual repository `raid.yaml` files. Run `raid --help` to see all available commands.
 
-Custom command names cannot shadow built-in names (`profile`, `install`, `env`, `doctor`, `context`).
+Custom command names cannot shadow built-in or reserved names (`profile`, `install`, `env`, `doctor`, `context`, `help`, `version`, `completion`).
 
 To run a command from a specific repository (e.g. when profiles shadow a repo command with the same name):
 

--- a/site/docs/usage/custom.mdx
+++ b/site/docs/usage/custom.mdx
@@ -83,9 +83,26 @@ commands:
 
 When `out` is omitted entirely, both stdout and stderr are shown. When `out` is present, only streams explicitly set to `true` are displayed. The `file` field writes both stdout and stderr to the specified path regardless of the `stdout`/`stderr` settings.
 
+## Repo-scoped commands
+
+When a profile and a repository define commands with the same name, the profile's version takes priority for `raid <command>`. To explicitly target a specific repository's command, use:
+
+```bash
+raid <repo-name> <command>
+```
+
+For example, if both the profile and the `backend` repo define a `test` command:
+
+```bash
+raid test           # runs the profile-level "test"
+raid backend test   # runs the backend repo's "test"
+```
+
+Each repository that defines commands appears as a subcommand in `raid --help`. Run `raid <repo> --help` to see that repo's available commands.
+
 ## Constraints
 
-Custom command names cannot shadow built-in names: `profile`, `install`, `env`, `doctor`.
+Custom command names cannot shadow built-in names: `profile`, `install`, `env`, `doctor`, `context`.
 
 ## Running tasks in parallel
 

--- a/site/docs/usage/custom.mdx
+++ b/site/docs/usage/custom.mdx
@@ -102,7 +102,7 @@ Each repository that defines commands appears as a subcommand in `raid --help`. 
 
 ## Constraints
 
-Custom command names cannot shadow built-in names: `profile`, `install`, `env`, `doctor`, `context`.
+Custom command names cannot shadow reserved built-in CLI names: `profile`, `install`, `env`, `doctor`, `context`, `help`, `version`, `completion`.
 
 ## Running tasks in parallel
 

--- a/src/cmd/raid.go
+++ b/src/cmd/raid.go
@@ -150,6 +150,7 @@ func executeRoot(args []string) int {
 	rootCmd.SilenceErrors = true
 	rootCmd.SilenceUsage = true
 	registerUserCommands(rootCmd, cmds)
+	registerRepoCommands(rootCmd, raid.GetRepos())
 
 	// Reset args so cobra parses from our slice rather than os.Args when the
 	// caller is providing a different args list (e.g. during tests).
@@ -195,6 +196,53 @@ func registerUserCommands(root *cobra.Command, cmds []lib.Command) {
 			},
 		})
 	}
+}
+
+// registerRepoCommands adds one subcommand per repository that has commands.
+// Each repo subcommand exposes the repo's own commands as sub-subcommands,
+// letting users run `raid <repo> <command>` to target a specific repo even
+// when a profile-level command has the same name.
+func registerRepoCommands(root *cobra.Command, repos []lib.Repo) {
+	for _, repo := range repos {
+		if len(repo.Commands) == 0 {
+			continue
+		}
+		if reservedNames[repo.Name] {
+			fmt.Fprintf(os.Stderr, "warning: repository '%s' conflicts with a built-in subcommand and will not be available as a command namespace\n", repo.Name)
+			continue
+		}
+		if hasCommand(root, repo.Name) {
+			fmt.Fprintf(os.Stderr, "warning: repository '%s' conflicts with a user command and will not be available as a command namespace\n", repo.Name)
+			continue
+		}
+		repoName := repo.Name
+		repoCmd := &cobra.Command{
+			Use:   repoName,
+			Short: fmt.Sprintf("Commands for the %s repository", repoName),
+		}
+		for _, cmd := range repo.Commands {
+			cmdName := cmd.Name
+			repoCmd.AddCommand(&cobra.Command{
+				Use:   cmdName,
+				Short: cmd.Usage,
+				RunE: func(c *cobra.Command, args []string) error {
+					return raid.WithMutationLock(func() error {
+						return raid.ExecuteRepoCommand(repoName, cmdName, args)
+					})
+				},
+			})
+		}
+		root.AddCommand(repoCmd)
+	}
+}
+
+func hasCommand(root *cobra.Command, name string) bool {
+	for _, c := range root.Commands() {
+		if c.Name() == name {
+			return true
+		}
+	}
+	return false
 }
 
 // baseVersion strips "-preview" and anything following it from a version string

--- a/src/cmd/raid_test.go
+++ b/src/cmd/raid_test.go
@@ -787,3 +787,134 @@ func TestExecute_nonInfoUpdateNotice(t *testing.T) {
 	// but this exercises both select branches across multiple runs.
 	_ = executeRoot([]string{"raid", "env", "list"})
 }
+
+// --- registerRepoCommands ---
+
+func TestRegisterRepoCommands_emptyRepos(t *testing.T) {
+	root := newTestRoot()
+	registerRepoCommands(root, nil)
+	if len(root.Commands()) != 0 {
+		t.Errorf("expected no subcommands, got %d", len(root.Commands()))
+	}
+}
+
+func TestRegisterRepoCommands_noCommandsSkipped(t *testing.T) {
+	root := newTestRoot()
+	registerRepoCommands(root, []lib.Repo{{Name: "empty"}})
+	if len(root.Commands()) != 0 {
+		t.Errorf("expected no subcommands for repo with no commands, got %d", len(root.Commands()))
+	}
+}
+
+func TestRegisterRepoCommands_appearsInHelp(t *testing.T) {
+	root := newTestRoot()
+	registerRepoCommands(root, []lib.Repo{{
+		Name:     "backend",
+		Commands: []lib.Command{{Name: "test", Usage: "Run backend tests"}},
+	}})
+
+	out := helpOutput(root)
+	if !strings.Contains(out, "backend") {
+		t.Errorf("help output missing repo name 'backend'\n\nfull output:\n%s", out)
+	}
+}
+
+func TestRegisterRepoCommands_repoSubcommands(t *testing.T) {
+	root := newTestRoot()
+	registerRepoCommands(root, []lib.Repo{{
+		Name: "api",
+		Commands: []lib.Command{
+			{Name: "test", Usage: "Run API tests"},
+			{Name: "migrate", Usage: "Run migrations"},
+		},
+	}})
+
+	var repoCmd *cobra.Command
+	for _, c := range root.Commands() {
+		if c.Name() == "api" {
+			repoCmd = c
+			break
+		}
+	}
+	if repoCmd == nil {
+		t.Fatal("expected 'api' subcommand on root")
+	}
+
+	var buf bytes.Buffer
+	repoCmd.SetOut(&buf)
+	repoCmd.SetErr(&buf)
+	_ = repoCmd.Help()
+	out := buf.String()
+	for _, want := range []string{"test", "Run API tests", "migrate", "Run migrations"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("repo help missing %q\n\nfull output:\n%s", want, out)
+		}
+	}
+}
+
+func TestRegisterRepoCommands_reservedNameSkipped(t *testing.T) {
+	root := newTestRoot()
+	var buf bytes.Buffer
+	root.SetErr(&buf)
+	registerRepoCommands(root, []lib.Repo{{
+		Name:     "install",
+		Commands: []lib.Command{{Name: "test"}},
+	}})
+
+	if len(root.Commands()) != 0 {
+		t.Error("repo with reserved name should not be registered")
+	}
+}
+
+func TestRegisterRepoCommands_conflictWithUserCommand(t *testing.T) {
+	root := newTestRoot()
+	registerUserCommands(root, []lib.Command{{Name: "deploy", Usage: "Deploy all"}})
+	registerRepoCommands(root, []lib.Repo{{
+		Name:     "deploy",
+		Commands: []lib.Command{{Name: "test"}},
+	}})
+
+	count := 0
+	for _, c := range root.Commands() {
+		if c.Name() == "deploy" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 'deploy' command (user cmd), got %d", count)
+	}
+}
+
+func TestRegisterRepoCommands_multipleRepos(t *testing.T) {
+	root := newTestRoot()
+	registerRepoCommands(root, []lib.Repo{
+		{Name: "backend", Commands: []lib.Command{{Name: "test"}}},
+		{Name: "frontend", Commands: []lib.Command{{Name: "build"}}},
+	})
+
+	names := map[string]bool{}
+	for _, c := range root.Commands() {
+		names[c.Name()] = true
+	}
+	if !names["backend"] || !names["frontend"] {
+		t.Errorf("expected both 'backend' and 'frontend', got %v", names)
+	}
+}
+
+func TestRegisterRepoCommands_runE(t *testing.T) {
+	setupTestConfig(t)
+	root := newTestRoot()
+	registerRepoCommands(root, []lib.Repo{{
+		Name:     "myrepo",
+		Commands: []lib.Command{{Name: "testcmd", Usage: "A test command"}},
+	}})
+
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"myrepo", "testcmd"})
+	err := root.Execute()
+	if err == nil {
+		t.Error("expected error with no context, got nil")
+	}
+}

--- a/src/internal/lib/command.go
+++ b/src/internal/lib/command.go
@@ -112,9 +112,10 @@ func ExecuteRepoCommand(repoName, cmdName string, args []string) error {
 	startSession()
 	defer endSession()
 
-	startedAt := RecordRecentStart(found.Name)
+	recentName := repoName + ":" + found.Name
+	startedAt := RecordRecentStart(recentName)
 	err := runCommand(found)
-	RecordRecentEnd(found.Name, err, startedAt)
+	RecordRecentEnd(recentName, err, startedAt)
 	return err
 }
 

--- a/src/internal/lib/command.go
+++ b/src/internal/lib/command.go
@@ -40,6 +40,14 @@ func GetCommands() []Command {
 	return context.Profile.Commands
 }
 
+// GetRepos returns the repositories in the active profile.
+func GetRepos() []Repo {
+	if context == nil {
+		return nil
+	}
+	return context.Profile.Repositories
+}
+
 // ExecuteCommand runs the tasks for the named command, applying any output configuration.
 // Args are exposed as RAID_ARG_1, RAID_ARG_2, ... environment variables for the duration
 // of the command and are unset afterwards.
@@ -53,6 +61,46 @@ func ExecuteCommand(name string, args []string) error {
 	}
 	if found.IsZero() {
 		return fmt.Errorf("command '%s' not found", name)
+	}
+
+	clearRaidArgs()
+	defer clearRaidArgs()
+	for i, arg := range args {
+		os.Setenv(fmt.Sprintf("RAID_ARG_%d", i+1), arg)
+	}
+
+	startSession()
+	defer endSession()
+
+	startedAt := RecordRecentStart(found.Name)
+	err := runCommand(found)
+	RecordRecentEnd(found.Name, err, startedAt)
+	return err
+}
+
+// ExecuteRepoCommand runs a command defined in a specific repository's raid.yaml.
+func ExecuteRepoCommand(repoName, cmdName string, args []string) error {
+	repos := GetRepos()
+	var repo *Repo
+	for i := range repos {
+		if repos[i].Name == repoName {
+			repo = &repos[i]
+			break
+		}
+	}
+	if repo == nil {
+		return fmt.Errorf("repository '%s' not found", repoName)
+	}
+
+	var found Command
+	for _, cmd := range repo.Commands {
+		if cmd.Name == cmdName {
+			found = cmd
+			break
+		}
+	}
+	if found.IsZero() {
+		return fmt.Errorf("command '%s' not found in repository '%s'", cmdName, repoName)
 	}
 
 	clearRaidArgs()

--- a/src/internal/lib/command_test.go
+++ b/src/internal/lib/command_test.go
@@ -372,3 +372,157 @@ func TestMergeCommands(t *testing.T) {
 		})
 	}
 }
+
+// --- GetRepos ---
+
+func TestGetRepos_nilContext(t *testing.T) {
+	old := context
+	context = nil
+	defer func() { context = old }()
+
+	if got := GetRepos(); got != nil {
+		t.Errorf("GetRepos() = %v, want nil when context is nil", got)
+	}
+}
+
+func TestGetRepos_withRepos(t *testing.T) {
+	context = &Context{
+		Profile: Profile{
+			Repositories: []Repo{
+				{Name: "backend"},
+				{Name: "frontend"},
+			},
+		},
+	}
+	defer func() { context = nil }()
+
+	got := GetRepos()
+	if len(got) != 2 {
+		t.Fatalf("GetRepos() = %d repos, want 2", len(got))
+	}
+	if got[0].Name != "backend" || got[1].Name != "frontend" {
+		t.Errorf("GetRepos() names = %v/%v, want backend/frontend", got[0].Name, got[1].Name)
+	}
+}
+
+// --- ExecuteRepoCommand ---
+
+func TestExecuteRepoCommand_repoNotFound(t *testing.T) {
+	setupTestConfig(t)
+	context = &Context{
+		Profile: Profile{
+			Repositories: []Repo{{Name: "backend"}},
+		},
+	}
+
+	err := ExecuteRepoCommand("nonexistent", "test", nil)
+	if err == nil {
+		t.Fatal("expected error for unknown repo, got nil")
+	}
+	if !strings.Contains(err.Error(), "nonexistent") {
+		t.Errorf("error %q should mention the repo name", err.Error())
+	}
+}
+
+func TestExecuteRepoCommand_cmdNotFound(t *testing.T) {
+	setupTestConfig(t)
+	context = &Context{
+		Profile: Profile{
+			Repositories: []Repo{{
+				Name:     "backend",
+				Commands: []Command{{Name: "build", Tasks: []Task{{Type: Shell, Cmd: "exit 0"}}}},
+			}},
+		},
+	}
+
+	err := ExecuteRepoCommand("backend", "nonexistent", nil)
+	if err == nil {
+		t.Fatal("expected error for unknown command, got nil")
+	}
+	if !strings.Contains(err.Error(), "nonexistent") || !strings.Contains(err.Error(), "backend") {
+		t.Errorf("error %q should mention both repo and command", err.Error())
+	}
+}
+
+func TestExecuteRepoCommand_success(t *testing.T) {
+	setupTestConfig(t)
+	origOut := commandStdout
+	commandStdout = io.Discard
+	t.Cleanup(func() { commandStdout = origOut })
+
+	context = &Context{
+		Profile: Profile{
+			Repositories: []Repo{{
+				Name:     "backend",
+				Commands: []Command{{Name: "noop", Tasks: []Task{{Type: Shell, Cmd: "exit 0"}}}},
+			}},
+		},
+	}
+
+	if err := ExecuteRepoCommand("backend", "noop", nil); err != nil {
+		t.Errorf("ExecuteRepoCommand() error: %v", err)
+	}
+}
+
+func TestExecuteRepoCommand_taskFailure(t *testing.T) {
+	setupTestConfig(t)
+	context = &Context{
+		Profile: Profile{
+			Repositories: []Repo{{
+				Name:     "backend",
+				Commands: []Command{{Name: "fail", Tasks: []Task{{Type: Shell, Cmd: "exit 1"}}}},
+			}},
+		},
+	}
+
+	if err := ExecuteRepoCommand("backend", "fail", nil); err == nil {
+		t.Fatal("expected error from failing task, got nil")
+	}
+}
+
+func TestExecuteRepoCommand_setsArgs(t *testing.T) {
+	setupTestConfig(t)
+	origOut := commandStdout
+	commandStdout = io.Discard
+	t.Cleanup(func() { commandStdout = origOut })
+
+	dir := t.TempDir()
+	srcFile := filepath.Join(dir, "args.tmpl")
+	outFile := filepath.Join(dir, "args.txt")
+	if err := os.WriteFile(srcFile, []byte("$RAID_ARG_1\n$RAID_ARG_2"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	context = &Context{
+		Profile: Profile{
+			Repositories: []Repo{{
+				Name: "backend",
+				Commands: []Command{{
+					Name: "tmpl",
+					Tasks: []Task{{Type: Template, Src: srcFile, Dest: outFile}},
+				}},
+			}},
+		},
+	}
+
+	if err := ExecuteRepoCommand("backend", "tmpl", []string{"hello", "world"}); err != nil {
+		t.Fatalf("ExecuteRepoCommand() error: %v", err)
+	}
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("reading output: %v", err)
+	}
+	if got := string(data); got != "hello\nworld" {
+		t.Errorf("template output = %q, want %q", got, "hello\nworld")
+	}
+}
+
+func TestExecuteRepoCommand_nilContext(t *testing.T) {
+	old := context
+	context = nil
+	defer func() { context = old }()
+
+	if err := ExecuteRepoCommand("any", "any", nil); err == nil {
+		t.Fatal("expected error with nil context, got nil")
+	}
+}

--- a/src/raid/raid.go
+++ b/src/raid/raid.go
@@ -102,6 +102,11 @@ func GetCommands() []lib.Command {
 	return lib.GetCommands()
 }
 
+// GetRepos returns the repositories in the active profile.
+func GetRepos() []lib.Repo {
+	return lib.GetRepos()
+}
+
 // QuietGetCommands performs a best-effort, read-only profile load and returns
 // the available commands. It does not create config files or emit warnings, and
 // returns nil if the config is absent or loading fails.
@@ -112,6 +117,11 @@ func QuietGetCommands() []lib.Command {
 // ExecuteCommand runs the named command from the active profile.
 func ExecuteCommand(name string, args []string) error {
 	return lib.ExecuteCommand(name, args)
+}
+
+// ExecuteRepoCommand runs a command defined in a specific repository's raid.yaml.
+func ExecuteRepoCommand(repoName, cmdName string, args []string) error {
+	return lib.ExecuteRepoCommand(repoName, cmdName, args)
 }
 
 // Severity indicates the importance of a Doctor finding.

--- a/src/raid/raid_test.go
+++ b/src/raid/raid_test.go
@@ -165,6 +165,20 @@ func TestExecuteCommand_noContext(t *testing.T) {
 	}
 }
 
+func TestGetRepos_emptyState(t *testing.T) {
+	setupConfig(t)
+	repos := GetRepos()
+	_ = repos
+}
+
+func TestExecuteRepoCommand_noContext(t *testing.T) {
+	setupConfig(t)
+	err := ExecuteRepoCommand("repo", "cmd", nil)
+	if err == nil {
+		t.Fatal("ExecuteRepoCommand() expected error with no context, got nil")
+	}
+}
+
 func TestInitialize_withTempConfig(t *testing.T) {
 	dir := t.TempDir()
 	old := lib.CfgPath

--- a/src/resources/app.properties
+++ b/src/resources/app.properties
@@ -1,2 +1,2 @@
-version=0.7.3-beta
+version=0.7.4-beta
 environment=development


### PR DESCRIPTION
## Summary

Adds the ability to explicitly run a command defined in a specific repository's `raid.yaml`, even when a profile-level command has the same name.

```bash
raid backend test     # run the "test" command from the backend repo
raid frontend build   # run the "build" command from the frontend repo
raid backend --help   # list available commands for the backend repo
```

Each repository that defines commands now appears as a subcommand in `raid --help`. The existing flat `raid <command>` behavior is fully preserved — this is purely additive.

Closes #21

## Changes

### Core (`src/internal/lib/command.go`)
- `GetRepos()` — returns the repositories in the active profile (parallel to `GetCommands()`)
- `ExecuteRepoCommand(repoName, cmdName, args)` — looks up a command in a specific repo and runs it (same session/args/recording flow as `ExecuteCommand`)

### Facade (`src/raid/raid.go`)
- `GetRepos()` and `ExecuteRepoCommand()` wrappers

### CLI (`src/cmd/raid.go`)
- `registerRepoCommands(root, repos)` — registers each repo as a Cobra subcommand with its commands as sub-subcommands
- Wired into `executeRoot()` after `registerUserCommands()`
- Conflict handling: repos whose name matches a built-in or user command are skipped with a warning
- RunE uses `WithMutationLock` (matching the existing user command pattern)

### Docs
- `README.md` — new `raid <repo> <command>` section
- `site/docs/usage/custom.mdx` — "Repo-scoped commands" section
- `site/docs/features/repo-config.mdx` — updated Commands section
- `site/docs/references/commands.mdx` — added repo-scoped syntax
- `site/docs/examples/custom-commands.mdx` — added `raid api migrate` example

## Test plan

- [x] `TestGetRepos_nilContext`, `TestGetRepos_withRepos`
- [x] `TestExecuteRepoCommand_success`, `_repoNotFound`, `_cmdNotFound`, `_taskFailure`, `_setsArgs`, `_nilContext`
- [x] `TestRegisterRepoCommands_appearsInHelp`, `_repoSubcommands`, `_reservedNameSkipped`, `_conflictWithUserCommand`, `_noCommandsSkipped`, `_multipleRepos`, `_emptyRepos`, `_runE`
- [x] `go test ./...` — all passing
- [x] `go vet ./...` — clean
- [x] `npm run build` in `site/` — docsite builds with no broken links
- [x] Version bumped to `0.7.4-beta`

---
_Generated by [Claude Code](https://claude.ai/code/session_017CQJHeuPVxks5JryoM2i7D)_