### PR TITLE
feat: publish JSON schemas at https://raidcli.dev/schema/v1/ (closes #48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Supported formats: `.yaml`, `.yml`, `.json`
 
 Example `my-project.raid.yaml`:
 ```yaml
-# yaml-language-server: $schema=https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-profile.schema.json
+# yaml-language-server: $schema=https://raidcli.dev/schema/v1/raid-profile.schema.json
 
 name: my-project
 
@@ -288,7 +288,7 @@ Multiple profiles can be defined in a single file using YAML document separators
 Individual repositories can carry their own `raid.yaml` at their root to define repo-specific environments and commands. These are merged with the profile configuration at load time. Committing this file to each repo is the primary way knowledge is shared — the command for running tests, applying patches, or starting a proxy lives here instead of in a wiki.
 
 ```yaml
-# yaml-language-server: $schema=https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-repo.schema.json
+# yaml-language-server: $schema=https://raidcli.dev/schema/v1/raid-repo.schema.json
 
 name: my-service
 branch: main

--- a/docs/examples/demo.raid.yaml
+++ b/docs/examples/demo.raid.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-profile.schema.json
+# yaml-language-server: $schema=https://raidcli.dev/schema/v1/raid-profile.schema.json
 
 # This is a raid profile definition for a fictional company called Acme. It defines two repositories (web and api) 
 # and a development environment with tasks to set up and run the projects.

--- a/docs/examples/example.raid.yaml
+++ b/docs/examples/example.raid.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=../../schemas/raid-profile.schema.json
+# yaml-language-server: $schema=https://raidcli.dev/schema/v1/raid-profile.schema.json
 
 name: raid
 repositories:

--- a/docs/examples/raid.yaml
+++ b/docs/examples/raid.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=../../schemas/raid-repo.schema.json
+# yaml-language-server: $schema=https://raidcli.dev/schema/v1/raid-repo.schema.json
 
 name: raid
 branch: main

--- a/llms.txt
+++ b/llms.txt
@@ -41,9 +41,9 @@ Raid is written in Go, distributed as a single self-contained binary, and publis
 
 ## Schemas
 
