### PR TITLE
Add support for profiles from URL, including git and raw file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ Layout: main.go→src/cmd. src/cmd/raid.go=root cmd+subcommand registration+vers
 
 Config: raid.yaml=per-repo (environments+tasks: Shell|Script|HTTP|Wait|Template|Group|Git|Prompt|Confirm|Set|Print). profile.raid.yml=user profile (tracked repos, global settings).
 
+Versioning: version in src/resources/app.properties. Bump second position (minor) for feature/large changes; bump third position (patch) for small changes or bug fixes.
+
 Non-obvious:
 - applyConfigFlag in src/cmd/raid.go scans os.Args for --config/-c BEFORE Cobra parses, because config must load before subcommand registration
 - Async version check goroutine on every invocation; info cmds (help/version/completion) wait up to 1.5s, others non-blocking
@@ -19,6 +21,7 @@ Non-obvious:
 - Cross-process mutation lock at ~/.raid/.lock via gofrs/flock. raid.WithMutationLock(fn) wraps the lock+release; every mutating cobra entry point and every MCP mutating handler must call it so CLI usage and the MCP server serialize against each other. Read paths don't acquire the lock. Tests must redirect lib.LockPathOverride (alongside RecentPathOverride) in any setup helper that exercises a mutating path; cmd/context tests use a TestMain to do this once for the whole package.
 - Cobra commands: prefer RunE over Run on read commands so enc.Encode errors and arg-validation errors propagate to the root error handler instead of being silently swallowed. Use cmd.OutOrStdout()/cmd.OutOrStderr() (not fmt.Println / os.Stdout) so tests can capture output via root.SetOut(&buf). When changing Run → RunE, also update any test that calls Command.Run(...) directly to Command.RunE(...).
 - JSON output is public CLI contract: --json field names and types are breaking-change surface. Use camelCase tags consistent with `raid context --json`; severities/enums encode as strings ("ok"/"warn"/"error", not ints). Renaming or removing a field needs a whats-new entry.
+- `raid profile add <url>` accepts HTTP/HTTPS/git@ URLs. URL type detection in src/cmd/profile/fetch.go: git@ prefix or .git suffix → clone; .yaml/.yml/.json extension → raw HTTP download; otherwise probed live with sys.DetectGitDefaultBranch. Profiles are copied to ~/<name>.raid.yaml (home dir root, not ~/.raid/). detectGitURL/gitCloneFunc/httpGetFunc are package-level vars for test injection; tests must set detectGitURL to avoid live network probes.
 
 CI: .github/workflows/ — build.yml (build+test), deploy.yml (release), preview.yml (preview releases), codecov.yml (coverage), docs.yml (deploy Pages from site/), docs-build.yml (PR build check for site/)
 

