### PR TITLE
feat: support local-only repositories (closes #71)

### DIFF
--- a/schemas/raid-profile.schema.json
+++ b/schemas/raid-profile.schema.json
@@ -26,10 +26,10 @@
           },
           "url": {
             "type": "string",
-            "description": "The URL of the repository"
+            "description": "The URL of the repository. Optional — omit for local-only repos that aren't backed by a git remote. When omitted, raid skips cloning and runs install tasks against the existing path."
           }
         },
-        "required": ["name", "path", "url"]
+        "required": ["name", "path"]
       },
       "minItems": 1
     },

--- a/site/docs/references/schema.mdx
+++ b/site/docs/references/schema.mdx
@@ -60,8 +60,8 @@ repositories:
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `name` | string | Yes | Used to reference the repo (e.g. `raid install api`) |
-| `url` | string | Yes | Git remote URL |
-| `path` | string | Yes | Local clone destination (supports `~`) |
+| `url` | string | No | Git remote URL. Omit for local-only directories with no git remote — raid skips cloning and runs install tasks against the existing `path`. |
+| `path` | string | Yes | Local clone destination (supports `~`). For local-only repos, the path must already exist. |
 | [`install`](#install) | object | No | Install configuration for this repo |
 
 ---

--- a/site/docs/whats-new.mdx
+++ b/site/docs/whats-new.mdx
@@ -9,6 +9,10 @@ description: Feature-by-feature release notes for Raid.
 
 User-visible changes per release, latest first. For full commit history see the [GitHub releases page](https://github.com/8bitalex/raid/releases).
 
+## 0.10.0 — upcoming
+
+**Local-only repositories.** `url` is now optional on profile repository entries. Omit it for projects that aren't backed by a git remote — raid skips cloning and runs install tasks against the existing path. The path must already exist on disk; if it doesn't, raid surfaces a clear error instead of trying to `git clone ""`. `raid doctor` no longer flags a missing `.git` directory as a warning for local-only repos. Closes [#71](https://github.com/8bitAlex/raid/issues/71).
+
 ## 0.9.0 — upcoming
 
 **Live variable updates in the MCP server.** `raid context serve` now watches `~/.raid/vars` and reloads the workspace when the file is modified by another raid process, a `Set` task in a separate invocation, or a hand edit. Connected MCP hosts see fresh state on the next read instead of stale values cached at server start. Reloads run under the cross-process mutation lock so they serialize cleanly with concurrent install / env-switch / run-task calls. Closes [#27](https://github.com/8bitAlex/raid/issues/27).

--- a/src/internal/lib/doctor.go
+++ b/src/internal/lib/doctor.go
@@ -116,6 +116,14 @@ func checkRepo(repo Repo) []Finding {
 	repoPath := sys.ExpandPath(repo.Path)
 
 	if !sys.FileExists(repoPath) {
+		if repo.IsLocalOnly() {
+			return append(findings, Finding{
+				Severity:   SeverityError,
+				Check:      fmt.Sprintf("repo/%s", repo.Name),
+				Message:    fmt.Sprintf("local-only repo missing at %s", repoPath),
+				Suggestion: "create the directory or add a 'url' so 'raid install' can clone it",
+			})
+		}
 		return append(findings, Finding{
 			Severity:   SeverityWarn,
 			Check:      fmt.Sprintf("repo/%s", repo.Name),
@@ -130,7 +138,9 @@ func checkRepo(repo Repo) []Finding {
 		Message:  fmt.Sprintf("found at %s", repoPath),
 	})
 
-	if !isGitRepository(repoPath) {
+	// Local-only repos don't need to be git repositories — that's the whole
+	// point. Only warn about a missing .git when a url is configured.
+	if !repo.IsLocalOnly() && !isGitRepository(repoPath) {
 		findings = append(findings, Finding{
 			Severity: SeverityWarn,
 			Check:    fmt.Sprintf("repo/%s", repo.Name),

--- a/src/internal/lib/doctor_test.go
+++ b/src/internal/lib/doctor_test.go
@@ -243,6 +243,27 @@ func TestCheckRepo_notGitRepository(t *testing.T) {
 	}
 }
 
+func TestCheckRepo_localOnly_notGitIsOK(t *testing.T) {
+	dir := t.TempDir()
+	// Local-only repo: no URL, no .git, but path exists.
+
+	repo := Repo{Name: "local", Path: dir}
+	findings := checkRepo(repo)
+	for _, f := range findings {
+		if f.Severity == SeverityWarn {
+			t.Errorf("checkRepo(): unexpected warning for local-only repo: %+v", f)
+		}
+	}
+}
+
+func TestCheckRepo_localOnly_missingPathIsError(t *testing.T) {
+	repo := Repo{Name: "local", Path: filepath.Join(t.TempDir(), "missing")}
+	findings := checkRepo(repo)
+	if !severitySet(findings)[SeverityError] {
+		t.Errorf("checkRepo(): expected error for missing local-only repo, got %+v", findings)
+	}
+}
+
 // severitySet returns a set of all severities present in findings.
 func severitySet(findings []Finding) map[Severity]bool {
 	out := make(map[Severity]bool, len(findings))

--- a/src/internal/lib/profile.go
+++ b/src/internal/lib/profile.go
@@ -258,9 +258,12 @@ func CollectRepos(reader *bufio.Reader) []RepoDraft {
 			break
 		}
 		name := sys.ReadLine(reader, "  Name: ")
-		url := sys.ReadLine(reader, "  URL: ")
+		url := sys.ReadLine(reader, "  URL (leave empty for local-only): ")
 		path := sys.ReadLine(reader, "  Local path: ")
-		defaultBranch := sys.DetectGitDefaultBranch(url)
+		var defaultBranch string
+		if url != "" {
+			defaultBranch = sys.DetectGitDefaultBranch(url)
+		}
 		branchPrompt := "  Default branch: "
 		if defaultBranch != "" {
 			branchPrompt = fmt.Sprintf("  Default branch [%s]: ", defaultBranch)
@@ -270,8 +273,8 @@ func CollectRepos(reader *bufio.Reader) []RepoDraft {
 			branch = defaultBranch
 		}
 		repo := RepoDraft{Name: name, URL: url, Path: path, Branch: branch}
-		if repo.Name == "" || repo.URL == "" || repo.Path == "" {
-			fmt.Println("  Name, URL, and path are all required. Skipping.")
+		if repo.Name == "" || repo.Path == "" {
+			fmt.Println("  Name and path are required. Skipping.")
 			continue
 		}
 		repos = append(repos, repo)

--- a/src/internal/lib/repo.go
+++ b/src/internal/lib/repo.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	sys "github.com/8bitalex/raid/src/internal/sys"
 	"gopkg.in/yaml.v3"
@@ -32,8 +33,13 @@ func (r Repo) IsZero() bool {
 // IsLocalOnly reports whether the repo has no configured git remote.
 // Local-only repos skip cloning; install tasks run directly against the
 // existing path. The path must already exist on disk for install to work.
+//
+// Whitespace-only URLs (e.g. `url: " "` from a stray edit) are treated as
+// local-only — the trimmed value is what would be handed to `git clone`,
+// and an empty string there produces a confusing error rather than a
+// useful one.
 func (r Repo) IsLocalOnly() bool {
-	return r.URL == ""
+	return strings.TrimSpace(r.URL) == ""
 }
 
 func (r Repo) getEnv(name string) Env {
@@ -100,7 +106,7 @@ func CloneRepository(repo Repo) error {
 		return fmt.Errorf("failed to create directory '%s': %w", path, err)
 	}
 
-	if err := clone(path, repo.URL, repo.Branch); err != nil {
+	if err := clone(path, strings.TrimSpace(repo.URL), repo.Branch); err != nil {
 		return fmt.Errorf("failed to clone repository '%s': %w", repo.Name, err)
 	}
 

--- a/src/internal/lib/repo.go
+++ b/src/internal/lib/repo.go
@@ -23,9 +23,17 @@ type Repo struct {
 	Commands     []Command `json:"commands"`
 }
 
-// IsZero reports whether the repo is uninitialized.
+// IsZero reports whether the repo is uninitialized. URL is intentionally
+// excluded — local-only repos with no git remote leave it empty.
 func (r Repo) IsZero() bool {
-	return r.Name == "" || r.Path == "" || r.URL == ""
+	return r.Name == "" || r.Path == ""
+}
+
+// IsLocalOnly reports whether the repo has no configured git remote.
+// Local-only repos skip cloning; install tasks run directly against the
+// existing path. The path must already exist on disk for install to work.
+func (r Repo) IsLocalOnly() bool {
+	return r.URL == ""
 }
 
 func (r Repo) getEnv(name string) Env {
@@ -63,9 +71,21 @@ func buildRepo(repo *Repo) error {
 	return nil
 }
 
-// CloneRepository clones a repository to its configured path. Skips if it already exists.
+// CloneRepository clones a repository to its configured path. Skips if it
+// already exists. Repos with no configured `url` (local-only) are never
+// cloned — the path must already exist on disk; otherwise an error is
+// returned so the user knows the local repo is missing rather than getting
+// a confusing git error.
 func CloneRepository(repo Repo) error {
 	path := sys.ExpandPath(repo.Path)
+
+	if repo.IsLocalOnly() {
+		if !sys.FileExists(path) {
+			return fmt.Errorf("repository '%s' has no url and path '%s' does not exist; create the directory or add a url to clone", repo.Name, path)
+		}
+		fmt.Fprintf(commandStdout, "Repository '%s' is local-only at %s, skipping clone\n", repo.Name, path)
+		return nil
+	}
 
 	if sys.FileExists(path) && isGitRepository(path) {
 		fmt.Fprintf(commandStdout, "Repository '%s' already exists at %s, skipping\n", repo.Name, path)

--- a/src/internal/lib/repo_test.go
+++ b/src/internal/lib/repo_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -15,9 +16,11 @@ func TestRepoIsZero(t *testing.T) {
 	}{
 		{"empty", Repo{}, true},
 		{"name only", Repo{Name: "test"}, true},
-		{"name and path", Repo{Name: "test", Path: "/path"}, true},
-		{"name and url", Repo{Name: "test", URL: "http://example.com"}, true},
-		{"path and url", Repo{Path: "/path", URL: "http://example.com"}, true},
+		// Local-only repos (no url) are valid as long as name and path
+		// are set — the URL check was dropped to support local-only setups.
+		{"name and path (local-only)", Repo{Name: "test", Path: "/path"}, false},
+		{"name and url (no path)", Repo{Name: "test", URL: "http://example.com"}, true},
+		{"path and url (no name)", Repo{Path: "/path", URL: "http://example.com"}, true},
 		{"all three fields", Repo{Name: "test", Path: "/path", URL: "http://example.com"}, false},
 	}
 
@@ -25,6 +28,24 @@ func TestRepoIsZero(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.repo.IsZero(); got != tt.want {
 				t.Errorf("IsZero() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRepoIsLocalOnly(t *testing.T) {
+	tests := []struct {
+		name string
+		repo Repo
+		want bool
+	}{
+		{"empty url", Repo{Name: "x", Path: "/p"}, true},
+		{"with url", Repo{Name: "x", Path: "/p", URL: "git@example.com:x.git"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.repo.IsLocalOnly(); got != tt.want {
+				t.Errorf("IsLocalOnly() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -108,6 +129,27 @@ func TestCloneRepository_pathExistsNotGitRepo(t *testing.T) {
 	err := CloneRepository(repo)
 	if err == nil {
 		t.Fatal("CloneRepository() expected error for failed clone")
+	}
+}
+
+func TestCloneRepository_localOnly_pathExists(t *testing.T) {
+	dir := t.TempDir()
+	// Local-only repo (no URL) at an existing path: must skip clone with no
+	// error so install tasks can run against the directory as-is.
+	repo := Repo{Name: "local", Path: dir}
+	if err := CloneRepository(repo); err != nil {
+		t.Errorf("CloneRepository() local-only at existing path: %v", err)
+	}
+}
+
+func TestCloneRepository_localOnly_missingPath(t *testing.T) {
+	repo := Repo{Name: "local", Path: filepath.Join(t.TempDir(), "missing")}
+	err := CloneRepository(repo)
+	if err == nil {
+		t.Fatal("CloneRepository() local-only with missing path: expected error")
+	}
+	if !strings.Contains(err.Error(), "no url") {
+		t.Errorf("error should mention missing url, got: %v", err)
 	}
 }
 

--- a/src/internal/lib/repo_test.go
+++ b/src/internal/lib/repo_test.go
@@ -40,6 +40,9 @@ func TestRepoIsLocalOnly(t *testing.T) {
 		want bool
 	}{
 		{"empty url", Repo{Name: "x", Path: "/p"}, true},
+		{"whitespace-only url", Repo{Name: "x", Path: "/p", URL: "   "}, true},
+		{"tabs and newlines", Repo{Name: "x", Path: "/p", URL: "\t\n "}, true},
+		{"padded url is remote", Repo{Name: "x", Path: "/p", URL: "  git@example.com:x.git  "}, false},
 		{"with url", Repo{Name: "x", Path: "/p", URL: "git@example.com:x.git"}, false},
 	}
 	for _, tt := range tests {

--- a/src/resources/app.properties
+++ b/src/resources/app.properties
@@ -1,2 +1,2 @@
-version=0.9.0-beta
+version=0.10.0-beta
 environment=development

--- a/src/resources/profile-template
+++ b/src/resources/profile-template
@@ -24,6 +24,11 @@
 #   - name: frontend
 #     path: ~/dev/my-project/frontend
 #     url: https://github.com/myorg/frontend.git
+#   - name: scratch
+#     path: ~/dev/my-project/scratch
+#     # url is optional — omit it for local-only directories with no git
+#     # remote. raid will skip cloning and run install tasks against the
+#     # existing path. The path must already exist on disk.
 
 # ---------------------------------------------------------------------------
 # Environments  (raid env <name>)


### PR DESCRIPTION
## Summary

Resolves #71 — *Support local development without a repo or remote*.

`url` is now optional on profile repository entries. When omitted, raid treats the entry as local-only:

- skips cloning entirely (so `raid install` no longer fatal-errors trying to `git clone ""` against a remote that doesn't exist)
- runs install tasks against the existing path as-is
- requires the path to already exist on disk; if it doesn't, returns a clear error pointing at the path
- `raid doctor` no longer flags a missing `.git` as a warning for local-only repos, and upgrades a missing path to error severity for them

The `Repo.IsZero()` definition was tightened to drop the URL check (it was the only thing keeping local-only repos out of the loaded profile). A new `Repo.IsLocalOnly()` exposes the missing-url state explicitly.

## Files

- `schemas/raid-profile.schema.json` — `url` removed from `required`; description notes the local-only mode.
- `src/internal/lib/repo.go` — `IsZero` no longer requires URL; new `IsLocalOnly`; `CloneRepository` short-circuits on local-only.
- `src/internal/lib/doctor.go` — context-aware checks for local-only repos.
- `src/internal/lib/profile.go` — interactive `raid profile create` accepts an empty URL prompt; default-branch detection skipped when URL is empty.
- `src/resources/profile-template`, `site/docs/references/schema.mdx`, `site/docs/whats-new.mdx` — docs updated.
- Version bumped 0.9.0-beta → 0.10.0-beta.

## Test plan

- [x] `go test ./...` — all packages green.
- [x] Coverage on internal/lib stays ≥ 93% with new tests covering `IsLocalOnly`, the local-only `CloneRepository` paths (existing-path-skip + missing-path-error), and the new doctor cases.
- [x] `cd site && npm run build` — no broken links.
- [x] **End-to-end**: tested against a real local-only project (`apple-app-list`):
  - `raid doctor` reports clean (no spurious "not a git repository" warning) once `url` is dropped from the profile.
  - `raid install` runs `swift build` + `npm install` against the existing path with no clone attempt — first line is `Repository 'apple-app-list' is local-only at <path>, skipping clone`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)