### PR TITLE
feat: declared arguments and flags on custom commands (closes #26)

### DIFF
--- a/schemas/raid-defs.schema.json
+++ b/schemas/raid-defs.schema.json
@@ -459,13 +459,14 @@
                     },
                     "args": {
                         "type": "array",
-                        "description": "Declared positional arguments. The supplied value is exported as an env var named after `name` (uppercased) for the duration of the command, available in tasks as $NAME. Required args without a corresponding positional value cause cobra to reject the invocation.",
+                        "description": "Declared positional arguments. Required args must be supplied; declarations cap the total number of positional args cobra accepts. The supplied value is exported as an env var named after `name` (uppercased) for the duration of the command, available in tasks as $NAME.",
                         "items": {
                             "type": "object",
                             "properties": {
                                 "name": {
                                     "type": "string",
-                                    "description": "Argument name. Uppercased to form the variable name."
+                                    "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+                                    "description": "Argument name. Must be a valid env var identifier ([A-Za-z_][A-Za-z0-9_]*). Uppercased to form the variable name."
                                 },
                                 "usage": {
                                     "type": "string",
@@ -489,7 +490,8 @@
                             "properties": {
                                 "name": {
                                     "type": "string",
-                                    "description": "Flag name; the long form is --<name> and the env var is the uppercased name."
+                                    "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+                                    "description": "Flag name. Must be a valid env var identifier ([A-Za-z_][A-Za-z0-9_]*). The long form is --<name> and the env var is the uppercased name."
                                 },
                                 "short": {
                                     "type": "string",
@@ -513,16 +515,30 @@
                                     "default": false
                                 },
                                 "default": {
-                                    "description": "Value used when the flag is omitted. Must match `type`.",
-                                    "oneOf": [
-                                        {"type": "string"},
-                                        {"type": "boolean"},
-                                        {"type": "integer"}
-                                    ]
+                                    "description": "Value used when the flag is omitted. Must match `type` — the conditional `allOf` below enforces this so a string default on an int flag is rejected at config-load time."
                                 }
                             },
                             "required": ["name"],
-                            "additionalProperties": false
+                            "additionalProperties": false,
+                            "allOf": [
+                                {
+                                    "if": {"properties": {"type": {"const": "bool"}}, "required": ["type"]},
+                                    "then": {"properties": {"default": {"type": "boolean"}}}
+                                },
+                                {
+                                    "if": {"properties": {"type": {"const": "int"}}, "required": ["type"]},
+                                    "then": {"properties": {"default": {"type": "integer"}}}
+                                },
+                                {
+                                    "if": {
+                                        "anyOf": [
+                                            {"not": {"required": ["type"]}},
+                                            {"properties": {"type": {"const": "string"}}, "required": ["type"]}
+                                        ]
+                                    },
+                                    "then": {"properties": {"default": {"type": "string"}}}
+                                }
+                            ]
                         }
                     },
                     "tasks": {

--- a/schemas/raid-defs.schema.json
+++ b/schemas/raid-defs.schema.json
@@ -457,6 +457,74 @@
                         "type": "string",
                         "description": "Short description shown in 'raid --help'"
                     },
+                    "args": {
+                        "type": "array",
+                        "description": "Declared positional arguments. The supplied value is exported as an env var named after `name` (uppercased) for the duration of the command, available in tasks as $NAME. Required args without a corresponding positional value cause cobra to reject the invocation.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Argument name. Uppercased to form the variable name."
+                                },
+                                "usage": {
+                                    "type": "string",
+                                    "description": "Short description shown in '--help'."
+                                },
+                                "required": {
+                                    "type": "boolean",
+                                    "description": "If true the command fails when the positional value is omitted.",
+                                    "default": false
+                                }
+                            },
+                            "required": ["name"],
+                            "additionalProperties": false
+                        }
+                    },
+                    "flags": {
+                        "type": "array",
+                        "description": "Declared flags / options. Long form is --<name>; an optional `short` adds a single-character -<x>. Values bind to an env var named after `name` (uppercased) for the duration of the command. Booleans bind as the literal strings 'true' or 'false'.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "description": "Flag name; the long form is --<name> and the env var is the uppercased name."
+                                },
+                                "short": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "maxLength": 1,
+                                    "description": "Single-character short form, e.g. 'v' to bind -v."
+                                },
+                                "usage": {
+                                    "type": "string",
+                                    "description": "Short description shown in '--help'."
+                                },
+                                "type": {
+                                    "type": "string",
+                                    "enum": ["string", "bool", "int"],
+                                    "description": "Value type. Defaults to 'string' when omitted.",
+                                    "default": "string"
+                                },
+                                "required": {
+                                    "type": "boolean",
+                                    "description": "If true cobra rejects the invocation when the flag is omitted.",
+                                    "default": false
+                                },
+                                "default": {
+                                    "description": "Value used when the flag is omitted. Must match `type`.",
+                                    "oneOf": [
+                                        {"type": "string"},
+                                        {"type": "boolean"},
+                                        {"type": "integer"}
+                                    ]
+                                }
+                            },
+                            "required": ["name"],
+                            "additionalProperties": false
+                        }
+                    },
                     "tasks": {
                         "$ref": "#/properties/tasks"
                     },

--- a/site/docs/references/schema.mdx
+++ b/site/docs/references/schema.mdx
@@ -121,12 +121,37 @@ commands:
 |---|---|---|---|
 | `name` | string | Yes | Command name — invoked as `raid <name>` |
 | `usage` | string | No | Description shown in `raid --help` |