-- [Profile JSON Schema](https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-profile.schema.json): Validation schema for `*.raid.yaml` profile files
-- [Repository JSON Schema](https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-repo.schema.json): Validation schema for per-repo `raid.yaml` files
-- [Shared definitions schema](https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-defs.schema.json): Common type definitions referenced by both schemas
+- [Profile JSON Schema](https://raidcli.dev/schema/v1/raid-profile.schema.json): Validation schema for `*.raid.yaml` profile files (v1 — stable URL)
+- [Repository JSON Schema](https://raidcli.dev/schema/v1/raid-repo.schema.json): Validation schema for per-repo `raid.yaml` files (v1 — stable URL)
+- [Shared definitions schema](https://raidcli.dev/schema/v1/raid-defs.schema.json): Common type definitions referenced by both schemas (v1 — stable URL)
 - [SchemaStore catalog](https://www.schemastore.org/api/json/catalog.json): Published catalog entries — auto-discovered by VS Code, JetBrains, Neovim, and other editors using the schemastore catalog
 
 ## Examples

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,51 +1,59 @@
 # Raid Schema Specifications
 
-This directory contains JSON Schema definitions for Raid configuration files.
+This directory contains the JSON Schema definitions for Raid configuration files.
+It is the **single source of truth** for the schemas — files here are both:
+
+1. Embedded into the Go binary via `go:embed` (used at runtime to validate
+   profile and repo files), and
+2. Copied into `site/static/schema/v1/` by `site/plugins/copy-schemas.ts` at
+   docsite build time, so they are served at the canonical URLs:
+
+   - https://raidcli.dev/schema/v1/raid-defs.schema.json
+   - https://raidcli.dev/schema/v1/raid-profile.schema.json
+   - https://raidcli.dev/schema/v1/raid-repo.schema.json
 
 ## Schema Files
 
-- `raid-profile.schema.json` - Schema for raid profile configuration files
-- `raid-repo.schema.json` - Schema for individual repository configuration files
+- `raid-defs.schema.json` — Shared `$defs` (task types, environments,
+  commands, install). Referenced from the other two schemas.
+- `raid-profile.schema.json` — Profile file schema (`*.raid.yaml`).
+- `raid-repo.schema.json` — Per-repository schema (`raid.yaml`).
 
-## Schema Version
+## Versioning
 
-These schemas follow the **JSON Schema Draft 2020-12** specification and are compatible with the `github.com/santhosh-tekuri/jsonschema/v6` library (v6.0.2).
+The `/schema/v1/` path is a **public stability contract**.
 
-The `$schema` field is properly supported and the library fully validates against the JSON Schema Draft 2020-12 specification.
+- Additive changes (new optional fields, new task types, new enum values) are
+  allowed within v1.
+- Breaking changes (renaming or removing a field, tightening a `required` list,
+  removing an enum value, turning an optional field required) require a new
+  major version. Cut a `/schema/v2/` folder by freezing the current v1 files
+  alongside the source and evolving the source separately.
+- Bump the second position of `version` in `src/resources/app.properties` when
+  publishing a new major schema version.
+
+The `$id` fields are baked as absolute URLs so external validators resolve
+cross-references without depending on the retrieval URL. Internal validation
+(see `src/internal/lib/lib.go`) registers each embedded schema under its `$id`
+and compiles by URL — no network access at runtime.
+
+## Schema draft
+
+These schemas follow **JSON Schema Draft 2020-12** and are validated with
+[`github.com/santhosh-tekuri/jsonschema/v6`](https://github.com/santhosh-tekuri/jsonschema)
+(v6.0.2).
+
+## Supported file formats
+
+YAML (`.yaml`, `.yml`) and JSON (`.json`).
 
 ## Usage
 
-The schemas are used to validate YAML and JSON configuration files in the Raid CLI tool. The validation ensures that configuration files have the correct structure and required fields.
+Profile files are validated against `raid-profile.schema.json` by `raid profile
+add` and during config load. Repository `raid.yaml` files are validated against
+`raid-repo.schema.json` when a repo is loaded.
 
-### Supported File Formats
-
-- YAML files (`.yaml`, `.yml`)
-- JSON files (`.json`)
-
-### Validation
-
-Profile files are validated against `raid-profile.schema.json` when using the `raid profile add` command. The validation checks:
-
-- Required fields are present
-- Data types are correct
-- Structure matches the schema definition
-
-## Schema Structure
-
-### Raid Profile Schema
-
-A raid profile configuration must contain:
-
-- `name` (string, required) - The name of the raid profile
-- `repositories` (array, optional) - Array of repository configurations
-  - Each repository must have:
-    - `name` (string, required) - The name of the repository
-    - `path` (string, required) - The local path to the repository
-    - `url` (string, required) - The URL of the repository
-
-### Raid Repository Schema
-
-A repository configuration must contain:
-
-- `name` (string, required) - The name of the repository
-- `branch` (string, required) - The branch to checkout
+Editors that consult [SchemaStore](https://www.schemastore.org/) — VS Code +
+Red Hat YAML, JetBrains, Neovim `yaml-language-server`, Helix — auto-associate
+`*.raid.yaml` and `raid.yaml` with the published schemas, so the `# yaml-language-server`
+modeline is optional.

--- a/schemas/raid-defs.schema.json
+++ b/schemas/raid-defs.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "raid-defs.schema.json",
+    "$id": "https://raidcli.dev/schema/v1/raid-defs.schema.json",
     "title": "Raid Schema Definitions",
     "description": "Shared schema definitions for raid",
     "type": "object",

--- a/schemas/raid-profile.schema.json
+++ b/schemas/raid-profile.schema.json
@@ -1,6 +1,6 @@
-{ 
+{
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "raid-profile.schema.json",
+  "$id": "https://raidcli.dev/schema/v1/raid-profile.schema.json",
   "title": "Raid Profile Configuration",
   "description": "Configuration for one or more raid profiles.",
   "type": "object",
@@ -34,22 +34,21 @@
       "minItems": 1
     },
     "environments": {
-      "$ref": "raid-defs.schema.json#/properties/environments"
+      "$ref": "https://raidcli.dev/schema/v1/raid-defs.schema.json#/properties/environments"
     },
     "install": {
-      "$ref": "raid-defs.schema.json#/properties/install"
+      "$ref": "https://raidcli.dev/schema/v1/raid-defs.schema.json#/properties/install"
     },
     "task_groups": {
       "type": "object",
       "description": "Named reusable task sequences. Reference them in any task list with type: Group and ref: <name>.",
       "additionalProperties": {
-        "$ref": "raid-defs.schema.json#/properties/tasks"
+        "$ref": "https://raidcli.dev/schema/v1/raid-defs.schema.json#/properties/tasks"
       }
     },
     "commands": {
-      "$ref": "raid-defs.schema.json#/properties/commands"
+      "$ref": "https://raidcli.dev/schema/v1/raid-defs.schema.json#/properties/commands"
     }
   },
   "required": ["name"]
 }
-

--- a/schemas/raid-repo.schema.json
+++ b/schemas/raid-repo.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "raid-repo.schema.json",
+    "$id": "https://raidcli.dev/schema/v1/raid-repo.schema.json",
     "title": "Raid Repository Configuration",
     "description": "Configuration for a single repository.",
     "type": "object",
@@ -15,13 +15,13 @@
             "description": "The branch to checkout"
         },
         "environments": {
-            "$ref": "raid-defs.schema.json#/properties/environments"
+            "$ref": "https://raidcli.dev/schema/v1/raid-defs.schema.json#/properties/environments"
         },
         "install": {
-            "$ref": "raid-defs.schema.json#/properties/install"
+            "$ref": "https://raidcli.dev/schema/v1/raid-defs.schema.json#/properties/install"
         },
         "commands": {
-            "$ref": "raid-defs.schema.json#/properties/commands"
+            "$ref": "https://raidcli.dev/schema/v1/raid-defs.schema.json#/properties/commands"
         }
     },
     "required": ["name","branch"]

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -10,6 +10,9 @@
 raid
 .env
 
+# Schemas copied from /schemas by plugins/copy-schemas.ts at build time
+/static/schema/
+
 # Misc
 .DS_Store
 .env.local

--- a/site/docs/examples/new-developer.mdx
+++ b/site/docs/examples/new-developer.mdx
@@ -15,7 +15,7 @@ The team has three repositories — an API, a frontend, and a shared config libr
 The team commits this file to an internal `dev-environment` repo:
 
 ```yaml title="acme.raid.yaml"
-# yaml-language-server: $schema=https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-profile.schema.json
+# yaml-language-server: $schema=https://raidcli.dev/schema/v1/raid-profile.schema.json
 name: acme-platform
 
 repositories:
@@ -60,7 +60,7 @@ install:
 Each repo ships its own `raid.yaml` defining the commands and environment variables specific to that service:
 
 ```yaml title="~/dev/acme/api/raid.yaml"
-# yaml-language-server: $schema=https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-repo.schema.json
+# yaml-language-server: $schema=https://raidcli.dev/schema/v1/raid-repo.schema.json
 name: "api"
 branch: "main"
 
@@ -92,7 +92,7 @@ environments:
 ```
 
 ```yaml title="~/dev/acme/frontend/raid.yaml"
-# yaml-language-server: $schema=https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-repo.schema.json
+# yaml-language-server: $schema=https://raidcli.dev/schema/v1/raid-repo.schema.json
 name: "frontend"
 branch: "main"
 

--- a/site/docs/references/schema.mdx
+++ b/site/docs/references/schema.mdx
@@ -6,6 +6,31 @@ sidebar_position: 5
 
 Complete field reference for profile files and repository `raid.yaml` files.
 
+## Published JSON Schemas
+
+Raid publishes versioned JSON Schemas under a stable URL. Point your editor or
+agent at these to get autocomplete, validation, and inline docs:
+
+| File | Schema URL |
+|---|---|
+| `*.raid.yaml` profile files | `https://raidcli.dev/schema/v1/raid-profile.schema.json` |
+| Per-repo `raid.yaml` files | `https://raidcli.dev/schema/v1/raid-repo.schema.json` |
+| Shared `$defs` (referenced by the two above) | `https://raidcli.dev/schema/v1/raid-defs.schema.json` |
+
+The `/v1/` path is a stability contract — schemas under it are kept
+backwards-compatible. Breaking changes will publish to `/v2/`.
+
+Add a `# yaml-language-server` modeline to wire schema validation in your editor:
+
+```yaml
+# yaml-language-server: $schema=https://raidcli.dev/schema/v1/raid-profile.schema.json
+name: my-project
+```
+
+Editors that consult SchemaStore (VS Code + Red Hat YAML, JetBrains, Neovim
+with `yaml-language-server`, Helix, …) auto-associate `*.raid.yaml` and
+`raid.yaml` with the published schemas, so the modeline is optional.
+
 ---
 
 ## Profile file

--- a/site/docs/whats-new.mdx
+++ b/site/docs/whats-new.mdx
@@ -9,6 +9,10 @@ description: Feature-by-feature release notes for Raid.
 
 User-visible changes per release, latest first. For full commit history see the [GitHub releases page](https://github.com/8bitalex/raid/releases).
 
+## 0.11.1 — upcoming
+
+**Schemas published at a stable URL.** The profile, repo, and shared-defs JSON Schemas are now served at `https://raidcli.dev/schema/v1/raid-profile.schema.json`, `…/raid-repo.schema.json`, and `…/raid-defs.schema.json`. Generated profile and repo templates point at these URLs out of the box, so YAML LSPs and agents get autocomplete and inline validation against the canonical contract. The `/v1/` path is a stability promise — additive changes only; breaking changes will publish to `/v2/`. The docsite build copies `schemas/` into `static/schema/v1/`, so the canonical source remains the single Go-embedded copy. Closes [#48](https://github.com/8bitAlex/raid/issues/48).
+
 ## 0.11.0 — upcoming
 
 **Declared arguments and flags on custom commands.** `commands[]` entries now accept an `args` list (named positional arguments) and a `flags` list (long/short options with optional default and type — `string`, `bool`, or `int`). Declared values are exported as env vars named after each entry (uppercased), so `args: [{name: ticket, required: true}]` makes `$TICKET` available in tasks for the duration of the command. Cobra enforces required values and validates positional cardinality before raid runs anything. `RAID_ARG_N` continues to work for unnamed positional arguments. Closes [#26](https://github.com/8bitAlex/raid/issues/26).

--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -51,6 +51,7 @@ const config: Config = {
   ],
 
   plugins: [
+    require.resolve('./plugins/copy-schemas.ts'),
     [
       '@easyops-cn/docusaurus-search-local',
       {

--- a/site/plugins/copy-schemas.ts
+++ b/site/plugins/copy-schemas.ts
@@ -1,0 +1,27 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { LoadContext, Plugin } from '@docusaurus/types';
+
+// copy-schemas publishes the JSON schemas under static/schema/v1/.
+// The repo's schemas/ directory is the single source of truth (also embedded
+// into the Go binary). This plugin copies them into the static tree before
+// Docusaurus walks static/, so it serves them at
+// https://raidcli.dev/schema/v1/<name>.
+//
+// The /v1/ path is part of the public schema contract: schemas under that URL
+// must remain backwards compatible. Breaking changes get a new /v2/ path.
+const repoRoot = path.resolve(__dirname, '..', '..');
+const srcDir = path.join(repoRoot, 'schemas');
+const destDir = path.join(__dirname, '..', 'static', 'schema', 'v1');
+
+fs.mkdirSync(destDir, { recursive: true });
+for (const entry of fs.readdirSync(srcDir)) {
+  if (!entry.endsWith('.schema.json')) continue;
+  fs.copyFileSync(path.join(srcDir, entry), path.join(destDir, entry));
+}
+
+export default function copySchemasPlugin(_context: LoadContext): Plugin {
+  return {
+    name: 'copy-schemas',
+  };
+}

--- a/src/internal/lib/lib.go
+++ b/src/internal/lib/lib.go
@@ -547,10 +547,11 @@ func ValidateSchema(path string, schemaPath string) error {
 }
 
 // validateWithEmbeddedSchema validates path against a schema embedded in the binary.
-// schemaName must be the bare filename of a schema in the embedded schemas directory
-// (e.g. "raid-profile.schema.json"). All embedded schemas are registered so that
-// cross-schema $ref values resolve correctly.
-func validateWithEmbeddedSchema(path, schemaName string) error {
+// schemaID must be the canonical $id URL of an embedded schema
+// (e.g. "https://raidcli.dev/schema/v1/raid-profile.schema.json"). All embedded
+// schemas are registered under their $id so cross-schema $ref values resolve
+// correctly without any network access.
+func validateWithEmbeddedSchema(path, schemaID string) error {
 	path = sys.ExpandPath(path)
 	if path == "" || !sys.FileExists(path) {
 		return fmt.Errorf("file not found at %s", path)
@@ -562,20 +563,28 @@ func validateWithEmbeddedSchema(path, schemaName string) error {
 		return fmt.Errorf("failed to read embedded schemas: %w", err)
 	}
 	for _, entry := range entries {
-		data, err := schemas.FS.ReadFile(entry.Name())
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".json") {
+			continue
+		}
+		data, err := schemas.FS.ReadFile(name)
 		if err != nil {
-			return fmt.Errorf("failed to read embedded schema %s: %w", entry.Name(), err)
+			return fmt.Errorf("failed to read embedded schema %s: %w", name, err)
 		}
-		var doc any
+		var doc map[string]any
 		if err := json.Unmarshal(data, &doc); err != nil {
-			return fmt.Errorf("failed to parse embedded schema %s: %w", entry.Name(), err)
+			return fmt.Errorf("failed to parse embedded schema %s: %w", name, err)
 		}
-		if err := c.AddResource(entry.Name(), doc); err != nil {
-			return fmt.Errorf("failed to register embedded schema %s: %w", entry.Name(), err)
+		id, _ := doc["$id"].(string)
+		if id == "" {
+			return fmt.Errorf("embedded schema %s is missing $id", name)
+		}
+		if err := c.AddResource(id, doc); err != nil {
+			return fmt.Errorf("failed to register embedded schema %s: %w", name, err)
 		}
 	}
 
-	sch, err := c.Compile(schemaName)
+	sch, err := c.Compile(schemaID)
 	if err != nil {
 		return err
 	}

--- a/src/internal/lib/lib.go
+++ b/src/internal/lib/lib.go
@@ -564,7 +564,7 @@ func validateWithEmbeddedSchema(path, schemaID string) error {
 	}
 	for _, entry := range entries {
 		name := entry.Name()
-		if !strings.HasSuffix(name, ".json") {
+		if !strings.HasSuffix(name, ".schema.json") {
 			continue
 		}
 		data, err := schemas.FS.ReadFile(name)

--- a/src/internal/lib/lib_test.go
+++ b/src/internal/lib/lib_test.go
@@ -784,6 +784,28 @@ func TestValidateWithEmbeddedSchema_invalidProfile(t *testing.T) {
 	}
 }
 
+func TestValidateWithEmbeddedSchema_unknownSchemaID(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "profile.yaml")
+	os.WriteFile(path, []byte("name: test\n"), 0644)
+
+	err := validateWithEmbeddedSchema(path, "https://raidcli.dev/schema/v1/does-not-exist.schema.json")
+	if err == nil {
+		t.Fatal("validateWithEmbeddedSchema: expected error for unknown schema ID")
+	}
+}
+
+func TestValidateWithEmbeddedSchema_repoSchema(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "raid.yaml")
+	os.WriteFile(path, []byte("name: test\nbranch: main\n"), 0644)
+
+	err := validateWithEmbeddedSchema(path, "https://raidcli.dev/schema/v1/raid-repo.schema.json")
+	if err != nil {
+		t.Errorf("validateWithEmbeddedSchema repo: %v", err)
+	}
+}
+
 // --- validateFile multi-doc YAML ---
 
 func TestValidateSchema_multiDocYAML(t *testing.T) {

--- a/src/internal/lib/lib_test.go
+++ b/src/internal/lib/lib_test.go
@@ -749,14 +749,14 @@ func TestValidateSchema_invalidJSONArrayElement(t *testing.T) {
 // --- validateWithEmbeddedSchema ---
 
 func TestValidateWithEmbeddedSchema_missingFile(t *testing.T) {
-	err := validateWithEmbeddedSchema("/nonexistent/file.yaml", "raid-profile.schema.json")
+	err := validateWithEmbeddedSchema("/nonexistent/file.yaml", "https://raidcli.dev/schema/v1/raid-profile.schema.json")
 	if err == nil {
 		t.Fatal("validateWithEmbeddedSchema: expected error for missing file")
 	}
 }
 
 func TestValidateWithEmbeddedSchema_emptyPath(t *testing.T) {
-	err := validateWithEmbeddedSchema("", "raid-profile.schema.json")
+	err := validateWithEmbeddedSchema("", "https://raidcli.dev/schema/v1/raid-profile.schema.json")
 	if err == nil {
 		t.Fatal("validateWithEmbeddedSchema: expected error for empty path")
 	}
@@ -767,7 +767,7 @@ func TestValidateWithEmbeddedSchema_validProfile(t *testing.T) {
 	path := filepath.Join(dir, "profile.yaml")
 	os.WriteFile(path, []byte("name: test\n"), 0644)
 
-	err := validateWithEmbeddedSchema(path, "raid-profile.schema.json")
+	err := validateWithEmbeddedSchema(path, "https://raidcli.dev/schema/v1/raid-profile.schema.json")
 	if err != nil {
 		t.Errorf("validateWithEmbeddedSchema valid: %v", err)
 	}
@@ -778,7 +778,7 @@ func TestValidateWithEmbeddedSchema_invalidProfile(t *testing.T) {
 	path := filepath.Join(dir, "bad.yaml")
 	os.WriteFile(path, []byte("notaname: test\nextra: bad\n"), 0644)
 
-	err := validateWithEmbeddedSchema(path, "raid-profile.schema.json")
+	err := validateWithEmbeddedSchema(path, "https://raidcli.dev/schema/v1/raid-profile.schema.json")
 	if err == nil {
 		t.Fatal("validateWithEmbeddedSchema: expected error for invalid profile")
 	}

--- a/src/internal/lib/profile.go
+++ b/src/internal/lib/profile.go
@@ -15,9 +15,9 @@ import (
 )
 
 const (
-	activeProfileKey  = "profile"
-	allProfilesKey    = "profiles"
-	profileSchemaPath = "https://raidcli.dev/schema/v1/raid-profile.schema.json"
+	activeProfileKey = "profile"
+	allProfilesKey   = "profiles"
+	profileSchemaID  = "https://raidcli.dev/schema/v1/raid-profile.schema.json"
 )
 
 // Profile represents a named collection of repositories, environments, and task groups.
@@ -219,7 +219,7 @@ func ContainsProfile(name string) bool {
 
 // ValidateProfile validates the profile file at path against the profile JSON schema.
 func ValidateProfile(path string) error {
-	return validateWithEmbeddedSchema(path, profileSchemaPath)
+	return validateWithEmbeddedSchema(path, profileSchemaID)
 }
 
 // ProfileDraft is the minimal structure written to a new profile file.

--- a/src/internal/lib/profile.go
+++ b/src/internal/lib/profile.go
@@ -17,7 +17,7 @@ import (
 const (
 	activeProfileKey  = "profile"
 	allProfilesKey    = "profiles"
-	profileSchemaPath = "raid-profile.schema.json"
+	profileSchemaPath = "https://raidcli.dev/schema/v1/raid-profile.schema.json"
 )
 
 // Profile represents a named collection of repositories, environments, and task groups.

--- a/src/internal/lib/repo.go
+++ b/src/internal/lib/repo.go
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const repoSchemaPath = "https://raidcli.dev/schema/v1/raid-repo.schema.json"
+const repoSchemaID = "https://raidcli.dev/schema/v1/raid-repo.schema.json"
 
 // Repo represents a single repository entry in a profile.
 type Repo struct {
@@ -137,7 +137,7 @@ func clone(path string, url string, branch string) error {
 
 // ValidateRepo validates the repo config file at path against the repo JSON schema.
 func ValidateRepo(path string) error {
-	return validateWithEmbeddedSchema(path, repoSchemaPath)
+	return validateWithEmbeddedSchema(path, repoSchemaID)
 }
 
 // ExtractRepo reads and parses the raid.yaml from the given repository directory.

--- a/src/internal/lib/repo.go
+++ b/src/internal/lib/repo.go
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const repoSchemaPath = "raid-repo.schema.json"
+const repoSchemaPath = "https://raidcli.dev/schema/v1/raid-repo.schema.json"
 
 // Repo represents a single repository entry in a profile.
 type Repo struct {

--- a/src/internal/lib/schemas_published_test.go
+++ b/src/internal/lib/schemas_published_test.go
@@ -1,0 +1,170 @@
+package lib
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/8bitalex/raid/schemas"
+)
+
+// publishedSchemaBaseURL is the canonical, stable URL prefix under which the
+// schemas are published. The /v1/ segment is a public contract: breaking
+// changes must publish to a new /v2/ path. See schemas/README.md.
+const publishedSchemaBaseURL = "https://raidcli.dev/schema/v1/"
+
+// TestEmbeddedSchemas_haveCanonicalID asserts that every embedded schema has a
+// $id under the published URL prefix. Catches accidental local-only $ids that
+// would leave external validators unable to resolve cross-references.
+func TestEmbeddedSchemas_haveCanonicalID(t *testing.T) {
+	entries, err := schemas.FS.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read embedded schemas: %v", err)
+	}
+	found := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".schema.json") {
+			continue
+		}
+		found++
+		data, err := schemas.FS.ReadFile(name)
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		var doc map[string]any
+		if err := json.Unmarshal(data, &doc); err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		id, _ := doc["$id"].(string)
+		want := publishedSchemaBaseURL + name
+		if id != want {
+			t.Errorf("%s: $id = %q, want %q", name, id, want)
+		}
+	}
+	if found == 0 {
+		t.Fatal("no embedded schemas found")
+	}
+}
+
+// TestPublishedSchemas_matchEmbedded asserts that if the docsite plugin has
+// copied schemas into site/static/schema/v1/, those files byte-equal the
+// embedded source. Catches drift between the canonical source and the
+// published copy. Skipped when the static directory is absent (e.g. before a
+// docs build has run locally).
+func TestPublishedSchemas_matchEmbedded(t *testing.T) {
+	root := repoRoot(t)
+	publishedDir := filepath.Join(root, "site", "static", "schema", "v1")
+	info, err := os.Stat(publishedDir)
+	if err != nil || !info.IsDir() {
+		t.Skipf("published schema dir not present (%s) — run docs build to generate", publishedDir)
+	}
+
+	entries, err := schemas.FS.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read embedded schemas: %v", err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".schema.json") {
+			continue
+		}
+		embedded, err := schemas.FS.ReadFile(name)
+		if err != nil {
+			t.Fatalf("read embedded %s: %v", name, err)
+		}
+		published, err := os.ReadFile(filepath.Join(publishedDir, name))
+		if err != nil {
+			t.Errorf("read published %s: %v", name, err)
+			continue
+		}
+		if string(embedded) != string(published) {
+			t.Errorf("%s: published copy differs from embedded source (rerun `npm run build` in site/)", name)
+		}
+	}
+}
+
+// TestEmbeddedTemplates_validateAgainstSchemas asserts that the profile and
+// repo template files (rendered into a minimal valid form) validate against
+// the embedded schemas. This guards against template/schema drift: if a
+// future template adds a field that the schema doesn't permit, this test
+// fails before users see it.
+func TestEmbeddedTemplates_validateAgainstSchemas(t *testing.T) {
+	root := repoRoot(t)
+
+	tests := []struct {
+		name        string
+		template    string
+		fill        string
+		schemaID    string
+		wantInvalid bool
+	}{
+		{
+			name:     "profile-template",
+			template: filepath.Join(root, "src/resources/profile-template"),
+			// Templates ship with all data commented out. Append a minimal
+			// schema-valid body so we exercise the rendered shape end-to-end.
+			fill:     "\nname: tmpl-test\n",
+			schemaID: "https://raidcli.dev/schema/v1/raid-profile.schema.json",
+		},
+		{
+			name:     "repo-template",
+			template: filepath.Join(root, "src/resources/repo-template"),
+			fill:     "\nname: tmpl-test\nbranch: main\n",
+			schemaID: "https://raidcli.dev/schema/v1/raid-repo.schema.json",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body, err := os.ReadFile(tc.template)
+			if err != nil {
+				t.Fatalf("read template: %v", err)
+			}
+			dir := t.TempDir()
+			path := filepath.Join(dir, "rendered.yaml")
+			if err := os.WriteFile(path, append(body, []byte(tc.fill)...), 0644); err != nil {
+				t.Fatalf("write rendered: %v", err)
+			}
+			if err := validateWithEmbeddedSchema(path, tc.schemaID); err != nil {
+				t.Errorf("%s: %v", tc.name, err)
+			}
+		})
+	}
+}
+
+// TestPublishedExamples_validateAgainstSchemas asserts that every committed
+// example under docs/examples/ validates against the appropriate schema.
+// These are user-facing references — keeping them schema-valid catches PRs
+// that break the example surface in lockstep with schema changes.
+func TestPublishedExamples_validateAgainstSchemas(t *testing.T) {
+	root := repoRoot(t)
+	examplesDir := filepath.Join(root, "docs", "examples")
+
+	cases := []struct {
+		file     string
+		schemaID string
+	}{
+		{"demo.raid.yaml", "https://raidcli.dev/schema/v1/raid-profile.schema.json"},
+		{"env-demo.raid.yaml", "https://raidcli.dev/schema/v1/raid-profile.schema.json"},
+		{"example.raid.yaml", "https://raidcli.dev/schema/v1/raid-profile.schema.json"},
+		{"install-demo.raid.yaml", "https://raidcli.dev/schema/v1/raid-profile.schema.json"},
+		{"multiple-profiles.yaml", "https://raidcli.dev/schema/v1/raid-profile.schema.json"},
+		{"multiple-profiles.json", "https://raidcli.dev/schema/v1/raid-profile.schema.json"},
+		{"raid.yaml", "https://raidcli.dev/schema/v1/raid-repo.schema.json"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.file, func(t *testing.T) {
+			path := filepath.Join(examplesDir, c.file)
+			if _, err := os.Stat(path); err != nil {
+				t.Skipf("example missing: %v", err)
+			}
+			if err := validateWithEmbeddedSchema(path, c.schemaID); err != nil {
+				t.Errorf("%s: %v", c.file, err)
+			}
+		})
+	}
+}

--- a/src/internal/lib/schemas_published_test.go
+++ b/src/internal/lib/schemas_published_test.go
@@ -95,11 +95,10 @@ func TestEmbeddedTemplates_validateAgainstSchemas(t *testing.T) {
 	root := repoRoot(t)
 
 	tests := []struct {
-		name        string
-		template    string
-		fill        string
-		schemaID    string
-		wantInvalid bool
+		name     string
+		template string
+		fill     string
+		schemaID string
 	}{
 		{
 			name:     "profile-template",

--- a/src/resources/app.properties
+++ b/src/resources/app.properties
@@ -1,2 +1,2 @@
-version=0.11.0-beta
+version=0.11.1-beta
 environment=development

--- a/src/resources/profile-template
+++ b/src/resources/profile-template
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-profile.schema.json
+# yaml-language-server: $schema=https://raidcli.dev/schema/v1/raid-profile.schema.json
 #
 # Raid Profile
 # A raid profile defines a collection of repositories, shared environments,

--- a/src/resources/repo-template
+++ b/src/resources/repo-template
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/8bitalex/raid/main/schemas/raid-repo.schema.json
+# yaml-language-server: $schema=https://raidcli.dev/schema/v1/raid-repo.schema.json
 #
 # Raid Repository Configuration
 # A raid.yaml file lives in the root of a repository and defines per-repo


### PR DESCRIPTION
## Summary

- Publish the three JSON schemas under a stable, versioned URL: `https://raidcli.dev/schema/v1/raid-profile.schema.json`, `raid-repo.schema.json`, `raid-defs.schema.json`. The `/v1/` segment is a public stability contract (additive-only; breaking changes go to `/v2/`).
- New Docusaurus plugin `site/plugins/copy-schemas.ts` copies `schemas/*.schema.json` into `site/static/schema/v1/` at docsite build start — single source of truth stays in `schemas/`, no committed duplicates.
- Rewrite `$id` and cross-`$ref` values in the three schemas to absolute URLs. Internal Go validation (`validateWithEmbeddedSchema`) now registers each embedded schema under its `$id` and compiles by URL.
- Update generated profile / repo templates, README, llms.txt, schema reference doc, and example YAMLs to point at the new URLs.
- New Go tests in `src/internal/lib/schemas_published_test.go`:
  - every embedded schema's `$id` matches the v1 URL,
  - `site/static/schema/v1/` (when built) byte-equals embedded source,
  - profile / repo templates pass schema validation in their rendered form,
  - every `docs/examples/*.{yaml,json}` validates against the appropriate schema.
- Document the versioning rule in `schemas/README.md`; add a "Published JSON Schemas" section to `site/docs/references/schema.mdx`.
- Patch bump: `0.11.0-beta` → `0.11.1-beta`; entry under 0.11.1 in `site/docs/whats-new.mdx`.

Closes #48.

Follow-up (external, separate PR): update the [SchemaStore](https://github.com/SchemaStore/schemastore) catalog entries for `*.raid.yaml` / `raid.yaml` to point at the new `https://raidcli.dev/schema/v1/...` URLs.

## Test plan

- [x] `go test ./...` — all packages green, including the four new tests
- [x] `npm run build` in `site/` — clean, schemas land at `site/build/schema/v1/<name>.schema.json` with absolute `\$id`
- [x] Built binary smoke test: valid profile accepted; unknown field rejected with the new URL surfaced in the validation error (`'https://raidcli.dev/schema/v1/raid-profile.schema.json#'`)
- [ ] After merge + docs deploy: verify the three schemas are reachable at their canonical URLs and resolve cross-refs in an external validator (e.g. [json-schema.app](https://json-schema.app/))