--- a/llms.txt
+++ b/llms.txt
@@ -28,7 +28,7 @@ Raid is written in Go, distributed as a single self-contained binary, and publis
 
 - [raid install](https://raidcli.dev/docs/usage/install): Clone repositories and run install tasks across your profile
 - [raid env](https://raidcli.dev/docs/usage/env): Switch between development, staging, and production environments
-- [raid profile](https://raidcli.dev/docs/usage/profile): Add, list, switch, and remove profiles
+- [raid profile](https://raidcli.dev/docs/usage/profile): Add profiles from a git repo URL, raw file URL, or local path; list, switch, and remove profiles
 - [Custom commands](https://raidcli.dev/docs/usage/custom): Define and invoke `raid <cmd>` team workflows
 - [raid doctor](https://raidcli.dev/docs/usage/doctor): Diagnose profile and repo configuration issues
 - [raid root command](https://raidcli.dev/docs/usage/raid): Global flags and top-level invocation

--- a/site/docs/features/profiles.mdx
+++ b/site/docs/features/profiles.mdx
@@ -51,6 +51,23 @@ commands:
         path: "~/dev/frontend"
 ```
 
+## Adding profiles from a URL
+
+`raid profile add` accepts a git repo URL, a raw file URL, or a local path:
+
+```bash
+# Shallow-clone a repo and import any *.raid.yaml files found at the root
+raid profile add https://github.com/my-org/raid-profiles
+
+# Download a single profile file directly
+raid profile add https://raw.githubusercontent.com/my-org/repo/main/team.raid.yaml
+
+# Register a local file
+raid profile add ./team.raid.yaml
+```
+
+Raid auto-detects the argument type. Git URLs (including `git@` and `.git`-suffix URLs) are cloned; HTTP URLs ending with `.yaml`, `.yml`, or `.json` are downloaded directly; ambiguous HTTP URLs are probed with `git ls-remote`. Downloaded profiles are saved to `~/<name>.raid.yaml` before registration.
+
 ## Top-level fields
 
 | Field | Required | Description |

--- a/site/docs/features/profiles.mdx
+++ b/site/docs/features/profiles.mdx
@@ -56,7 +56,7 @@ commands:
 `raid profile add` accepts a git repo URL, a raw file URL, or a local path:
 
 ```bash
-# Shallow-clone a repo and import any *.raid.yaml files found at the root
+# Shallow-clone a repo and import *.raid.yaml, *.raid.yml, and profile.json files found at the root
 raid profile add https://github.com/my-org/raid-profiles
 
 # Download a single profile file directly

--- a/site/docs/usage/profile.mdx
+++ b/site/docs/usage/profile.mdx
@@ -28,13 +28,21 @@ Create a new profile interactively:
 raid profile create
 ```
 
-Register your team's shared profile from a URL:
+Add a profile from a git repository (raid shallow-clones it and looks for `*.raid.yaml` files at the repo root):
+
+```bash
+raid profile add https://github.com/my-org/raid-profiles
+raid profile add git@github.com:my-org/raid-profiles.git
+```
+
+Add a profile from a raw URL pointing directly to a YAML or JSON file:
 
 ```bash
 raid profile add https://example.com/team-profile.yaml
+raid profile add https://raw.githubusercontent.com/my-org/repo/main/team.raid.yaml
 ```
 
-Register a local file:
+The profile is saved to `~/<name>.raid.yaml` and registered automatically. If the argument has no URL scheme it is treated as a local file path:
 
 ```bash
 raid profile add ./my-profile.yaml

--- a/site/docs/usage/profile.mdx
+++ b/site/docs/usage/profile.mdx
@@ -28,7 +28,7 @@ Create a new profile interactively:
 raid profile create
 ```
 
-Add a profile from a git repository (raid shallow-clones it and looks for `*.raid.yaml` files at the repo root):
+Add a profile from a git repository (raid shallow-clones it and looks for `*.raid.yaml`, `*.raid.yml`, and `profile.json` files at the repo root):
 
 ```bash
 raid profile add https://github.com/my-org/raid-profiles

--- a/site/docs/whats-new.mdx
+++ b/site/docs/whats-new.mdx
@@ -11,7 +11,7 @@ User-visible changes per release, latest first. For full commit history see the 
 
 ## 0.7.0 — upcoming
 
-**Add profiles from a URL.** `raid profile add` now accepts a git repo URL or a direct file URL in addition to a local path. Pass a GitHub (or any git host) URL and raid shallow-clones the repo, finds `*.raid.yaml` files at the root, and saves them to `~/<name>.raid.yaml`. Pass a raw HTTPS URL ending in `.yaml`/`.yml`/`.json` and raid downloads and registers it directly. Ambiguous HTTPS URLs are probed with `git ls-remote` to determine the right strategy automatically.
+**Add profiles from a URL.** `raid profile add` now accepts a git repo URL or a direct file URL in addition to a local path. Pass a GitHub (or any git host) URL and raid shallow-clones the repo, finds `*.raid.yaml`, `*.raid.yml`, or `profile.json` files at the root, and saves them to `~/<name>.raid.yaml`. Pass a raw HTTPS URL ending in `.yaml`/`.yml`/`.json` and raid downloads and registers it directly. Ambiguous HTTPS URLs are probed with `git ls-remote` to determine the right strategy automatically.
 
 **MCP server.** `raid context serve` runs raid as a [Model Context Protocol](https://modelcontextprotocol.io) server over stdio, so MCP-aware hosts (Claude Code, Cursor, Cline) can read the active workspace as resources and invoke raid tools (`raid_install`, `raid_env_switch`, `raid_run_task`, `raid_list_profiles`, `raid_list_repos`, `raid_describe_repo`) directly. Output from mutating tools is captured into the tool result so it doesn't corrupt JSON-RPC framing on stdout. See [Context → MCP server](/docs/usage/context).
 

--- a/site/docs/whats-new.mdx
+++ b/site/docs/whats-new.mdx
@@ -11,6 +11,8 @@ User-visible changes per release, latest first. For full commit history see the 
 
 ## 0.7.0 — upcoming
 
+**Add profiles from a URL.** `raid profile add` now accepts a git repo URL or a direct file URL in addition to a local path. Pass a GitHub (or any git host) URL and raid shallow-clones the repo, finds `*.raid.yaml` files at the root, and saves them to `~/<name>.raid.yaml`. Pass a raw HTTPS URL ending in `.yaml`/`.yml`/`.json` and raid downloads and registers it directly. Ambiguous HTTPS URLs are probed with `git ls-remote` to determine the right strategy automatically.
+
 **MCP server.** `raid context serve` runs raid as a [Model Context Protocol](https://modelcontextprotocol.io) server over stdio, so MCP-aware hosts (Claude Code, Cursor, Cline) can read the active workspace as resources and invoke raid tools (`raid_install`, `raid_env_switch`, `raid_run_task`, `raid_list_profiles`, `raid_list_repos`, `raid_describe_repo`) directly. Output from mutating tools is captured into the tool result so it doesn't corrupt JSON-RPC framing on stdout. See [Context → MCP server](/docs/usage/context).
 
 **Set variables reach subprocesses.** Variables defined by a `Set` task are now exported as environment variables to Script and Shell task subprocesses, so a script's source can reference `$VAR` directly without raid pre-expanding the script body. Raid values take precedence over OS-environment variables of the same name.

--- a/src/cmd/profile/add.go
+++ b/src/cmd/profile/add.go
@@ -36,6 +36,9 @@ var AddProfileCmd = &cobra.Command{
 // Extracted from AddProfileCmd.Run so tests can observe the exit code
 // without os.Exit terminating the test process.
 func runAddProfile(path string) int {
+	if isURL(path) {
+		return runAddProfileFromURL(path)
+	}
 	path = sys.ExpandPath(path)
 
 	if !sys.FileExists(path) {

--- a/src/cmd/profile/fetch.go
+++ b/src/cmd/profile/fetch.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	sys "github.com/8bitalex/raid/src/internal/sys"
 	"github.com/8bitalex/raid/src/raid"
@@ -21,7 +22,8 @@ var (
 		return exec.Command("git", "clone", "--depth", "1", repoURL, dir).Run()
 	}
 	httpGetFunc = func(rawURL string) ([]byte, error) {
-		resp, err := http.Get(rawURL) //nolint:gosec
+		client := &http.Client{Timeout: 30 * time.Second}
+		resp, err := client.Get(rawURL) //nolint:gosec
 		if err != nil {
 			return nil, err
 		}
@@ -29,7 +31,15 @@ var (
 		if resp.StatusCode != http.StatusOK {
 			return nil, fmt.Errorf("HTTP %d from %s", resp.StatusCode, rawURL)
 		}
-		return io.ReadAll(resp.Body)
+		const maxBytes = 10 * 1024 * 1024
+		data, err := io.ReadAll(io.LimitReader(resp.Body, maxBytes+1))
+		if err != nil {
+			return nil, err
+		}
+		if int64(len(data)) > maxBytes {
+			return nil, fmt.Errorf("response from %s exceeds 10 MB limit", rawURL)
+		}
+		return data, nil
 	}
 	// detectGitURL is injectable so tests can skip the live git ls-remote probe.
 	detectGitURL = isGitURL
@@ -99,7 +109,11 @@ func addProfilesFromHTTPURL(rawURL string) int {
 		return 1
 	}
 
-	u, _ := url.Parse(rawURL)
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		fmt.Printf("Invalid URL: %v\n", err)
+		return 1
+	}
 	ext := strings.ToLower(filepath.Ext(u.Path))
 	if ext == "" {
 		ext = ".yaml"
@@ -142,7 +156,10 @@ func findProfileFilesInDir(dir string) []string {
 	add("profile.raid.yaml")
 	add("profile.raid.yml")
 
-	entries, _ := os.ReadDir(dir)
+	entries, rdErr := os.ReadDir(dir)
+	if rdErr != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to read directory %q: %v\n", dir, rdErr)
+	}
 	for _, e := range entries {
 		if e.IsDir() {
 			continue
@@ -170,6 +187,7 @@ func processProfileFiles(paths []string) int {
 
 	var queued []pending
 	var existingNames []string
+	seenQueued := map[string]bool{}
 
 	for _, srcPath := range paths {
 		if err := proValidate(srcPath); err != nil {
@@ -182,10 +200,19 @@ func processProfileFiles(paths []string) int {
 			continue
 		}
 		for _, p := range profiles {
+			if err := sys.ValidateFileName(p.Name); err != nil {
+				fmt.Printf("Skipping profile with invalid name %q: %v\n", p.Name, err)
+				continue
+			}
 			if proContains(p.Name) {
 				existingNames = append(existingNames, p.Name)
 				continue
 			}
+			if seenQueued[p.Name] {
+				fmt.Printf("Skipping duplicate profile name %q\n", p.Name)
+				continue
+			}
+			seenQueued[p.Name] = true
 			queued = append(queued, pending{p: p, srcPath: srcPath})
 		}
 	}

--- a/src/cmd/profile/fetch.go
+++ b/src/cmd/profile/fetch.go
@@ -1,0 +1,243 @@
+package profile
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	sys "github.com/8bitalex/raid/src/internal/sys"
+	"github.com/8bitalex/raid/src/raid"
+	pro "github.com/8bitalex/raid/src/raid/profile"
+)
+
+// Injectable for testing.
+var (
+	gitCloneFunc = func(repoURL, dir string) error {
+		return exec.Command("git", "clone", "--depth", "1", repoURL, dir).Run()
+	}
+	httpGetFunc = func(rawURL string) ([]byte, error) {
+		resp, err := http.Get(rawURL) //nolint:gosec
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("HTTP %d from %s", resp.StatusCode, rawURL)
+		}
+		return io.ReadAll(resp.Body)
+	}
+	// detectGitURL is injectable so tests can skip the live git ls-remote probe.
+	detectGitURL = isGitURL
+	getHomeDir   = sys.GetHomeDir
+)
+
+// isURL reports whether s is an HTTP, HTTPS, or git SSH URL.
+func isURL(s string) bool {
+	return strings.HasPrefix(s, "http://") ||
+		strings.HasPrefix(s, "https://") ||
+		strings.HasPrefix(s, "git@")
+}
+
+// isGitURL reports whether rawURL points to a clonable git repository.
+// git@ and .git-suffix URLs are always git. HTTP URLs with a recognised file
+// extension (.yaml/.yml/.json) are raw files; all others are probed with ls-remote.
+func isGitURL(rawURL string) bool {
+	if strings.HasPrefix(rawURL, "git@") || strings.HasSuffix(rawURL, ".git") {
+		return true
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	switch strings.ToLower(filepath.Ext(u.Path)) {
+	case ".yaml", ".yml", ".json":
+		return false
+	}
+	return sys.DetectGitDefaultBranch(rawURL) != ""
+}
+
+// runAddProfileFromURL is the entry point when the add argument is a URL.
+func runAddProfileFromURL(rawURL string) int {
+	if detectGitURL(rawURL) {
+		return addProfilesFromGitURL(rawURL)
+	}
+	return addProfilesFromHTTPURL(rawURL)
+}
+
+func addProfilesFromGitURL(repoURL string) int {
+	tmpDir, err := os.MkdirTemp("", "raid-profile-*")
+	if err != nil {
+		fmt.Printf("Failed to create temp directory: %v\n", err)
+		return 1
+	}
+	defer os.RemoveAll(tmpDir)
+
+	fmt.Printf("Cloning %s...\n", repoURL)
+	if err := gitCloneFunc(repoURL, tmpDir); err != nil {
+		fmt.Printf("Failed to clone repository: %v\n", err)
+		return 1
+	}
+
+	paths := findProfileFilesInDir(tmpDir)
+	if len(paths) == 0 {
+		fmt.Println("No profile files found in repository")
+		return 1
+	}
+
+	return processProfileFiles(paths)
+}
+
+func addProfilesFromHTTPURL(rawURL string) int {
+	data, err := httpGetFunc(rawURL)
+	if err != nil {
+		fmt.Printf("Failed to download profile: %v\n", err)
+		return 1
+	}
+
+	u, _ := url.Parse(rawURL)
+	ext := strings.ToLower(filepath.Ext(u.Path))
+	if ext == "" {
+		ext = ".yaml"
+	}
+
+	tmpFile, err := os.CreateTemp("", "raid-profile-*"+ext)
+	if err != nil {
+		fmt.Printf("Failed to create temp file: %v\n", err)
+		return 1
+	}
+	tmpPath := tmpFile.Name()
+	defer os.Remove(tmpPath)
+
+	if _, err := tmpFile.Write(data); err != nil {
+		tmpFile.Close()
+		fmt.Printf("Failed to write temp file: %v\n", err)
+		return 1
+	}
+	tmpFile.Close()
+
+	return processProfileFiles([]string{tmpPath})
+}
+
+// findProfileFilesInDir returns profile YAML/JSON files found at the root of dir.
+// Priority: profile.raid.yaml/yml first, then any *.raid.yaml/yml, then profile.json.
+func findProfileFilesInDir(dir string) []string {
+	seen := map[string]bool{}
+	var found []string
+
+	add := func(name string) {
+		if seen[name] {
+			return
+		}
+		seen[name] = true
+		if full := filepath.Join(dir, name); sys.FileExists(full) {
+			found = append(found, full)
+		}
+	}
+
+	add("profile.raid.yaml")
+	add("profile.raid.yml")
+
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		lower := strings.ToLower(name)
+		ext := filepath.Ext(lower)
+		stem := strings.TrimSuffix(lower, ext)
+		if (ext == ".yaml" || ext == ".yml") && strings.HasSuffix(stem, ".raid") {
+			add(name)
+		}
+	}
+
+	add("profile.json")
+
+	return found
+}
+
+// processProfileFiles validates, saves, and registers profiles from the given local paths.
+func processProfileFiles(paths []string) int {
+	type pending struct {
+		p       pro.Profile
+		srcPath string
+	}
+
+	var queued []pending
+	var existingNames []string
+
+	for _, srcPath := range paths {
+		if err := proValidate(srcPath); err != nil {
+			fmt.Printf("Skipping %s: invalid profile (%v)\n", filepath.Base(srcPath), err)
+			continue
+		}
+		profiles, err := proUnmarshal(srcPath)
+		if err != nil {
+			fmt.Printf("Skipping %s: could not read profiles (%v)\n", filepath.Base(srcPath), err)
+			continue
+		}
+		for _, p := range profiles {
+			if proContains(p.Name) {
+				existingNames = append(existingNames, p.Name)
+				continue
+			}
+			queued = append(queued, pending{p: p, srcPath: srcPath})
+		}
+	}
+
+	if len(existingNames) > 0 {
+		fmt.Printf("Profiles already exist with names:\n\t%s\n\n", strings.Join(existingNames, ",\n\t"))
+	}
+
+	if len(queued) == 0 {
+		fmt.Println("No new profiles found")
+		return 0
+	}
+
+	// Copy each profile to a stable home-dir path before registering.
+	home := getHomeDir()
+	var toRegister []pro.Profile
+	var destPaths []string
+	for _, q := range queued {
+		destPath := filepath.Join(home, q.p.Name+".raid.yaml")
+		if err := sys.CopyFile(q.srcPath, destPath); err != nil {
+			fmt.Printf("Failed to save profile '%s': %v\n", q.p.Name, err)
+			continue
+		}
+		q.p.Path = destPath
+		toRegister = append(toRegister, q.p)
+		destPaths = append(destPaths, destPath)
+	}
+
+	if len(toRegister) == 0 {
+		fmt.Println("No new profiles found")
+		return 0
+	}
+
+	writeErr := raid.WithMutationLock(func() error {
+		if err := proAddAll(toRegister); err != nil {
+			return fmt.Errorf("save: %w", err)
+		}
+		if proGet().IsZero() {
+			if err := proSet(toRegister[0].Name); err != nil {
+				return fmt.Errorf("set active: %w", err)
+			}
+			fmt.Printf("Profile '%s' set as active\n", toRegister[0].Name)
+		}
+		return nil
+	})
+	if writeErr != nil {
+		fmt.Printf("Failed to save profiles: %v\n", writeErr)
+		return 1
+	}
+
+	for i, p := range toRegister {
+		fmt.Printf("Profile '%s' added from URL, saved to %s\n", p.Name, destPaths[i])
+	}
+	return 0
+}

--- a/src/cmd/profile/fetch_test.go
+++ b/src/cmd/profile/fetch_test.go
@@ -443,6 +443,67 @@ func TestRunAddProfile_copyError(t *testing.T) {
 	}
 }
 
+func TestRunAddProfile_invalidProfileName(t *testing.T) {
+	setupConfig(t)
+	defer saveFetchMocks()()
+	defer saveProMocks()()
+
+	homeDir := t.TempDir()
+	getHomeDir = func() string { return homeDir }
+	detectGitURL = func(string) bool { return false }
+	httpGetFunc = func(string) ([]byte, error) {
+		return []byte("name: goodprofile\n"), nil
+	}
+	proValidate = func(string) error { return nil }
+	proUnmarshal = func(string) ([]pro.Profile, error) {
+		return []pro.Profile{{Name: "../../evil"}}, nil
+	}
+	proContains = func(string) bool { return false }
+
+	out := captureStdout(t, func() {
+		if code := runAddProfile("https://example.com/profile.yaml"); code != 0 {
+			t.Errorf("code = %d, want 0", code)
+		}
+	})
+	if !strings.Contains(out, "invalid name") {
+		t.Errorf("got %q, want 'invalid name' in output", out)
+	}
+	if _, err := os.Stat(filepath.Join(homeDir, "..evil.raid.yaml")); err == nil {
+		t.Error("traversal file must not be written")
+	}
+}
+
+func TestRunAddProfile_duplicateProfileName(t *testing.T) {
+	setupConfig(t)
+	defer saveFetchMocks()()
+	defer saveProMocks()()
+
+	homeDir := t.TempDir()
+	getHomeDir = func() string { return homeDir }
+	detectGitURL = func(string) bool { return false }
+	httpGetFunc = func(string) ([]byte, error) {
+		return []byte("name: dupprofile\n"), nil
+	}
+	proValidate = func(string) error { return nil }
+	proUnmarshal = func(string) ([]pro.Profile, error) {
+		return []pro.Profile{{Name: "dupprofile"}, {Name: "dupprofile"}}, nil
+	}
+	proContains = func(string) bool { return false }
+
+	out := captureStdout(t, func() {
+		if code := runAddProfile("https://example.com/profile.yaml"); code != 0 {
+			t.Errorf("code = %d, want 0", code)
+		}
+	})
+	if !strings.Contains(out, "duplicate") {
+		t.Errorf("got %q, want 'duplicate' in output", out)
+	}
+	// Only one file should be written.
+	if _, err := os.Stat(filepath.Join(homeDir, "dupprofile.raid.yaml")); err != nil {
+		t.Errorf("expected one saved file: %v", err)
+	}
+}
+
 // --- Subprocess test: AddProfileCmd.Run wrapper calls osExit on clone failure ---
 
 const subprocURLCloneFail = "RAID_TEST_URL_CLONE_FAIL"

--- a/src/cmd/profile/fetch_test.go
+++ b/src/cmd/profile/fetch_test.go
@@ -1,0 +1,472 @@
+package profile
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/8bitalex/raid/src/internal/lib"
+	pro "github.com/8bitalex/raid/src/raid/profile"
+	"github.com/spf13/cobra"
+)
+
+// saveFetchMocks saves and returns a restore function for the fetch injectable vars.
+func saveFetchMocks() func() {
+	origGitClone := gitCloneFunc
+	origHTTPGet := httpGetFunc
+	origDetect := detectGitURL
+	origHome := getHomeDir
+	return func() {
+		gitCloneFunc = origGitClone
+		httpGetFunc = origHTTPGet
+		detectGitURL = origDetect
+		getHomeDir = origHome
+	}
+}
+
+// writeRaidYAML writes a minimal valid profile YAML to dir/<name>.yaml and returns its path.
+func writeRaidYAML(t *testing.T, dir, filename, profileName string) string {
+	t.Helper()
+	path := filepath.Join(dir, filename)
+	if err := os.WriteFile(path, []byte("name: "+profileName+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// --- isURL ---
+
+func TestIsURL(t *testing.T) {
+	cases := []struct {
+		input string
+		want  bool
+	}{
+		{"http://example.com/p.yaml", true},
+		{"https://example.com/p.yaml", true},
+		{"git@github.com:user/repo.git", true},
+		{"/local/path/profile.yaml", false},
+		{"./relative/profile.yaml", false},
+		{"profile.yaml", false},
+	}
+	for _, c := range cases {
+		if got := isURL(c.input); got != c.want {
+			t.Errorf("isURL(%q) = %v, want %v", c.input, got, c.want)
+		}
+	}
+}
+
+// --- isGitURL ---
+
+func TestIsGitURL_gitAtPrefix(t *testing.T) {
+	if !isGitURL("git@github.com:user/repo.git") {
+		t.Error("git@ URL should be detected as git")
+	}
+}
+
+func TestIsGitURL_dotGitSuffix(t *testing.T) {
+	if !isGitURL("https://github.com/user/repo.git") {
+		t.Error(".git suffix URL should be detected as git")
+	}
+}
+
+func TestIsGitURL_yamlExtension(t *testing.T) {
+	if isGitURL("https://raw.githubusercontent.com/user/repo/main/profile.yaml") {
+		t.Error(".yaml URL should not be detected as git")
+	}
+}
+
+func TestIsGitURL_ymlExtension(t *testing.T) {
+	if isGitURL("https://example.com/profile.yml") {
+		t.Error(".yml URL should not be detected as git")
+	}
+}
+
+func TestIsGitURL_jsonExtension(t *testing.T) {
+	if isGitURL("https://example.com/profile.json") {
+		t.Error(".json URL should not be detected as git")
+	}
+}
+
+// --- findProfileFilesInDir ---
+
+func TestFindProfileFilesInDir_empty(t *testing.T) {
+	dir := t.TempDir()
+	if got := findProfileFilesInDir(dir); len(got) != 0 {
+		t.Errorf("findProfileFilesInDir empty dir: got %v, want none", got)
+	}
+}
+
+func TestFindProfileFilesInDir_exactName(t *testing.T) {
+	dir := t.TempDir()
+	writeRaidYAML(t, dir, "profile.raid.yaml", "p")
+	got := findProfileFilesInDir(dir)
+	if len(got) != 1 || !strings.HasSuffix(got[0], "profile.raid.yaml") {
+		t.Errorf("findProfileFilesInDir exact: got %v", got)
+	}
+}
+
+func TestFindProfileFilesInDir_multipleFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeRaidYAML(t, dir, "profile.raid.yaml", "p1") // high-priority
+	writeRaidYAML(t, dir, "team.raid.yaml", "p2")
+	got := findProfileFilesInDir(dir)
+	if len(got) != 2 {
+		t.Errorf("findProfileFilesInDir multi: got %d files, want 2", len(got))
+	}
+	if !strings.HasSuffix(got[0], "profile.raid.yaml") {
+		t.Errorf("findProfileFilesInDir multi: first should be profile.raid.yaml, got %s", got[0])
+	}
+}
+
+func TestFindProfileFilesInDir_jsonFallback(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "profile.json")
+	if err := os.WriteFile(path, []byte(`{"name":"jsonprofile"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	got := findProfileFilesInDir(dir)
+	if len(got) != 1 || !strings.HasSuffix(got[0], "profile.json") {
+		t.Errorf("findProfileFilesInDir json: got %v", got)
+	}
+}
+
+func TestFindProfileFilesInDir_noDuplicates(t *testing.T) {
+	dir := t.TempDir()
+	// profile.raid.yaml also matches the *.raid.yaml glob — must appear once only.
+	writeRaidYAML(t, dir, "profile.raid.yaml", "p")
+	got := findProfileFilesInDir(dir)
+	if len(got) != 1 {
+		t.Errorf("findProfileFilesInDir dedup: got %d files, want 1", len(got))
+	}
+}
+
+func TestFindProfileFilesInDir_noRaidYAML_noJSON(t *testing.T) {
+	dir := t.TempDir()
+	// A plain .yaml file should not be picked up.
+	writeRaidYAML(t, dir, "plain.yaml", "p")
+	got := findProfileFilesInDir(dir)
+	if len(got) != 0 {
+		t.Errorf("findProfileFilesInDir plain yaml: got %v, want none", got)
+	}
+}
+
+// --- runAddProfile (URL paths) ---
+
+func TestRunAddProfile_gitURL_success(t *testing.T) {
+	setupConfig(t)
+	defer saveFetchMocks()()
+
+	homeDir := t.TempDir()
+	getHomeDir = func() string { return homeDir }
+	detectGitURL = func(string) bool { return true }
+	gitCloneFunc = func(_, dir string) error {
+		writeRaidYAML(t, dir, "cloned.raid.yaml", "cloned")
+		return nil
+	}
+
+	out := captureStdout(t, func() {
+		if code := runAddProfile("https://github.com/example/repo"); code != 0 {
+			t.Errorf("code = %d, want 0", code)
+		}
+	})
+	if !strings.Contains(out, "cloned") {
+		t.Errorf("got %q, want 'cloned' in output", out)
+	}
+	if _, err := os.Stat(filepath.Join(homeDir, "cloned.raid.yaml")); err != nil {
+		t.Errorf("saved file not found: %v", err)
+	}
+}
+
+func TestRunAddProfile_gitURL_setsActive(t *testing.T) {
+	setupConfig(t)
+	defer saveFetchMocks()()
+
+	homeDir := t.TempDir()
+	getHomeDir = func() string { return homeDir }
+	detectGitURL = func(string) bool { return true }
+	gitCloneFunc = func(_, dir string) error {
+		writeRaidYAML(t, dir, "active.raid.yaml", "active")
+		return nil
+	}
+
+	out := captureStdout(t, func() {
+		if code := runAddProfile("https://github.com/example/repo"); code != 0 {
+			t.Errorf("code = %d, want 0", code)
+		}
+	})
+	if !strings.Contains(out, "set as active") {
+		t.Errorf("got %q, want 'set as active'", out)
+	}
+	if lib.GetProfile().Name != "active" {
+		t.Errorf("active profile = %q, want 'active'", lib.GetProfile().Name)
+	}
+}
+
+func TestRunAddProfile_gitURL_existingSkipped(t *testing.T) {
+	setupConfig(t)
+	defer saveFetchMocks()()
+
+	if err := lib.AddProfile(lib.Profile{Name: "existing", Path: "/fake"}); err != nil {
+		t.Fatal(err)
+	}
+	homeDir := t.TempDir()
+	getHomeDir = func() string { return homeDir }
+	detectGitURL = func(string) bool { return true }
+	gitCloneFunc = func(_, dir string) error {
+		writeRaidYAML(t, dir, "existing.raid.yaml", "existing")
+		return nil
+	}
+
+	out := captureStdout(t, func() {
+		if code := runAddProfile("https://github.com/example/repo"); code != 0 {
+			t.Errorf("code = %d, want 0", code)
+		}
+	})
+	if !strings.Contains(out, "already exist") {
+		t.Errorf("got %q, want 'already exist'", out)
+	}
+}
+
+func TestRunAddProfile_gitURL_cloneError(t *testing.T) {
+	setupConfig(t)
+	defer saveFetchMocks()()
+
+	detectGitURL = func(string) bool { return true }
+	gitCloneFunc = func(_, _ string) error { return fmt.Errorf("network error") }
+
+	out := captureStdout(t, func() {
+		if code := runAddProfile("https://github.com/example/repo"); code != 1 {
+			t.Errorf("code = %d, want 1", code)
+		}
+	})
+	if !strings.Contains(out, "Failed to clone") {
+		t.Errorf("got %q, want 'Failed to clone'", out)
+	}
+}
+
+func TestRunAddProfile_gitURL_noProfiles(t *testing.T) {
+	setupConfig(t)
+	defer saveFetchMocks()()
+
+	detectGitURL = func(string) bool { return true }
+	gitCloneFunc = func(_, _ string) error { return nil } // writes nothing
+
+	out := captureStdout(t, func() {
+		if code := runAddProfile("https://github.com/example/repo"); code != 1 {
+			t.Errorf("code = %d, want 1", code)
+		}
+	})
+	if !strings.Contains(out, "No profile files found") {
+		t.Errorf("got %q, want 'No profile files found'", out)
+	}
+}
+
+func TestRunAddProfile_httpURL_success(t *testing.T) {
+	setupConfig(t)
+	defer saveFetchMocks()()
+
+	homeDir := t.TempDir()
+	getHomeDir = func() string { return homeDir }
+	detectGitURL = func(string) bool { return false }
+	httpGetFunc = func(string) ([]byte, error) {
+		return []byte("name: httpprofile\n"), nil
+	}
+
+	out := captureStdout(t, func() {
+		if code := runAddProfile("https://example.com/profile.yaml"); code != 0 {
+			t.Errorf("code = %d, want 0", code)
+		}
+	})
+	if !strings.Contains(out, "httpprofile") {
+		t.Errorf("got %q, want 'httpprofile' in output", out)
+	}
+	if _, err := os.Stat(filepath.Join(homeDir, "httpprofile.raid.yaml")); err != nil {
+		t.Errorf("saved file not found: %v", err)
+	}
+}
+
+func TestRunAddProfile_httpURL_downloadError(t *testing.T) {
+	setupConfig(t)
+	defer saveFetchMocks()()
+
+	detectGitURL = func(string) bool { return false }
+	httpGetFunc = func(string) ([]byte, error) { return nil, fmt.Errorf("connection refused") }
+
+	out := captureStdout(t, func() {
+		if code := runAddProfile("https://example.com/profile.yaml"); code != 1 {
+			t.Errorf("code = %d, want 1", code)
+		}
+	})
+	if !strings.Contains(out, "Failed to download") {
+		t.Errorf("got %q, want 'Failed to download'", out)
+	}
+}
+
+func TestRunAddProfile_httpURL_invalidProfile(t *testing.T) {
+	setupConfig(t)
+	defer saveFetchMocks()()
+
+	homeDir := t.TempDir()
+	getHomeDir = func() string { return homeDir }
+	detectGitURL = func(string) bool { return false }
+	// Valid YAML syntax but fails schema (extra property).
+	httpGetFunc = func(string) ([]byte, error) {
+		return []byte("name: bad\nextra: notallowed\n"), nil
+	}
+
+	out := captureStdout(t, func() {
+		if code := runAddProfile("https://example.com/profile.yaml"); code != 0 {
+			t.Errorf("code = %d, want 0", code)
+		}
+	})
+	if !strings.Contains(out, "No new profiles found") {
+		t.Errorf("got %q, want 'No new profiles found'", out)
+	}
+}
+
+func TestRunAddProfile_httpURL_unmarshalError(t *testing.T) {
+	setupConfig(t)
+	defer saveFetchMocks()()
+	defer saveProMocks()()
+
+	homeDir := t.TempDir()
+	getHomeDir = func() string { return homeDir }
+	detectGitURL = func(string) bool { return false }
+	httpGetFunc = func(string) ([]byte, error) {
+		return []byte("name: mockprofile\n"), nil
+	}
+	proValidate = func(string) error { return nil }
+	proUnmarshal = func(string) ([]pro.Profile, error) { return nil, errMock }
+
+	out := captureStdout(t, func() {
+		if code := runAddProfile("https://example.com/profile.yaml"); code != 0 {
+			t.Errorf("code = %d, want 0", code)
+		}
+	})
+	if !strings.Contains(out, "No new profiles found") {
+		t.Errorf("got %q, want 'No new profiles found'", out)
+	}
+}
+
+func TestRunAddProfile_httpURL_addAllError(t *testing.T) {
+	setupConfig(t)
+	defer saveFetchMocks()()
+	defer saveProMocks()()
+
+	homeDir := t.TempDir()
+	getHomeDir = func() string { return homeDir }
+	detectGitURL = func(string) bool { return false }
+	httpGetFunc = func(string) ([]byte, error) {
+		return []byte("name: addallprofile\n"), nil
+	}
+	proValidate = func(string) error { return nil }
+	proUnmarshal = func(string) ([]pro.Profile, error) {
+		return []pro.Profile{{Name: "addallprofile"}}, nil
+	}
+	proContains = func(string) bool { return false }
+	proAddAll = func([]pro.Profile) error { return errMock }
+
+	out := captureStdout(t, func() {
+		if code := runAddProfile("https://example.com/profile.yaml"); code != 1 {
+			t.Errorf("code = %d, want 1", code)
+		}
+	})
+	if !strings.Contains(out, "Failed to save profiles") {
+		t.Errorf("got %q, want 'Failed to save profiles'", out)
+	}
+}
+
+func TestRunAddProfile_httpURL_setActiveError(t *testing.T) {
+	setupConfig(t)
+	defer saveFetchMocks()()
+	defer saveProMocks()()
+
+	homeDir := t.TempDir()
+	getHomeDir = func() string { return homeDir }
+	detectGitURL = func(string) bool { return false }
+	httpGetFunc = func(string) ([]byte, error) {
+		return []byte("name: setactiveerr\n"), nil
+	}
+	proValidate = func(string) error { return nil }
+	proUnmarshal = func(string) ([]pro.Profile, error) {
+		return []pro.Profile{{Name: "setactiveerr"}}, nil
+	}
+	proContains = func(string) bool { return false }
+	proAddAll = func([]pro.Profile) error { return nil }
+	proGet = func() pro.Profile { return pro.Profile{} }
+	proSet = func(string) error { return errMock }
+
+	out := captureStdout(t, func() {
+		if code := runAddProfile("https://example.com/profile.yaml"); code != 1 {
+			t.Errorf("code = %d, want 1", code)
+		}
+	})
+	if !strings.Contains(out, "Failed to save profiles") {
+		t.Errorf("got %q, want 'Failed to save profiles'", out)
+	}
+}
+
+func TestRunAddProfile_copyError(t *testing.T) {
+	setupConfig(t)
+	defer saveFetchMocks()()
+	defer saveProMocks()()
+
+	// Use a plain file as the "home dir" so os.WriteFile inside the subdirectory fails.
+	f, err := os.CreateTemp("", "raid-home-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	defer os.Remove(f.Name())
+
+	getHomeDir = func() string { return f.Name() }
+	detectGitURL = func(string) bool { return false }
+	httpGetFunc = func(string) ([]byte, error) {
+		return []byte("name: copyerr\n"), nil
+	}
+	proValidate = func(string) error { return nil }
+	proUnmarshal = func(string) ([]pro.Profile, error) {
+		return []pro.Profile{{Name: "copyerr"}}, nil
+	}
+	proContains = func(string) bool { return false }
+
+	out := captureStdout(t, func() {
+		if code := runAddProfile("https://example.com/profile.yaml"); code != 0 {
+			t.Errorf("code = %d, want 0", code)
+		}
+	})
+	if !strings.Contains(out, "No new profiles found") {
+		t.Errorf("got %q, want 'No new profiles found'", out)
+	}
+}
+
+// --- Subprocess test: AddProfileCmd.Run wrapper calls osExit on clone failure ---
+
+const subprocURLCloneFail = "RAID_TEST_URL_CLONE_FAIL"
+
+func TestAddProfileCmd_urlCloneFail_subprocess(t *testing.T) {
+	if os.Getenv(subprocURLCloneFail) == "1" {
+		setupConfig(t)
+		detectGitURL = func(string) bool { return true }
+		gitCloneFunc = func(_, _ string) error { return fmt.Errorf("forced clone failure") }
+		root := &cobra.Command{Use: "raid"}
+		root.AddCommand(AddProfileCmd)
+		root.SetArgs([]string{"add", "https://github.com/example/repo"})
+		_ = root.Execute()
+		return
+	}
+
+	proc := exec.Command(os.Args[0], "-test.run=^TestAddProfileCmd_urlCloneFail_subprocess$", "-test.v")
+	proc.Env = append(os.Environ(), subprocURLCloneFail+"=1")
+	err := proc.Run()
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("expected *exec.ExitError, got: %T %v", err, err)
+	}
+	if exitErr.ExitCode() != 1 {
+		t.Errorf("exit code = %d, want 1", exitErr.ExitCode())
+	}
+}

--- a/src/cmd/profile/profile_test.go
+++ b/src/cmd/profile/profile_test.go
@@ -880,7 +880,7 @@ func TestRunAddProfile_setActiveSuccess(t *testing.T) {
 
 // --- Mock-based tests for runAddProfile error paths ---
 
-// saveProMocks saves and returns a restore function for all pro* function vars.
+// saveProMocks saves and returns a restore function for all pro* and fetch injectable vars.
 func saveProMocks() func() {
 	origValidate := proValidate
 	origUnmarshal := proUnmarshal
@@ -891,6 +891,10 @@ func saveProMocks() func() {
 	origWriteFile := proWriteFile
 	origCollectRepos := proCollectRepos
 	origCreateRepoConfigs := proCreateRepoConfigs
+	origGitClone := gitCloneFunc
+	origHTTPGet := httpGetFunc
+	origDetect := detectGitURL
+	origHome := getHomeDir
 	return func() {
 		proValidate = origValidate
 		proUnmarshal = origUnmarshal
@@ -901,6 +905,10 @@ func saveProMocks() func() {
 		proWriteFile = origWriteFile
 		proCollectRepos = origCollectRepos
 		proCreateRepoConfigs = origCreateRepoConfigs
+		gitCloneFunc = origGitClone
+		httpGetFunc = origHTTPGet
+		detectGitURL = origDetect
+		getHomeDir = origHome
 	}
 }
 

--- a/src/internal/sys/system.go
+++ b/src/internal/sys/system.go
@@ -59,6 +59,18 @@ func CreateFile(filePath string) (*os.File, error) {
 	return os.OpenFile(pathEx, os.O_RDWR|os.O_CREATE, 0644)
 }
 
+// CopyFile copies the file at src to dest, creating parent directories as needed.
+func CopyFile(src, dest string) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(dest, data, 0644)
+}
+
 // FileExists reports whether the file or directory at path exists.
 // Permission errors are treated as the path existing to avoid silently
 // overwriting or recreating inaccessible files.

--- a/src/internal/sys/system.go
+++ b/src/internal/sys/system.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -61,14 +62,23 @@ func CreateFile(filePath string) (*os.File, error) {
 
 // CopyFile copies the file at src to dest, creating parent directories as needed.
 func CopyFile(src, dest string) error {
-	data, err := os.ReadFile(src)
+	srcFile, err := os.Open(src)
 	if err != nil {
-		return err
+		return fmt.Errorf("open %s: %w", src, err)
 	}
+	defer srcFile.Close()
 	if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
-		return err
+		return fmt.Errorf("create parent dir for %s: %w", dest, err)
 	}
-	return os.WriteFile(dest, data, 0644)
+	destFile, err := os.Create(dest)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", dest, err)
+	}
+	defer destFile.Close()
+	if _, err := io.Copy(destFile, srcFile); err != nil {
+		return fmt.Errorf("copy %s → %s: %w", src, dest, err)
+	}
+	return nil
 }
 
 // FileExists reports whether the file or directory at path exists.

--- a/src/internal/sys/system_test.go
+++ b/src/internal/sys/system_test.go
@@ -261,6 +261,55 @@ func TestCreateFile_existingFile(t *testing.T) {
 	f.Close()
 }
 
+// --- CopyFile ---
+
+func TestCopyFile_createsDestWithContent(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	dest := filepath.Join(dir, "sub", "dest.txt")
+	if err := os.WriteFile(src, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := CopyFile(src, dest); err != nil {
+		t.Fatalf("CopyFile() error: %v", err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("ReadFile dest: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Errorf("dest content = %q, want %q", got, "hello")
+	}
+}
+
+func TestCopyFile_srcNotFound(t *testing.T) {
+	dir := t.TempDir()
+	if err := CopyFile(filepath.Join(dir, "missing.txt"), filepath.Join(dir, "dest.txt")); err == nil {
+		t.Error("CopyFile() with missing src: want error, got nil")
+	}
+}
+
+func TestCopyFile_destParentIsFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("ENOTDIR semantics differ on Windows")
+	}
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	if err := os.WriteFile(src, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Use a regular file as the parent directory — MkdirAll must fail.
+	f, err := os.CreateTemp(dir, "file-not-dir-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	dest := filepath.Join(f.Name(), "dest.txt")
+	if err := CopyFile(src, dest); err == nil {
+		t.Error("CopyFile() with file-as-parent: want error, got nil")
+	}
+}
+
 // --- ValidateFileName ---
 
 func TestValidateFileName(t *testing.T) {

--- a/src/resources/app.properties
+++ b/src/resources/app.properties
@@ -1,2 +1,2 @@
-version=0.7.4-beta
+version=0.8.0-beta
 environment=development


### PR DESCRIPTION
This pull request adds support for importing profiles from remote sources in addition to local files. Now, `raid profile add` can accept a git repository URL or a direct file URL, automatically detecting the type and handling the download or clone process. The documentation and tests are updated to reflect and validate this new functionality.

**New profile import functionality:**

* [`src/cmd/profile/fetch.go`](diffhunk://#diff-4ec68943cd5cf84a8021136782ce0c9fbea54aa40892c655fb33b123f936480bR1-R243): Added logic to detect if the argument is a URL, distinguish between git and raw file URLs, clone or download as appropriate, and register found profiles. Includes robust file detection, error handling, and ensures profiles are saved to the user's home directory.
* [`src/cmd/profile/add.go`](diffhunk://#diff-8e3a8760123213b912873a4addc4ced07eaeff5f0dbe13e8d0167c06f5da266aR39-R41): Updated to delegate to the new URL-handling logic when a URL is provided.

**Documentation updates:**

* `site/docs/whats-new.mdx`, `site/docs/features/profiles.mdx`, `site/docs/usage/profile.mdx`, `llms.txt`: Updated to document the new ability to add profiles from git repositories and direct file URLs, including usage examples and behavioral details. [[1]](diffhunk://#diff-1bd8d9a03e07abf9afca5851d7d66b451dc7ab6750fc61e3267fc20b31640256R14-R15) [[2]](diffhunk://#diff-92b612e795b4e09dddb8b7c17c3be96f0a75edae18618276138a825a26066660R54-R70) [[3]](diffhunk://#diff-8ac39a067439a8b13268d4101c1a9a88b9d402c3f038b88a2ee23c7f0c33652eL31-R45) [[4]](diffhunk://#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114L31-R31)

**Internal utilities and testing:**

* `src/internal/sys/system.go`, `src/internal/sys/system_test.go`: Added and tested a new `CopyFile` utility to support copying profile files to their final destination. [[1]](diffhunk://#diff-c519081caa210ed80b2135caf68a239c08bcf8b7264657dc768096395fda1cc5R62-R73) [[2]](diffhunk://#diff-2a1a6a7f2e83018275ec81092ae17d66fe03429a6dd38046dc8d7460d2f5b471R264-R312)
* [`src/cmd/profile/profile_test.go`](diffhunk://#diff-f8f59ff7afd62ffeb1734a4dc6e071db0df6c8e3f5091ab4f2e21ed1e5585792L883-R883): Extended test harness to mock the new injectable functions for git and HTTP operations, ensuring testability of the new import logic. [[1]](diffhunk://#diff-f8f59ff7afd62ffeb1734a4dc6e071db0df6c8e3f5091ab4f2e21ed1e5585792L883-R883) [[2]](diffhunk://#diff-f8f59ff7afd62ffeb1734a4dc6e071db0df6c8e3f5091ab4f2e21ed1e5585792R894-R897) [[3]](diffhunk://#diff-f8f59ff7afd62ffeb1734a4dc6e071db0df6c8e3f5091ab4f2e21ed1e5585792R908-R911)

These changes make it much easier to share and reuse profile configurations across teams and environments.…and raw file URLs

Closes #23 