+| `args` | list | No | Declared positional arguments. See [Args](#command-args). |
+| `flags` | list | No | Declared flags / options. See [Flags](#command-flags). |
 | [`tasks`](#task) | list | Yes | Task sequence to run |
 | [`out`](#output) | object | No | Output configuration |
 
 Command names cannot shadow built-in names: `install`, `env`, `profile`, `doctor`.
 
-Arguments passed after the command name are available as `RAID_ARG_1`, `RAID_ARG_2`, etc.
+Arguments passed after the command name are available as `RAID_ARG_1`, `RAID_ARG_2`, etc. Declared `args` and `flags` (below) additionally bind to env vars named after each entry's `name` (uppercased).
+
+### Command args
+
+Each entry under `args` declares a positional argument. The supplied value is exported as an env var named after `name` (uppercased) for the duration of the command.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | Yes | Argument name — uppercased to form the env var. |
+| `usage` | string | No | Short description shown in `--help`. |
+| `required` | bool | No | If true, the command fails when the positional value is omitted. Defaults to false. |
+
+### Command flags
+
+Each entry under `flags` declares a long-form `--name` flag (and optionally a `-x` short form). Values bind to an env var named after `name` (uppercased).
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | Yes | Flag name — long form is `--name`, env var is `NAME`. |
+| `short` | string (1 char) | No | Single-character short form, e.g. `v` → `-v`. |
+| `usage` | string | No | Short description shown in `--help`. |
+| `type` | enum | No | One of `string` (default), `bool`, `int`. Bool flags bind as the literal strings `"true"` / `"false"`. |
+| `required` | bool | No | If true, cobra rejects the invocation when the flag is omitted. |
+| `default` | string \| bool \| int | No | Value used when the flag is omitted. Must match `type`. |
 
 ### Output
 

--- a/site/docs/usage/custom.mdx
+++ b/site/docs/usage/custom.mdx
@@ -112,7 +112,7 @@ raid patch -s host.example.com 67890         # comment optional
 | `required` | When true, cobra rejects the invocation if the value is omitted. |
 | `default` (flags only) | Used when the flag is omitted. Type must match `type`. |
 
-Unparsed positional arguments (those beyond declared `args`) and `RAID_ARG_N` continue to work; declarations are additive.
+Once a command declares `args`, cobra rejects extra positional values beyond the declared list — the cap is `len(args)`. To accept an unbounded number of positional arguments, omit `args:` and read them from `$RAID_ARG_1`, `$RAID_ARG_2`, … as before. `RAID_ARG_N` remains populated for declared positional values too, so a task can reference either `$TICKET` (named) or `$RAID_ARG_1` interchangeably.
 
 ## Output configuration
 

--- a/site/docs/usage/custom.mdx
+++ b/site/docs/usage/custom.mdx
@@ -64,6 +64,56 @@ commands:
 
 The variables are set for the duration of the command and cleared afterwards.
 
+### Declared arguments and flags
+
+Commands can also declare named positional arguments and flags. Declared values are bound to env vars named after the field's `name` (uppercased) and made available to tasks for the duration of the command — so `name: ticket` becomes `$TICKET`. Required values that aren't supplied cause raid to reject the invocation with a clear cobra error.
+
+```yaml title="profile.yaml"
+commands:
+  - name: "patch"
+    usage: "Apply a patch to a SUV host"
+    args:
+      - name: ticket
+        usage: "Ticket number"
+        required: true
+      - name: comment
+        usage: "Optional changelog note"
+    flags:
+      - name: suv
+        short: s
+        usage: "Target SUV hostname"
+        required: true
+      - name: verbose
+        short: v
+        type: bool
+      - name: retries
+        type: int
+        default: 3
+    tasks:
+      - type: Print
+        message: "Patching $TICKET on $SUV (retries=$RETRIES, verbose=$VERBOSE)"
+      - type: Shell
+        cmd: ./scripts/patch.sh "$TICKET" --host "$SUV" --retries "$RETRIES"
+```
+
+Invocation:
+
+```bash
+raid patch --suv host.example.com -v 12345 "rolling out the fix"
+raid patch -s host.example.com 67890         # comment optional
+```
+
+| Field on `args[]` / `flags[]` | Meaning |
+|---|---|
+| `name` | Long form (`--name`) and the env var (uppercased). |
+| `short` (flags only) | Single-character short form, e.g. `s` → `-s`. |
+| `usage` | Short description shown in `--help`. |
+| `type` (flags only) | `string` (default), `bool`, or `int`. Bool flags bind as the literal strings `"true"` / `"false"`. |
+| `required` | When true, cobra rejects the invocation if the value is omitted. |
+| `default` (flags only) | Used when the flag is omitted. Type must match `type`. |
+
+Unparsed positional arguments (those beyond declared `args`) and `RAID_ARG_N` continue to work; declarations are additive.
+
 ## Output configuration
 
 Use the `out` field to control what output a command shows and optionally write it to a file.

--- a/site/docs/whats-new.mdx
+++ b/site/docs/whats-new.mdx
@@ -9,6 +9,10 @@ description: Feature-by-feature release notes for Raid.
 
 User-visible changes per release, latest first. For full commit history see the [GitHub releases page](https://github.com/8bitalex/raid/releases).
 
+## 0.11.0 — upcoming
+
+**Declared arguments and flags on custom commands.** `commands[]` entries now accept an `args` list (named positional arguments) and a `flags` list (long/short options with optional default and type — `string`, `bool`, or `int`). Declared values are exported as env vars named after each entry (uppercased), so `args: [{name: ticket, required: true}]` makes `$TICKET` available in tasks for the duration of the command. Cobra enforces required values and validates positional cardinality before raid runs anything. `RAID_ARG_N` continues to work for unnamed positional arguments. Closes [#26](https://github.com/8bitAlex/raid/issues/26).
+
 ## 0.10.1 — upcoming
 
 **Plain-yaml profiles via `raid profile add <url>`.** When the URL points at a git repo (or a single-file gist) whose profile file isn't named with the `*.raid.yaml` convention — e.g. just `profile.yaml`, `myprofile.yml`, or `config.json` — raid now picks it up as a fallback after no `*.raid.yaml`/`profile.json` matches are found. Schema validation runs the same way, so non-profile YAML lying around in a repo root is still rejected with a clear "invalid profile" message. Makes ad-hoc gists usable without renaming the file.

--- a/src/cmd/context/serve.go
+++ b/src/cmd/context/serve.go
@@ -451,7 +451,10 @@ func handleRunTask(_ stdctx.Context, req mcp.CallToolRequest) (*mcp.CallToolResu
 	lockErr := raid.WithMutationLock(func() error {
 		var runErr error
 		output, runErr = captureCommandOutput(func() error {
-			return raid.ExecuteCommand(command, args)
+			// MCP `raid_run_task` doesn't currently accept named args/flags;
+			// pass nil so cobra-side declared bindings stay unset (commands
+			// without declared args/flags are unaffected).
+			return raid.ExecuteCommand(command, args, nil)
 		})
 		if runErr == nil {
 			// ExecuteCommand mutates env vars and recent.json. ForceLoad

--- a/src/cmd/raid.go
+++ b/src/cmd/raid.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -185,16 +186,20 @@ func registerUserCommands(root *cobra.Command, cmds []lib.Command) {
 			continue
 		}
 		name := cmd.Name
-		root.AddCommand(&cobra.Command{
-			Use:         name,
+		def := cmd
+		coCmd := &cobra.Command{
+			Use:         buildCommandUse(name, def.Args),
 			Short:       cmd.Usage,
 			Annotations: map[string]string{CommandSourceAnnotation: CommandSourceUser},
-			RunE: func(c *cobra.Command, args []string) error {
-				return raid.WithMutationLock(func() error {
-					return raid.ExecuteCommand(name, args)
-				})
-			},
-		})
+		}
+		attachCommandArgsAndFlags(coCmd, def)
+		coCmd.RunE = func(c *cobra.Command, args []string) error {
+			named := gatherCommandValues(c, def, args)
+			return raid.WithMutationLock(func() error {
+				return raid.ExecuteCommand(name, args, named)
+			})
+		}
+		root.AddCommand(coCmd)
 	}
 }
 
@@ -222,18 +227,127 @@ func registerRepoCommands(root *cobra.Command, repos []lib.Repo) {
 		}
 		for _, cmd := range repo.Commands {
 			cmdName := cmd.Name
-			repoCmd.AddCommand(&cobra.Command{
-				Use:   cmdName,
+			def := cmd
+			subCmd := &cobra.Command{
+				Use:   buildCommandUse(cmdName, def.Args),
 				Short: cmd.Usage,
-				RunE: func(c *cobra.Command, args []string) error {
-					return raid.WithMutationLock(func() error {
-						return raid.ExecuteRepoCommand(repoName, cmdName, args)
-					})
-				},
-			})
+			}
+			attachCommandArgsAndFlags(subCmd, def)
+			subCmd.RunE = func(c *cobra.Command, args []string) error {
+				named := gatherCommandValues(c, def, args)
+				return raid.WithMutationLock(func() error {
+					return raid.ExecuteRepoCommand(repoName, cmdName, args, named)
+				})
+			}
+			repoCmd.AddCommand(subCmd)
 		}
 		root.AddCommand(repoCmd)
 	}
+}
+
+// buildCommandUse renders the cobra Use string with declared positional
+// args so `--help` shows the expected invocation shape, e.g.
+// `patch <ticket> [comment]`.
+func buildCommandUse(name string, args []lib.Arg) string {
+	if len(args) == 0 {
+		return name
+	}
+	var b strings.Builder
+	b.WriteString(name)
+	for _, a := range args {
+		b.WriteByte(' ')
+		if a.Required {
+			b.WriteString("<")
+			b.WriteString(a.Name)
+			b.WriteString(">")
+		} else {
+			b.WriteString("[")
+			b.WriteString(a.Name)
+			b.WriteString("]")
+		}
+	}
+	return b.String()
+}
+
+// attachCommandArgsAndFlags configures a cobra subcommand from the lib.Command
+// definition: positional-arg cardinality validators and declared flags. Type
+// defaults to "string" when unset; "bool" / "int" are also recognised. A
+// missing or wrong-typed Default falls back to the zero value rather than
+// failing — the schema's `oneOf` already guards the YAML side.
+func attachCommandArgsAndFlags(co *cobra.Command, cmd lib.Command) {
+	if n := len(cmd.Args); n > 0 {
+		req := 0
+		for _, a := range cmd.Args {
+			if a.Required {
+				req++
+			}
+		}
+		switch {
+		case req == n:
+			co.Args = cobra.ExactArgs(n)
+		case req == 0:
+			co.Args = cobra.MaximumNArgs(n)
+		default:
+			co.Args = cobra.RangeArgs(req, n)
+		}
+	}
+
+	for _, f := range cmd.Flags {
+		switch f.Type {
+		case "bool":
+			d, _ := f.Default.(bool)
+			co.Flags().BoolP(f.Name, f.Short, d, f.Usage)
+		case "int":
+			d := 0
+			switch v := f.Default.(type) {
+			case int:
+				d = v
+			case float64:
+				// YAML numbers unmarshal into float64 through interface{}.
+				d = int(v)
+			}
+			co.Flags().IntP(f.Name, f.Short, d, f.Usage)
+		default:
+			d, _ := f.Default.(string)
+			co.Flags().StringP(f.Name, f.Short, d, f.Usage)
+		}
+		if f.Required {
+			_ = co.MarkFlagRequired(f.Name)
+		}
+	}
+}
+
+// gatherCommandValues builds the name → value map that ExecuteCommand binds
+// to env vars. Returns nil when the command has no declared args/flags so
+// the legacy positional-only path stays untouched.
+func gatherCommandValues(co *cobra.Command, cmd lib.Command, posArgs []string) map[string]string {
+	if len(cmd.Args) == 0 && len(cmd.Flags) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(cmd.Args)+len(cmd.Flags))
+	for i, a := range cmd.Args {
+		if i < len(posArgs) {
+			out[a.Name] = posArgs[i]
+		}
+	}
+	for _, f := range cmd.Flags {
+		switch f.Type {
+		case "bool":
+			v, _ := co.Flags().GetBool(f.Name)
+			if v {
+				out[f.Name] = "true"
+			} else {
+				out[f.Name] = "false"
+			}
+		case "int":
+			v, _ := co.Flags().GetInt(f.Name)
+			out[f.Name] = strconv.Itoa(v)
+		default:
+			v, _ := co.Flags().GetString(f.Name)
+			out[f.Name] = v
+		}
+	}
+	return out
 }
 
 func hasCommand(root *cobra.Command, name string) bool {

--- a/src/cmd/raid_test.go
+++ b/src/cmd/raid_test.go
@@ -214,6 +214,201 @@ func TestRegisterUserCommands_visibleForAllInvocationTypes(t *testing.T) {
 	}
 }
 
+// --- declared args / flags ---
+
+func TestBuildCommandUse(t *testing.T) {
+	tests := []struct {
+		name string
+		args []lib.Arg
+		want string
+	}{
+		{"no args", nil, "patch"},
+		{"single required", []lib.Arg{{Name: "ticket", Required: true}}, "patch <ticket>"},
+		{"single optional", []lib.Arg{{Name: "comment"}}, "patch [comment]"},
+		{"mixed", []lib.Arg{
+			{Name: "ticket", Required: true},
+			{Name: "comment"},
+		}, "patch <ticket> [comment]"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildCommandUse("patch", tt.args); got != tt.want {
+				t.Errorf("buildCommandUse = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAttachCommandArgsAndFlags_argValidatorCardinality(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []lib.Arg
+		passed    []string
+		wantError bool
+	}{
+		{"no args declared accepts none", nil, []string{}, false},
+		{"all required exact match", []lib.Arg{{Name: "a", Required: true}, {Name: "b", Required: true}}, []string{"x", "y"}, false},
+		{"all required missing one", []lib.Arg{{Name: "a", Required: true}, {Name: "b", Required: true}}, []string{"x"}, true},
+		{"all optional accepts zero", []lib.Arg{{Name: "a"}, {Name: "b"}}, []string{}, false},
+		{"all optional caps at max", []lib.Arg{{Name: "a"}, {Name: "b"}}, []string{"x", "y", "z"}, true},
+		{"mixed below required", []lib.Arg{{Name: "a", Required: true}, {Name: "b"}}, []string{}, true},
+		{"mixed at min", []lib.Arg{{Name: "a", Required: true}, {Name: "b"}}, []string{"x"}, false},
+		{"mixed at max", []lib.Arg{{Name: "a", Required: true}, {Name: "b"}}, []string{"x", "y"}, false},
+		{"mixed above max", []lib.Arg{{Name: "a", Required: true}, {Name: "b"}}, []string{"x", "y", "z"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			co := &cobra.Command{Use: "cmd"}
+			attachCommandArgsAndFlags(co, lib.Command{Args: tt.args})
+			var err error
+			if co.Args != nil {
+				err = co.Args(co, tt.passed)
+			}
+			if (err != nil) != tt.wantError {
+				t.Errorf("validator err = %v, wantError = %v", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestAttachCommandArgsAndFlags_flagDefaultsAndTypes(t *testing.T) {
+	co := &cobra.Command{Use: "cmd"}
+	attachCommandArgsAndFlags(co, lib.Command{Flags: []lib.Flag{
+		{Name: "host", Type: "string", Default: "localhost"},
+		{Name: "verbose", Short: "v", Type: "bool", Default: true},
+		{Name: "count", Type: "int", Default: 5},
+		// Default supplied as float64 (YAML / JSON unmarshal path) must coerce to int.
+		{Name: "retries", Type: "int", Default: float64(3)},
+		// Type omitted defaults to string.
+		{Name: "label", Default: "x"},
+	}})
+
+	if got, _ := co.Flags().GetString("host"); got != "localhost" {
+		t.Errorf("host default = %q, want localhost", got)
+	}
+	if got, _ := co.Flags().GetBool("verbose"); !got {
+		t.Errorf("verbose default = false, want true")
+	}
+	if got, _ := co.Flags().GetInt("count"); got != 5 {
+		t.Errorf("count default = %d, want 5", got)
+	}
+	if got, _ := co.Flags().GetInt("retries"); got != 3 {
+		t.Errorf("retries (float64 default) = %d, want 3", got)
+	}
+	if got, _ := co.Flags().GetString("label"); got != "x" {
+		t.Errorf("label default = %q, want x", got)
+	}
+	if co.Flags().ShorthandLookup("v") == nil {
+		t.Errorf("expected -v shorthand registered for --verbose")
+	}
+}
+
+func TestAttachCommandArgsAndFlags_requiredFlag(t *testing.T) {
+	co := &cobra.Command{
+		Use:  "cmd",
+		Run:  func(*cobra.Command, []string) {},
+		// Silence cobra's usage dump on error so the test output stays clean.
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	attachCommandArgsAndFlags(co, lib.Command{Flags: []lib.Flag{
+		{Name: "host", Required: true},
+	}})
+
+	co.SetArgs([]string{})
+	if err := co.Execute(); err == nil {
+		t.Fatal("expected error when required flag is omitted")
+	}
+}
+
+func TestGatherCommandValues_returnsNilWhenNothingDeclared(t *testing.T) {
+	co := &cobra.Command{Use: "cmd"}
+	if got := gatherCommandValues(co, lib.Command{}, []string{"x"}); got != nil {
+		t.Errorf("gatherCommandValues with no args/flags = %v, want nil", got)
+	}
+}
+
+func TestGatherCommandValues_bindsArgsAndFlags(t *testing.T) {
+	cmd := lib.Command{
+		Args: []lib.Arg{{Name: "ticket", Required: true}, {Name: "comment"}},
+		Flags: []lib.Flag{
+			{Name: "host", Type: "string", Default: "localhost"},
+			{Name: "verbose", Type: "bool"},
+			{Name: "count", Type: "int"},
+		},
+	}
+	co := &cobra.Command{Use: "cmd", Run: func(*cobra.Command, []string) {}}
+	attachCommandArgsAndFlags(co, cmd)
+
+	co.SetArgs([]string{"--host", "remote", "--verbose", "--count", "9", "T-100", "fix it"})
+	if err := co.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	got := gatherCommandValues(co, cmd, []string{"T-100", "fix it"})
+	want := map[string]string{
+		"ticket":  "T-100",
+		"comment": "fix it",
+		"host":    "remote",
+		"verbose": "true",
+		"count":   "9",
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("gathered[%q] = %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+func TestGatherCommandValues_omittedOptionalArg(t *testing.T) {
+	cmd := lib.Command{
+		Args: []lib.Arg{{Name: "ticket", Required: true}, {Name: "comment"}},
+	}
+	co := &cobra.Command{Use: "cmd"}
+	attachCommandArgsAndFlags(co, cmd)
+
+	got := gatherCommandValues(co, cmd, []string{"T-1"})
+	if got["ticket"] != "T-1" {
+		t.Errorf("ticket = %q, want T-1", got["ticket"])
+	}
+	if _, set := got["comment"]; set {
+		t.Errorf("comment must not be set when omitted, got %q", got["comment"])
+	}
+}
+
+func TestGatherCommandValues_boolFalseWhenAbsent(t *testing.T) {
+	cmd := lib.Command{Flags: []lib.Flag{{Name: "verbose", Type: "bool"}}}
+	co := &cobra.Command{Use: "cmd", Run: func(*cobra.Command, []string) {}}
+	attachCommandArgsAndFlags(co, cmd)
+	co.SetArgs([]string{})
+	if err := co.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	got := gatherCommandValues(co, cmd, nil)
+	if got["verbose"] != "false" {
+		t.Errorf("absent bool flag = %q, want \"false\"", got["verbose"])
+	}
+}
+
+func TestRegisterUserCommands_useStringIncludesDeclaredArgs(t *testing.T) {
+	root := newTestRoot()
+	registerUserCommands(root, []lib.Command{
+		{Name: "patch", Args: []lib.Arg{
+			{Name: "ticket", Required: true},
+			{Name: "comment"},
+		}},
+	})
+	for _, c := range root.Commands() {
+		if c.Name() == "patch" {
+			if want := "patch <ticket> [comment]"; c.Use != want {
+				t.Errorf("Use = %q, want %q", c.Use, want)
+			}
+			return
+		}
+	}
+	t.Fatal("patch command not registered")
+}
+
 func TestApplyConfigFlag_shortFlagWithEquals(t *testing.T) {
 	old := *raid.ConfigPath
 	*raid.ConfigPath = ""

--- a/src/internal/lib/command.go
+++ b/src/internal/lib/command.go
@@ -14,8 +14,33 @@ import (
 type Command struct {
 	Name  string   `json:"name"`
 	Usage string   `json:"usage"`
+	Args  []Arg    `json:"args,omitempty"`
+	Flags []Flag   `json:"flags,omitempty"`
 	Tasks []Task   `json:"tasks"`
 	Out   *Output  `json:"out,omitempty"`
+}
+
+// Arg declares a positional argument for a custom command. The supplied value
+// is bound to the env var named after Name (uppercased) for the duration of
+// the command, so tasks can reference it as `$NAME`. Required args without a
+// matching positional value cause cobra to reject the invocation.
+type Arg struct {
+	Name     string `json:"name"`
+	Usage    string `json:"usage,omitempty"`
+	Required bool   `json:"required,omitempty"`
+}
+
+// Flag declares a long-form (--name) and optional short-form (-x) flag for a
+// custom command. Type is one of "string" (default), "bool", or "int".
+// Required flags are enforced by cobra. Default supplies the value when the
+// flag is omitted; bool flags default to false unless overridden.
+type Flag struct {
+	Name     string `json:"name"`
+	Short    string `json:"short,omitempty"`
+	Usage    string `json:"usage,omitempty"`
+	Type     string `json:"type,omitempty"`
+	Required bool   `json:"required,omitempty"`
+	Default  any    `json:"default,omitempty"`
 }
 
 // Output configures how a command's task output is handled.
@@ -49,9 +74,11 @@ func GetRepos() []Repo {
 }
 
 // ExecuteCommand runs the tasks for the named command, applying any output configuration.
-// Args are exposed as RAID_ARG_1, RAID_ARG_2, ... environment variables for the duration
-// of the command and are unset afterwards.
-func ExecuteCommand(name string, args []string) error {
+// Positional `args` are exposed as RAID_ARG_1, RAID_ARG_2, ... environment
+// variables. When `named` is non-nil, each entry is also exported as a env
+// var with the key uppercased — this is how cobra-parsed named arguments and
+// flags reach task scripts. All bindings are unset after the command exits.
+func ExecuteCommand(name string, args []string, named map[string]string) error {
 	var found Command
 	for _, cmd := range GetCommands() {
 		if cmd.Name == name {
@@ -63,11 +90,8 @@ func ExecuteCommand(name string, args []string) error {
 		return fmt.Errorf("command '%s' not found", name)
 	}
 
-	clearRaidArgs()
-	defer clearRaidArgs()
-	for i, arg := range args {
-		os.Setenv(fmt.Sprintf("RAID_ARG_%d", i+1), arg)
-	}
+	cleanup := setCommandArgs(args, named)
+	defer cleanup()
 
 	startSession()
 	defer endSession()
@@ -79,7 +103,8 @@ func ExecuteCommand(name string, args []string) error {
 }
 
 // ExecuteRepoCommand runs a command defined in a specific repository's raid.yaml.
-func ExecuteRepoCommand(repoName, cmdName string, args []string) error {
+// See ExecuteCommand for how `args` and `named` are bound to env vars.
+func ExecuteRepoCommand(repoName, cmdName string, args []string, named map[string]string) error {
 	repos := GetRepos()
 	var repo *Repo
 	for i := range repos {
@@ -103,11 +128,8 @@ func ExecuteRepoCommand(repoName, cmdName string, args []string) error {
 		return fmt.Errorf("command '%s' not found in repository '%s'", cmdName, repoName)
 	}
 
-	clearRaidArgs()
-	defer clearRaidArgs()
-	for i, arg := range args {
-		os.Setenv(fmt.Sprintf("RAID_ARG_%d", i+1), arg)
-	}
+	cleanup := setCommandArgs(args, named)
+	defer cleanup()
 
 	startSession()
 	defer endSession()
@@ -117,6 +139,29 @@ func ExecuteRepoCommand(repoName, cmdName string, args []string) error {
 	err := runCommand(found)
 	RecordRecentEnd(recentName, err, startedAt)
 	return err
+}
+
+// setCommandArgs binds positional args to RAID_ARG_N and named args/flags to
+// uppercased env vars for the lifetime of a command run. Returns a cleanup
+// closure that unsets every env var we touched, including the named ones,
+// so a second invocation doesn't see stale state from the first.
+func setCommandArgs(args []string, named map[string]string) func() {
+	clearRaidArgs()
+	for i, arg := range args {
+		os.Setenv(fmt.Sprintf("RAID_ARG_%d", i+1), arg)
+	}
+	touched := make([]string, 0, len(named))
+	for k, v := range named {
+		key := strings.ToUpper(k)
+		os.Setenv(key, v)
+		touched = append(touched, key)
+	}
+	return func() {
+		clearRaidArgs()
+		for _, k := range touched {
+			os.Unsetenv(k)
+		}
+	}
 }
 
 // clearRaidArgs unsets all RAID_ARG_* environment variables.

--- a/src/internal/lib/command.go
+++ b/src/internal/lib/command.go
@@ -142,26 +142,70 @@ func ExecuteRepoCommand(repoName, cmdName string, args []string, named map[strin
 }
 
 // setCommandArgs binds positional args to RAID_ARG_N and named args/flags to
-// uppercased env vars for the lifetime of a command run. Returns a cleanup
-// closure that unsets every env var we touched, including the named ones,
-// so a second invocation doesn't see stale state from the first.
+// sanitised, uppercased env vars for the lifetime of a command run. Returns
+// a cleanup closure that restores any pre-existing values raid overwrote
+// (or unsets entries that didn't exist) so a command declaring e.g.
+// `name: PATH` doesn't permanently clobber the parent process's PATH.
+//
+// Names are normalised via sanitizeEnvName: lowercase → uppercase, anything
+// outside [A-Za-z0-9_] becomes '_'. Names that sanitise to a non-identifier
+// (empty / all-underscores) are skipped — the schema rejects these
+// up-front via the `pattern` constraint, this is defence-in-depth for
+// callers that construct lib.Command directly (tests, future MCP hooks).
 func setCommandArgs(args []string, named map[string]string) func() {
 	clearRaidArgs()
 	for i, arg := range args {
 		os.Setenv(fmt.Sprintf("RAID_ARG_%d", i+1), arg)
 	}
-	touched := make([]string, 0, len(named))
+	type prev struct {
+		key      string
+		oldValue string
+		hadValue bool
+	}
+	snapshots := make([]prev, 0, len(named))
 	for k, v := range named {
-		key := strings.ToUpper(k)
+		key := sanitizeEnvName(k)
+		if key == "" {
+			continue
+		}
+		old, had := os.LookupEnv(key)
+		snapshots = append(snapshots, prev{key, old, had})
 		os.Setenv(key, v)
-		touched = append(touched, key)
 	}
 	return func() {
 		clearRaidArgs()
-		for _, k := range touched {
-			os.Unsetenv(k)
+		for _, p := range snapshots {
+			if p.hadValue {
+				os.Setenv(p.key, p.oldValue)
+			} else {
+				os.Unsetenv(p.key)
+			}
 		}
 	}
+}
+
+// sanitizeEnvName normalises an arg/flag name to a valid env var identifier.
+// Mirrors sanitizeRepoVarName so RAID_REPO_* and command-arg/flag names use
+// the same scheme. Returns "" for inputs that produce only underscores
+// (which would expand to a meaningless empty/underscore env var).
+func sanitizeEnvName(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r - ('a' - 'A'))
+		case (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+	out := b.String()
+	if strings.Trim(out, "_") == "" {
+		return ""
+	}
+	return out
 }
 
 // clearRaidArgs unsets all RAID_ARG_* environment variables.

--- a/src/internal/lib/command_test.go
+++ b/src/internal/lib/command_test.go
@@ -194,6 +194,107 @@ func TestExecuteCommand_staleArgsCleared(t *testing.T) {
 	}
 }
 
+func TestSanitizeEnvName(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"ticket", "TICKET"},
+		{"dry-run", "DRY_RUN"},
+		{"foo.bar", "FOO_BAR"},
+		{"already_VALID", "ALREADY_VALID"},
+		{"with spaces", "WITH_SPACES"},
+		{"123abc", "123ABC"}, // permissive — schema is the primary gate
+		{"", ""},
+		{"___", ""}, // all-underscore sanitises to empty (rejected)
+		{"!@#", ""}, // only non-identifier characters
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := sanitizeEnvName(tt.in); got != tt.want {
+				t.Errorf("sanitizeEnvName(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExecuteCommand_namedBindings_restoresPreviousEnv(t *testing.T) {
+	setupTestConfig(t)
+	origOut, origErr := commandStdout, commandStderr
+	commandStdout, commandStderr = io.Discard, io.Discard
+	t.Cleanup(func() { commandStdout = origOut; commandStderr = origErr })
+
+	// Deliberately collide with a name a real user might declare ("PATH"-like
+	// scenarios). The cleanup must restore the original value, not leave the
+	// process with an unset / stale env after the command exits.
+	const key = "RAID_NAMED_TEST_KEY"
+	t.Setenv(key, "original")
+
+	context = &Context{
+		Profile: Profile{
+			Commands: []Command{{Name: "noop", Tasks: []Task{}}},
+		},
+	}
+
+	if err := ExecuteCommand("noop", nil, map[string]string{key: "overwritten"}); err != nil {
+		t.Fatalf("ExecuteCommand: %v", err)
+	}
+
+	if got := os.Getenv(key); got != "original" {
+		t.Errorf("env after exec = %q, want \"original\" (cleanup must restore)", got)
+	}
+}
+
+func TestExecuteCommand_namedBindings_unsetsAddedKeys(t *testing.T) {
+	setupTestConfig(t)
+	origOut, origErr := commandStdout, commandStderr
+	commandStdout, commandStderr = io.Discard, io.Discard
+	t.Cleanup(func() { commandStdout = origOut; commandStderr = origErr })
+
+	// Key must NOT exist in env at start so cleanup can verify the unset path.
+	const key = "RAID_NAMED_UNSET_TEST"
+	os.Unsetenv(key)
+	t.Cleanup(func() { os.Unsetenv(key) })
+
+	context = &Context{
+		Profile: Profile{
+			Commands: []Command{{Name: "noop", Tasks: []Task{}}},
+		},
+	}
+
+	if err := ExecuteCommand("noop", nil, map[string]string{key: "value"}); err != nil {
+		t.Fatalf("ExecuteCommand: %v", err)
+	}
+
+	if _, set := os.LookupEnv(key); set {
+		t.Errorf("env still set after exec, want unset (had no prior value)")
+	}
+}
+
+func TestExecuteCommand_namedBindings_skipsInvalidKeys(t *testing.T) {
+	setupTestConfig(t)
+	origOut, origErr := commandStdout, commandStderr
+	commandStdout, commandStderr = io.Discard, io.Discard
+	t.Cleanup(func() { commandStdout = origOut; commandStderr = origErr })
+
+	context = &Context{
+		Profile: Profile{
+			Commands: []Command{{Name: "noop", Tasks: []Task{}}},
+		},
+	}
+
+	// Empty keys and all-underscore keys must not call os.Setenv (which would
+	// either error on the empty key or set a useless `_=value`).
+	if err := ExecuteCommand("noop", nil, map[string]string{
+		"":    "skipme",
+		"___": "skipme",
+	}); err != nil {
+		t.Fatalf("ExecuteCommand: %v", err)
+	}
+	if got := os.Getenv("___"); got != "" {
+		t.Errorf("invalid key was set: %q", got)
+	}
+}
+
 func TestExecuteCommand_namedBindings(t *testing.T) {
 	setupTestConfig(t)
 	origOut, origErr := commandStdout, commandStderr

--- a/src/internal/lib/command_test.go
+++ b/src/internal/lib/command_test.go
@@ -70,7 +70,7 @@ func TestExecuteCommand_notFound(t *testing.T) {
 		},
 	}
 
-	if err := ExecuteCommand("nonexistent", nil); err == nil {
+	if err := ExecuteCommand("nonexistent", nil, nil); err == nil {
 		t.Fatal("ExecuteCommand() expected error for unknown command, got nil")
 	}
 }
@@ -87,7 +87,7 @@ func TestExecuteCommand_success(t *testing.T) {
 		},
 	}
 
-	if err := ExecuteCommand("noop", nil); err != nil {
+	if err := ExecuteCommand("noop", nil, nil); err != nil {
 		t.Errorf("ExecuteCommand() error: %v", err)
 	}
 }
@@ -100,7 +100,7 @@ func TestExecuteCommand_taskFailure(t *testing.T) {
 		},
 	}
 
-	if err := ExecuteCommand("fail", nil); err == nil {
+	if err := ExecuteCommand("fail", nil, nil); err == nil {
 		t.Fatal("ExecuteCommand() expected error from failing task, got nil")
 	}
 }
@@ -126,7 +126,7 @@ func TestExecuteCommand_argsSetAsEnvVars(t *testing.T) {
 		},
 	}
 
-	if err := ExecuteCommand("capture", []string{"foo", "bar"}); err != nil {
+	if err := ExecuteCommand("capture", []string{"foo", "bar"}, nil); err != nil {
 		t.Fatalf("ExecuteCommand() error: %v", err)
 	}
 
@@ -178,10 +178,10 @@ func TestExecuteCommand_staleArgsCleared(t *testing.T) {
 	}
 
 	// First call with two args, second call with one — RAID_ARG_2 must not bleed through.
-	if err := ExecuteCommand("capture", []string{"first", "stale"}); err != nil {
+	if err := ExecuteCommand("capture", []string{"first", "stale"}, nil); err != nil {
 		t.Fatalf("first ExecuteCommand() error: %v", err)
 	}
-	if err := ExecuteCommand("capture", []string{"second"}); err != nil {
+	if err := ExecuteCommand("capture", []string{"second"}, nil); err != nil {
 		t.Fatalf("second ExecuteCommand() error: %v", err)
 	}
 
@@ -191,6 +191,53 @@ func TestExecuteCommand_staleArgsCleared(t *testing.T) {
 	}
 	if got := string(data); got != "" {
 		t.Errorf("RAID_ARG_2 on second call = %q, want empty (stale value leaked)", got)
+	}
+}
+
+func TestExecuteCommand_namedBindings(t *testing.T) {
+	setupTestConfig(t)
+	origOut, origErr := commandStdout, commandStderr
+	commandStdout, commandStderr = io.Discard, io.Discard
+	t.Cleanup(func() { commandStdout = origOut; commandStderr = origErr })
+
+	dir := t.TempDir()
+	srcFile := filepath.Join(dir, "named.tmpl")
+	outFile := filepath.Join(dir, "named.txt")
+	if err := os.WriteFile(srcFile, []byte("$TICKET|$VERBOSE|$COUNT"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	context = &Context{
+		Profile: Profile{
+			Commands: []Command{{Name: "patch", Tasks: []Task{
+				{Type: Template, Src: srcFile, Dest: outFile},
+			}}},
+		},
+	}
+
+	named := map[string]string{
+		"TICKET":  "12345",
+		"verbose": "true", // lowercase here exercises the uppercase normalisation
+		"count":   "7",
+	}
+	if err := ExecuteCommand("patch", nil, named); err != nil {
+		t.Fatalf("ExecuteCommand() error: %v", err)
+	}
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if got, want := string(data), "12345|true|7"; got != want {
+		t.Errorf("named bindings during exec = %q, want %q", got, want)
+	}
+
+	// Bindings must be cleared after the command exits — second call without
+	// `named` must see empty values.
+	for _, k := range []string{"TICKET", "VERBOSE", "COUNT"} {
+		if got := os.Getenv(k); got != "" {
+			t.Errorf("%s after exec = %q, want cleared", k, got)
+		}
 	}
 }
 
@@ -205,7 +252,7 @@ func TestExecuteCommand_notFoundDoesNotSetArgs(t *testing.T) {
 		},
 	}
 
-	_ = ExecuteCommand("nonexistent", []string{"should-not-be-set"})
+	_ = ExecuteCommand("nonexistent", []string{"should-not-be-set"}, nil)
 	if got := os.Getenv("RAID_ARG_1"); got != "" {
 		t.Errorf("RAID_ARG_1 set to %q after not-found error, want empty", got)
 	}
@@ -415,7 +462,7 @@ func TestExecuteRepoCommand_repoNotFound(t *testing.T) {
 		},
 	}
 
-	err := ExecuteRepoCommand("nonexistent", "test", nil)
+	err := ExecuteRepoCommand("nonexistent", "test", nil, nil)
 	if err == nil {
 		t.Fatal("expected error for unknown repo, got nil")
 	}
@@ -435,7 +482,7 @@ func TestExecuteRepoCommand_cmdNotFound(t *testing.T) {
 		},
 	}
 
-	err := ExecuteRepoCommand("backend", "nonexistent", nil)
+	err := ExecuteRepoCommand("backend", "nonexistent", nil, nil)
 	if err == nil {
 		t.Fatal("expected error for unknown command, got nil")
 	}
@@ -459,7 +506,7 @@ func TestExecuteRepoCommand_success(t *testing.T) {
 		},
 	}
 
-	if err := ExecuteRepoCommand("backend", "noop", nil); err != nil {
+	if err := ExecuteRepoCommand("backend", "noop", nil, nil); err != nil {
 		t.Errorf("ExecuteRepoCommand() error: %v", err)
 	}
 }
@@ -475,7 +522,7 @@ func TestExecuteRepoCommand_taskFailure(t *testing.T) {
 		},
 	}
 
-	if err := ExecuteRepoCommand("backend", "fail", nil); err == nil {
+	if err := ExecuteRepoCommand("backend", "fail", nil, nil); err == nil {
 		t.Fatal("expected error from failing task, got nil")
 	}
 }
@@ -505,7 +552,7 @@ func TestExecuteRepoCommand_setsArgs(t *testing.T) {
 		},
 	}
 
-	if err := ExecuteRepoCommand("backend", "tmpl", []string{"hello", "world"}); err != nil {
+	if err := ExecuteRepoCommand("backend", "tmpl", []string{"hello", "world"}, nil); err != nil {
 		t.Fatalf("ExecuteRepoCommand() error: %v", err)
 	}
 	data, err := os.ReadFile(outFile)
@@ -522,7 +569,7 @@ func TestExecuteRepoCommand_nilContext(t *testing.T) {
 	context = nil
 	defer func() { context = old }()
 
-	if err := ExecuteRepoCommand("any", "any", nil); err == nil {
+	if err := ExecuteRepoCommand("any", "any", nil, nil); err == nil {
 		t.Fatal("expected error with nil context, got nil")
 	}
 }

--- a/src/internal/lib/profile_test.go
+++ b/src/internal/lib/profile_test.go
@@ -396,6 +396,138 @@ func TestValidateProfile_schemaViolation(t *testing.T) {
 	}
 }
 
+// TestValidateProfile_commandArgsAndFlags exercises the schema constraints on
+// the new command `args` / `flags` declarations: the name pattern, the
+// conditional default-type matching, and that valid declarations pass.
+func TestValidateProfile_commandArgsAndFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr bool
+	}{
+		{
+			name: "valid args and flags",
+			body: `name: t
+commands:
+  - name: patch
+    args:
+      - name: ticket
+        required: true
+    flags:
+      - name: host
+        type: string
+        default: "localhost"
+      - name: count
+        type: int
+        default: 3
+      - name: verbose
+        type: bool
+        default: false
+    tasks:
+      - type: Print
+        message: hi
+`,
+		},
+		{
+			name: "arg name with hyphen rejected",
+			body: `name: t
+commands:
+  - name: c
+    args:
+      - name: dry-run
+    tasks:
+      - type: Print
+        message: hi
+`,
+			wantErr: true,
+		},
+		{
+			name: "flag name starting with digit rejected",
+			body: `name: t
+commands:
+  - name: c
+    flags:
+      - name: 1invalid
+    tasks:
+      - type: Print
+        message: hi
+`,
+			wantErr: true,
+		},
+		{
+			name: "int flag with string default rejected",
+			body: `name: t
+commands:
+  - name: c
+    flags:
+      - name: count
+        type: int
+        default: "not a number"
+    tasks:
+      - type: Print
+        message: hi
+`,
+			wantErr: true,
+		},
+		{
+			name: "bool flag with string default rejected",
+			body: `name: t
+commands:
+  - name: c
+    flags:
+      - name: verbose
+        type: bool
+        default: "yes"
+    tasks:
+      - type: Print
+        message: hi
+`,
+			wantErr: true,
+		},
+		{
+			name: "string flag (default type) with bool default rejected",
+			body: `name: t
+commands:
+  - name: c
+    flags:
+      - name: host
+        default: true
+    tasks:
+      - type: Print
+        message: hi
+`,
+			wantErr: true,
+		},
+		{
+			name: "short longer than one char rejected",
+			body: `name: t
+commands:
+  - name: c
+    flags:
+      - name: host
+        short: "ho"
+    tasks:
+      - type: Print
+        message: hi
+`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "profile.yaml")
+			if err := os.WriteFile(path, []byte(tt.body), 0644); err != nil {
+				t.Fatalf("write profile: %v", err)
+			}
+			err := ValidateProfile(path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateProfile() err = %v, wantErr = %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 // TestValidateProfile_taskAcceptsSharedAndVariantFields verifies that the
 // allOf+taskCommon schema refactor still permits both shared task properties
 // (name, concurrent, condition) and variant-specific ones (cmd) on the same

--- a/src/internal/lib/session_test.go
+++ b/src/internal/lib/session_test.go
@@ -316,7 +316,7 @@ func TestShellSession_exportedVarFlowsToSetThenShell(t *testing.T) {
 		},
 	}
 
-	if err := ExecuteCommand("test", nil); err != nil {
+	if err := ExecuteCommand("test", nil, nil); err != nil {
 		t.Fatalf("ExecuteCommand error: %v", err)
 	}
 
@@ -356,7 +356,7 @@ func TestShellSession_earlyExitStillCapturesEnv(t *testing.T) {
 	commandStdout = &buf
 	t.Cleanup(func() { commandStdout = origOut })
 
-	if err := ExecuteCommand("early", nil); err != nil {
+	if err := ExecuteCommand("early", nil, nil); err != nil {
 		t.Fatalf("ExecuteCommand error: %v", err)
 	}
 	if got := strings.TrimSpace(buf.String()); got != "captured" {
@@ -385,7 +385,7 @@ func TestShellSession_setECapturesEnvBeforeFailure(t *testing.T) {
 	}
 
 	// The command fails (false exits 1), but BEFORE_FAIL must be captured.
-	_ = ExecuteCommand("sete", nil)
+	_ = ExecuteCommand("sete", nil, nil)
 
 	commandSession = &commandSessionStore{
 		vars:     map[string]string{},
@@ -429,7 +429,7 @@ func TestShellSession_shellLocalVarNotExpandedByRaid(t *testing.T) {
 		},
 	}
 
-	if err := ExecuteCommand("local", nil); err != nil {
+	if err := ExecuteCommand("local", nil, nil); err != nil {
 		t.Fatalf("ExecuteCommand error: %v", err)
 	}
 

--- a/src/raid/raid.go
+++ b/src/raid/raid.go
@@ -124,14 +124,17 @@ func QuietGetCommands() []lib.Command {
 	return lib.QuietLoad()
 }
 
-// ExecuteCommand runs the named command from the active profile.
-func ExecuteCommand(name string, args []string) error {
-	return lib.ExecuteCommand(name, args)
+// ExecuteCommand runs the named command from the active profile. `named`
+// carries values for declared args/flags; pass nil for the legacy
+// positional-only path.
+func ExecuteCommand(name string, args []string, named map[string]string) error {
+	return lib.ExecuteCommand(name, args, named)
 }
 
 // ExecuteRepoCommand runs a command defined in a specific repository's raid.yaml.
-func ExecuteRepoCommand(repoName, cmdName string, args []string) error {
-	return lib.ExecuteRepoCommand(repoName, cmdName, args)
+// See ExecuteCommand for `named`.
+func ExecuteRepoCommand(repoName, cmdName string, args []string, named map[string]string) error {
+	return lib.ExecuteRepoCommand(repoName, cmdName, args, named)
 }
 
 // Severity indicates the importance of a Doctor finding.

--- a/src/raid/raid_test.go
+++ b/src/raid/raid_test.go
@@ -169,7 +169,7 @@ func TestInstallRepo_noProfile(t *testing.T) {
 
 func TestExecuteCommand_noContext(t *testing.T) {
 	setupConfig(t)
-	err := ExecuteCommand("somecmd", nil)
+	err := ExecuteCommand("somecmd", nil, nil)
 	if err == nil {
 		t.Fatal("ExecuteCommand() expected error with no context, got nil")
 	}
@@ -183,7 +183,7 @@ func TestGetRepos_emptyState(t *testing.T) {
 
 func TestExecuteRepoCommand_noContext(t *testing.T) {
 	setupConfig(t)
-	err := ExecuteRepoCommand("repo", "cmd", nil)
+	err := ExecuteRepoCommand("repo", "cmd", nil, nil)
 	if err == nil {
 		t.Fatal("ExecuteRepoCommand() expected error with no context, got nil")
 	}

--- a/src/resources/app.properties
+++ b/src/resources/app.properties
@@ -1,2 +1,2 @@
-version=0.10.1-beta
+version=0.11.0-beta
 environment=development


### PR DESCRIPTION
## Summary

Resolves #26. Profile and repo `commands[]` entries can now declare named positional arguments and flags. Declared values are exported as env vars named after each entry's `name` (uppercased) for the duration of the command — so `args: [{name: ticket, required: true}]` makes `\$TICKET` available in tasks. Cobra enforces required values and positional cardinality before raid runs anything.

\`\`\`yaml
commands:
  - name: patch
    args:
      - name: ticket
        required: true
      - name: comment
    flags:
      - name: suv
        short: s
        required: true
      - name: verbose
        short: v
        type: bool
      - name: retries
        type: int
        default: 3
    tasks:
      - type: Print
        message: \"Patching \$TICKET on \$SUV (retries=\$RETRIES, verbose=\$VERBOSE)\"
\`\`\`

\`\`\`bash
raid patch --suv host.example.com -v 12345 \"rolling out the fix\"
\`\`\`

\`RAID_ARG_N\` continues to work for unnamed positional arguments — declarations are additive.

## Files

- \`schemas/raid-defs.schema.json\` — \`args\` and \`flags\` arrays on the command definition with full per-field validation (\`type\` enum, \`short\` length 1, \`default\` \`oneOf\` matching the type set).
- \`src/internal/lib/command.go\` — new \`Arg\` and \`Flag\` structs on \`Command\`; \`ExecuteCommand\` / \`ExecuteRepoCommand\` accept a \`named map[string]string\` and bind it to env vars (uppercased keys), with cleanup.
- \`src/cmd/raid.go\` — three new helpers (\`buildCommandUse\`, \`attachCommandArgsAndFlags\`, \`gatherCommandValues\`) used by \`registerUserCommands\` and \`registerRepoCommands\` to wire the cobra side: validator selection (\`ExactArgs\`/\`MaximumNArgs\`/\`RangeArgs\`), flag registration with type-aware defaults, \`MarkFlagRequired\`, and value gathering into the named map.
- \`src/raid/raid.go\`, \`src/cmd/context/serve.go\` — propagate the new \`named\` parameter; MCP \`raid_run_task\` passes \`nil\` (the MCP tool keeps positional-only semantics for now).
- Docs: \`site/docs/usage/custom.mdx\`, \`site/docs/references/schema.mdx\`, \`site/docs/whats-new.mdx\`.
- Version 0.10.1-beta → 0.11.0-beta.

## Test plan

- [x] \`go test ./...\` — all green.
- [x] Coverage on changed packages: \`src/cmd\` 97.6%, \`src/internal/lib\` 93.4%. All new statements in my diff range covered (verified via \`go tool cover\`).
- [x] New tests:
  - \`TestExecuteCommand_namedBindings\` — named map → env vars during exec, cleared after; uppercase normalisation.
  - \`TestBuildCommandUse\` — positional args render as \`<required>\` / \`[optional]\` in cobra Use.
  - \`TestAttachCommandArgsAndFlags_argValidatorCardinality\` — table-driven, 9 cases covering all-required / all-optional / mixed at min / max / above-max.
  - \`TestAttachCommandArgsAndFlags_flagDefaultsAndTypes\` — string / bool / int defaults, including the YAML-via-interface{} float64 → int coercion path.
  - \`TestAttachCommandArgsAndFlags_requiredFlag\` — cobra rejects missing required flag.
  - \`TestGatherCommandValues_*\` — nil when nothing declared, full bind round-trip, optional arg omitted ⇒ key absent, bool-absent ⇒ \"false\".
  - \`TestRegisterUserCommands_useStringIncludesDeclaredArgs\` — end-to-end via the registration path.
- [x] \`cd site && npm run build\` — no broken links.

## Notes / out of scope

- MCP \`raid_run_task\` still accepts only positional \`args\`. Surfacing declared flags via MCP is a separate, smaller change.
- No grouping / aliases / repeated flags / list-typed flags — the declaration model is intentionally narrow for the first cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)