### PR TITLE
feat: shared options block on every task type (closes #54)

### DIFF
--- a/schemas/raid-defs.schema.json
+++ b/schemas/raid-defs.schema.json
@@ -623,7 +623,7 @@
             "properties": {
                 "showExeTime": {
                     "type": "boolean",
-                    "description": "When true, print a dim line to stderr after the task (or command) completes showing the elapsed time, e.g. `→ task-name (1.2s)`.",
+                    "description": "When true, print a dim line to stderr after the task (or command) completes showing the elapsed time, e.g. `task-name complete in 1.2s`.",
                     "default": false
                 }
             },

--- a/schemas/raid-defs.schema.json
+++ b/schemas/raid-defs.schema.json
@@ -544,6 +544,9 @@
                     "tasks": {
                         "$ref": "#/properties/tasks"
                     },
+                    "options": {
+                        "$ref": "#/$defs/taskOptions"
+                    },
                     "out": {
                         "type": "object",
                         "description": "Output configuration for the command",
@@ -608,8 +611,23 @@
                         }
                     },
                     "additionalProperties": false
+                },
+                "options": {
+                    "$ref": "#/$defs/taskOptions"
                 }
             }
+        },
+        "taskOptions": {
+            "type": "object",
+            "description": "Shared task / command options. Compose cleanly across task types and on commands; omitting `options` (or any field within) leaves default behavior unchanged. Additional fields will be added in future releases.",
+            "properties": {
+                "showExeTime": {
+                    "type": "boolean",
+                    "description": "When true, print a dim line to stderr after the task (or command) completes showing the elapsed time, e.g. `→ task-name (1.2s)`.",
+                    "default": false
+                }
+            },
+            "additionalProperties": false
         }
     }
 }

--- a/site/docs/references/schema.mdx
+++ b/site/docs/references/schema.mdx
@@ -149,6 +149,7 @@ commands:
 | `args` | list | No | Declared positional arguments. See [Args](#command-args). |
 | `flags` | list | No | Declared flags / options. See [Flags](#command-flags). |
 | [`tasks`](#task) | list | Yes | Task sequence to run |
+| [`options`](#options) | object | No | Shared options block. Same shape as on tasks. Fires once per command — independent of per-task `options`. |
 | [`out`](#output) | object | No | Output configuration |
 
 Command names cannot shadow built-in names: `install`, `env`, `profile`, `doctor`.
@@ -236,6 +237,41 @@ All tasks share these common fields:
 | `name` | string | No | Human-readable label, surfaced in logs and agent output. Does not affect execution. |
 | `concurrent` | bool | No | Run in parallel with adjacent concurrent tasks |
 | [`condition`](#condition) | object | No | Conditions that must all pass for the task to run |
+| [`options`](#options) | object | No | Shared options block. Composes across every task type and is also accepted on commands. |
+
+### Options
+
+The `options:` block is shared by every task type and by user-defined commands. Omitting it (or any field within) leaves default behavior unchanged. New fields ship additively.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `showExeTime` | bool | `false` | When true, raid prints a dim line to stderr after the task (or command) completes: `→ <name> (1.2s)`. Fires for both success and failure. On a command this fires once for the whole command's elapsed time; on a task it fires for that single task. The two are independent — set both to time the command end-to-end *and* see per-task breakdowns. |
+
+```yaml
+commands:
+  - name: build
+    options:
+      showExeTime: true     # one final line after the whole command
+    tasks:
+      - type: Shell
+        name: server-build
+        cmd: swift build
+        options:
+          showExeTime: true # per-task line too
+      - type: Shell
+        name: client-install
+        cmd: npm install
+        options:
+          showExeTime: true
+```
+
+Output:
+
+```
+→ server-build (164.1s)
+→ client-install (0.9s)
+→ build (165.0s)
+```
 
 ### Condition
 

--- a/site/docs/references/schema.mdx
+++ b/site/docs/references/schema.mdx
@@ -245,7 +245,7 @@ The `options:` block is shared by every task type and by user-defined commands. 
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `showExeTime` | bool | `false` | When true, raid prints a dim line to stderr after the task (or command) completes: `→ <name> (1.2s)`. Fires for both success and failure. On a command this fires once for the whole command's elapsed time; on a task it fires for that single task. The two are independent — set both to time the command end-to-end *and* see per-task breakdowns. |
+| `showExeTime` | bool | `false` | When true, raid prints a dim line to stderr after the task (or command) completes: `<name> complete in 1.2s`. Fires for both success and failure. On a command this fires once for the whole command's elapsed time; on a task it fires for that single task. The two are independent — set both to time the command end-to-end *and* see per-task breakdowns. |
 
 ```yaml
 commands:
@@ -268,9 +268,9 @@ commands:
 Output:
 
 ```
-→ server-build (164.1s)
-→ client-install (0.9s)
-→ build (165.0s)
+server-build complete in 164.1s
+client-install complete in 0.9s
+build complete in 165.0s
 ```
 
 ### Condition

--- a/site/docs/whats-new.mdx
+++ b/site/docs/whats-new.mdx
@@ -11,7 +11,7 @@ User-visible changes per release, latest first. For full commit history see the 
 
 ## 0.14.0 — upcoming
 
-**Shared `options:` block on every task type.** A new `options:` block on the base task definition composes uniformly across every task type (and on user-defined commands) so cross-cutting fields don't have to be re-declared per type. The initial field, `showExeTime: bool`, prints a dim line to stderr after a task or command completes with the elapsed time: `→ task-name (1.2s)`. Omitting `options` (or any field within it) leaves current behavior unchanged, so the addition is fully backwards compatible. Additional fields (`quiet`, `timeout`, …) will ship additively. Closes [#54](https://github.com/8bitAlex/raid/issues/54).
+**Shared `options:` block on every task type.** A new `options:` block on the base task definition composes uniformly across every task type (and on user-defined commands) so cross-cutting fields don't have to be re-declared per type. The initial field, `showExeTime: bool`, prints a dim line to stderr after a task or command completes with the elapsed time: `task-name complete in 1.2s`. Omitting `options` (or any field within it) leaves current behavior unchanged, so the addition is fully backwards compatible. Additional fields (`quiet`, `timeout`, …) will ship additively. Closes [#54](https://github.com/8bitAlex/raid/issues/54).
 
 ## 0.13.0 — upcoming
 

--- a/site/docs/whats-new.mdx
+++ b/site/docs/whats-new.mdx
@@ -9,6 +9,10 @@ description: Feature-by-feature release notes for Raid.
 
 User-visible changes per release, latest first. For full commit history see the [GitHub releases page](https://github.com/8bitalex/raid/releases).
 
+## 0.14.0 — upcoming
+
+**Shared `options:` block on every task type.** A new `options:` block on the base task definition composes uniformly across every task type (and on user-defined commands) so cross-cutting fields don't have to be re-declared per type. The initial field, `showExeTime: bool`, prints a dim line to stderr after a task or command completes with the elapsed time: `→ task-name (1.2s)`. Omitting `options` (or any field within it) leaves current behavior unchanged, so the addition is fully backwards compatible. Additional fields (`quiet`, `timeout`, …) will ship additively. Closes [#54](https://github.com/8bitAlex/raid/issues/54).
+
 ## 0.13.0 — upcoming
 
 **Structured error output.** Every raid failure now carries a stable `code` (e.g. `PROFILE_NOT_FOUND`, `REPO_NOT_CLONED`, `CLONE_FAILED`, `TASK_SHELL_FAILED`), a category that maps directly to one of five exit codes (`1` generic / `2` config / `3` task / `4` network / `5` not-found), and an optional `hint` explaining what the user can do next. Pass `--json` to any command (including `raid install`, `raid profile add`, custom commands) and errors come back as a single line of `{"error": {"code": "...", "category": "...", "message": "...", "hint": "..."}}` — agents can pivot on the code instead of parsing prose. The `--json` flag itself moved from per-command to a persistent flag on `rootCmd`, so it now works on every command. Error codes are treated as semver-stable: new codes ship additively; existing codes never change name or category across minor versions. See the new [Errors reference](/docs/references/errors) for the full table and JSON shape. Closes [#47](https://github.com/8bitAlex/raid/issues/47).

--- a/src/internal/lib/command.go
+++ b/src/internal/lib/command.go
@@ -13,12 +13,13 @@ import (
 
 // Command is a named, user-defined CLI command that can be invoked via 'raid <name>'.
 type Command struct {
-	Name  string   `json:"name"`
-	Usage string   `json:"usage"`
-	Args  []Arg    `json:"args,omitempty"`
-	Flags []Flag   `json:"flags,omitempty"`
-	Tasks []Task   `json:"tasks"`
-	Out   *Output  `json:"out,omitempty"`
+	Name    string       `json:"name"`
+	Usage   string       `json:"usage"`
+	Args    []Arg        `json:"args,omitempty"`
+	Flags   []Flag       `json:"flags,omitempty"`
+	Tasks   []Task       `json:"tasks"`
+	Options *TaskOptions `json:"options,omitempty"`
+	Out     *Output      `json:"out,omitempty"`
 }
 
 // Arg declares a positional argument for a custom command. The supplied value
@@ -220,6 +221,23 @@ func clearRaidArgs() {
 }
 
 func runCommand(cmd Command) error {
+	// Command-level showExeTime is independent of per-task timing — both
+	// flags can be set together. The command line is emitted after the
+	// final task (and after any per-task lines) so the timeline reads
+	// top-down. Like the task variant, it fires for both success and
+	// failure so the elapsed time is always visible.
+	if cmd.Options != nil && cmd.Options.ShowExeTime {
+		start := timeNowFn()
+		err := runCommandTasks(cmd)
+		emitExeTime(cmd.Name, timeNowFn().Sub(start))
+		return err
+	}
+	return runCommandTasks(cmd)
+}
+
+// runCommandTasks applies the optional Out wrapping and runs the task
+// sequence. Split out so the showExeTime wrapper above stays focused.
+func runCommandTasks(cmd Command) error {
 	if cmd.Out == nil {
 		return ExecuteTasks(cmd.Tasks)
 	}

--- a/src/internal/lib/command.go
+++ b/src/internal/lib/command.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	liberrs "github.com/8bitalex/raid/src/internal/lib/errs"
 	"github.com/8bitalex/raid/src/internal/sys"
@@ -220,30 +221,44 @@ func clearRaidArgs() {
 	}
 }
 
+// runCommand applies the optional Out wrapping and runs the task
+// sequence. Command-level showExeTime is independent of per-task timing —
+// both flags can be set together. The command line is emitted after the
+// final task (and after any per-task lines) so the timeline reads
+// top-down. Like the task variant, it fires for both success and failure
+// so the elapsed time is always visible.
+//
+// The exe-time line is emitted *inside* the Out wrapping so it respects
+// `out.stderr: false` (suppression) and `out.file` (capture) the same way
+// task output does. Emitting it after the wrappers unwound would bypass
+// both, so we keep all emission ordered against the Out lifecycle here.
 func runCommand(cmd Command) error {
-	// Command-level showExeTime is independent of per-task timing — both
-	// flags can be set together. The command line is emitted after the
-	// final task (and after any per-task lines) so the timeline reads
-	// top-down. Like the task variant, it fires for both success and
-	// failure so the elapsed time is always visible.
-	if cmd.Options != nil && cmd.Options.ShowExeTime {
-		start := timeNowFn()
-		err := runCommandTasks(cmd)
-		emitExeTime(cmd.Name, timeNowFn().Sub(start))
-		return err
+	showExeTime := cmd.Options != nil && cmd.Options.ShowExeTime
+	var start time.Time
+	if showExeTime {
+		start = timeNowFn()
 	}
-	return runCommandTasks(cmd)
-}
 
-// runCommandTasks applies the optional Out wrapping and runs the task
-// sequence. Split out so the showExeTime wrapper above stays focused.
-func runCommandTasks(cmd Command) error {
 	if cmd.Out == nil {
-		return ExecuteTasks(cmd.Tasks)
+		err := ExecuteTasks(cmd.Tasks)
+		if showExeTime {
+			emitExeTime(cmd.Name, timeNowFn().Sub(start))
+		}
+		return err
 	}
 
 	origOut, origErr := commandStdout, commandStderr
+	var outFile *os.File
 	defer func() {
+		// Emit the exe-time line BEFORE the file is closed and the
+		// original writers are restored, so it lands in the same place
+		// as the task output (file capture, stderr suppression).
+		if showExeTime {
+			emitExeTime(cmd.Name, timeNowFn().Sub(start))
+		}
+		if outFile != nil {
+			outFile.Close()
+		}
 		commandStdout = origOut
 		commandStderr = origErr
 	}()
@@ -264,7 +279,7 @@ func runCommandTasks(cmd Command) error {
 		if err != nil {
 			return liberrs.Newf(liberrs.CodeTaskFailed, liberrs.CategoryTask, "failed to open output file '%s': %v", cmd.Out.File, err)
 		}
-		defer f.Close()
+		outFile = f
 		commandStdout = io.MultiWriter(commandStdout, f)
 		commandStderr = io.MultiWriter(commandStderr, f)
 	}

--- a/src/internal/lib/command_test.go
+++ b/src/internal/lib/command_test.go
@@ -326,6 +326,50 @@ func TestRunCommand_showExeTime_emitsLine(t *testing.T) {
 	}
 }
 
+func TestRunCommand_showExeTime_respectsOutSuppressionAndFile(t *testing.T) {
+	// When `out.stderr: false` and `out.file: ...` are both set, the
+	// exe-time line must (a) NOT appear on the original stderr, and
+	// (b) BE captured in the output file — same rules as task output.
+	origNow := timeNowFn
+	calls := 0
+	t0 := time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC)
+	timeNowFn = func() time.Time {
+		defer func() { calls++ }()
+		if calls == 0 {
+			return t0
+		}
+		return t0.Add(750 * time.Millisecond)
+	}
+	t.Cleanup(func() { timeNowFn = origNow })
+
+	var stderrBuf bytes.Buffer
+	restore := SetCommandOutput(io.Discard, &stderrBuf)
+	t.Cleanup(restore)
+
+	outFile := filepath.Join(t.TempDir(), "captured.txt")
+	cmd := Command{
+		Name:    "build",
+		Options: &TaskOptions{ShowExeTime: true},
+		Tasks:   []Task{{Type: Shell, Cmd: "exit 0"}},
+		Out:     &Output{Stdout: true, Stderr: false, File: outFile},
+	}
+	if err := runCommand(cmd); err != nil {
+		t.Fatalf("runCommand: %v", err)
+	}
+
+	if strings.Contains(stderrBuf.String(), "→ build") {
+		t.Errorf("exe-time line leaked to suppressed stderr: %q", stderrBuf.String())
+	}
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(data), "→ build (750ms)") {
+		t.Errorf("exe-time line missing from out.file capture: %q", string(data))
+	}
+}
+
 func TestRunCommand_showExeTime_off_byDefault(t *testing.T) {
 	var buf bytes.Buffer
 	restore := SetCommandOutput(io.Discard, &buf)

--- a/src/internal/lib/command_test.go
+++ b/src/internal/lib/command_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 // --- Command.IsZero ---
@@ -292,6 +293,50 @@ func TestExecuteCommand_namedBindings_skipsInvalidKeys(t *testing.T) {
 	}
 	if got := os.Getenv("___"); got != "" {
 		t.Errorf("invalid key was set: %q", got)
+	}
+}
+
+func TestRunCommand_showExeTime_emitsLine(t *testing.T) {
+	origNow := timeNowFn
+	calls := 0
+	t0 := time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC)
+	timeNowFn = func() time.Time {
+		defer func() { calls++ }()
+		if calls == 0 {
+			return t0
+		}
+		return t0.Add(750 * time.Millisecond)
+	}
+	t.Cleanup(func() { timeNowFn = origNow })
+
+	var buf bytes.Buffer
+	restore := SetCommandOutput(io.Discard, &buf)
+	t.Cleanup(restore)
+
+	cmd := Command{
+		Name:    "build",
+		Options: &TaskOptions{ShowExeTime: true},
+		Tasks:   []Task{{Type: Shell, Cmd: "exit 0"}},
+	}
+	if err := runCommand(cmd); err != nil {
+		t.Fatalf("runCommand: %v", err)
+	}
+	if !strings.Contains(buf.String(), "→ build (750ms)") {
+		t.Errorf("stderr %q should carry command-level exe-time line", buf.String())
+	}
+}
+
+func TestRunCommand_showExeTime_off_byDefault(t *testing.T) {
+	var buf bytes.Buffer
+	restore := SetCommandOutput(io.Discard, &buf)
+	t.Cleanup(restore)
+
+	cmd := Command{Name: "noop", Tasks: []Task{{Type: Shell, Cmd: "exit 0"}}}
+	if err := runCommand(cmd); err != nil {
+		t.Fatalf("runCommand: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("default runCommand must not emit on stderr, got %q", buf.String())
 	}
 }
 

--- a/src/internal/lib/command_test.go
+++ b/src/internal/lib/command_test.go
@@ -321,7 +321,7 @@ func TestRunCommand_showExeTime_emitsLine(t *testing.T) {
 	if err := runCommand(cmd); err != nil {
 		t.Fatalf("runCommand: %v", err)
 	}
-	if !strings.Contains(buf.String(), "→ build (750ms)") {
+	if !strings.Contains(buf.String(), "build complete in 750ms") {
 		t.Errorf("stderr %q should carry command-level exe-time line", buf.String())
 	}
 }

--- a/src/internal/lib/command_test.go
+++ b/src/internal/lib/command_test.go
@@ -357,7 +357,7 @@ func TestRunCommand_showExeTime_respectsOutSuppressionAndFile(t *testing.T) {
 		t.Fatalf("runCommand: %v", err)
 	}
 
-	if strings.Contains(stderrBuf.String(), "→ build") {
+	if strings.Contains(stderrBuf.String(), "build complete in") {
 		t.Errorf("exe-time line leaked to suppressed stderr: %q", stderrBuf.String())
 	}
 
@@ -365,7 +365,7 @@ func TestRunCommand_showExeTime_respectsOutSuppressionAndFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)
 	}
-	if !strings.Contains(string(data), "→ build (750ms)") {
+	if !strings.Contains(string(data), "build complete in 750ms") {
 		t.Errorf("exe-time line missing from out.file capture: %q", string(data))
 	}
 }

--- a/src/internal/lib/profile_test.go
+++ b/src/internal/lib/profile_test.go
@@ -552,6 +552,87 @@ install:
 	}
 }
 
+// TestValidateProfile_optionsAccepted_onEveryTaskType locks in the
+// taskCommon `options` block: every task variant must accept it so
+// schema authors don't have to re-declare per type. Also covers the
+// command-level options block.
+func TestValidateProfile_optionsAccepted_onEveryTaskType(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "profile.yaml")
+	body := `name: opts
+install:
+  tasks:
+    - type: Shell
+      cmd: 'true'
+      options: {showExeTime: true}
+    - type: Script
+      path: ./x.sh
+      options: {showExeTime: false}
+    - type: HTTP
+      url: 'https://example.com/a'
+      dest: /tmp/a
+      options: {showExeTime: true}
+    - type: Wait
+      url: 'https://example.com/ready'
+      options: {showExeTime: true}
+    - type: Template
+      src: ./t.tmpl
+      dest: /tmp/out
+      options: {showExeTime: true}
+    - type: Git
+      op: pull
+      options: {showExeTime: true}
+    - type: Prompt
+      var: NAME
+      options: {showExeTime: true}
+    - type: Confirm
+      message: ok?
+      options: {showExeTime: true}
+    - type: Print
+      message: hi
+      options: {showExeTime: true}
+    - type: Set
+      var: X
+      value: y
+      options: {showExeTime: true}
+commands:
+  - name: build
+    options: {showExeTime: true}
+    tasks:
+      - type: Shell
+        cmd: 'true'
+`
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	if err := ValidateProfile(path); err != nil {
+		t.Fatalf("ValidateProfile() unexpected error: %v", err)
+	}
+}
+
+func TestValidateProfile_optionsRejectsUnknownField(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "profile.yaml")
+	// `quiet` is reserved for a future option (#54 mentions it explicitly
+	// as out of scope). Until it lands, the schema must reject it so
+	// authors get a clear error instead of silent acceptance.
+	body := `name: t
+install:
+  tasks:
+    - type: Shell
+      cmd: 'true'
+      options:
+        showExeTime: true
+        quiet: true
+`
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	if err := ValidateProfile(path); err == nil {
+		t.Fatal("ValidateProfile() should reject unknown option fields")
+	}
+}
+
 // TestValidateProfile_taskRejectsUnknownField verifies that an unknown
 // property on a task is still rejected after the schema was refactored to use
 // allOf + unevaluatedProperties:false instead of additionalProperties:false on

--- a/src/internal/lib/task.go
+++ b/src/internal/lib/task.go
@@ -25,6 +25,30 @@ type TaskProps struct {
 	// Name is an optional human-readable label for the task, surfaced in logs
 	// and agent-facing output. It does not affect execution.
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+	// Options is the shared options block — see TaskOptions. Composes across
+	// every task type and is also accepted on user-defined commands. Omitting
+	// the block (or any field within) leaves default behavior unchanged.
+	Options *TaskOptions `json:"options,omitempty" yaml:"options,omitempty"`
+}
+
+// TaskOptions is the shared `options:` block applied uniformly across all
+// task types and to user-defined commands. New fields ship additively; old
+// fields keep their semantics across minor versions.
+type TaskOptions struct {
+	// ShowExeTime, when true, prints a dim "→ <label> (1.2s)" line to
+	// stderr after the task (or command) completes — for both success and
+	// failure, so the elapsed time is always visible.
+	ShowExeTime bool `json:"showExeTime,omitempty" yaml:"showExeTime,omitempty"`
+}
+
+// Label returns the human-readable identifier for a task: its `name:`
+// field when set, otherwise the task type. Used by showExeTime so a task
+// without a name still prints something meaningful (e.g. "Shell").
+func (t Task) Label() string {
+	if t.Name != "" {
+		return t.Name
+	}
+	return string(t.Type)
 }
 
 // Task represents a single unit of work in a task sequence.

--- a/src/internal/lib/task_runner.go
+++ b/src/internal/lib/task_runner.go
@@ -200,15 +200,15 @@ func dispatchTask(task Task) error {
 // sleeping.
 var timeNowFn = time.Now
 
-// emitExeTime writes the "→ <label> (Xs)" line to commandStderr using
-// dim-grey ANSI styling. Label falls back to the task type when no
+// emitExeTime writes the "<label> complete in <Xs>" line to commandStderr
+// using dim-grey ANSI styling. Label falls back to the task type when no
 // `name:` was given so the output is still recognisable.
 func emitExeTime(label string, d time.Duration) {
 	const (
 		dim   = "\033[2m"
 		reset = "\033[0m"
 	)
-	fmt.Fprintf(commandStderr, "%s→ %s (%s)%s\n", dim, label, formatExeDuration(d), reset)
+	fmt.Fprintf(commandStderr, "%s%s complete in %s%s\n", dim, label, formatExeDuration(d), reset)
 }
 
 // formatExeDuration renders a duration as a short, human-readable string

--- a/src/internal/lib/task_runner.go
+++ b/src/internal/lib/task_runner.go
@@ -151,6 +151,22 @@ func ExecuteTask(task Task) error {
 		return nil
 	}
 
+	// Wrap the per-type dispatch with showExeTime timing so the emitted
+	// line covers both happy and failure paths (the user still wants to
+	// know how long the task ran when it errors).
+	if task.Options != nil && task.Options.ShowExeTime {
+		start := timeNowFn()
+		err := dispatchTask(task)
+		emitExeTime(task.Label(), timeNowFn().Sub(start))
+		return err
+	}
+	return dispatchTask(task)
+}
+
+// dispatchTask is the inner switch separated from ExecuteTask so the
+// timing wrapper above stays readable and so tests can target it
+// directly when needed.
+func dispatchTask(task Task) error {
 	switch task.Type.ToLower() {
 	case Shell:
 		return execShell(task)
@@ -176,6 +192,37 @@ func ExecuteTask(task Task) error {
 		return execSetVar(task)
 	default:
 		return liberrs.Newf(liberrs.CodeTaskFailed, liberrs.CategoryTask, "invalid task type: %s", task.Type)
+	}
+}
+
+// timeNowFn is the time source used by the showExeTime wrapper. Tests
+// override it to assert deterministic elapsed-time output without
+// sleeping.
+var timeNowFn = time.Now
+
+// emitExeTime writes the "→ <label> (Xs)" line to commandStderr using
+// dim-grey ANSI styling. Label falls back to the task type when no
+// `name:` was given so the output is still recognisable.
+func emitExeTime(label string, d time.Duration) {
+	const (
+		dim   = "\033[2m"
+		reset = "\033[0m"
+	)
+	fmt.Fprintf(commandStderr, "%s→ %s (%s)%s\n", dim, label, formatExeDuration(d), reset)
+}
+
+// formatExeDuration renders a duration as a short, human-readable string
+// matching the recent-runs formatting in src/cmd/context.
+func formatExeDuration(d time.Duration) string {
+	switch {
+	case d < time.Second:
+		return fmt.Sprintf("%dms", d.Milliseconds())
+	case d < time.Minute:
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	case d < time.Hour:
+		return fmt.Sprintf("%dm%02ds", int(d.Minutes()), int(d.Seconds())%60)
+	default:
+		return fmt.Sprintf("%dh%02dm", int(d.Hours()), int(d.Minutes())%60)
 	}
 }
 

--- a/src/internal/lib/task_runner_test.go
+++ b/src/internal/lib/task_runner_test.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"bytes"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 // --- getShell ---
@@ -95,6 +97,130 @@ func TestGetShell_powershell(t *testing.T) {
 				t.Errorf("getShell(%q)[1] = %q, want \"-Command\"", input, got[1])
 			}
 		})
+	}
+}
+
+// --- showExeTime ---
+
+// withStubbedTime swaps the package time source so duration output is
+// deterministic across runs. The first call returns the t0 sentinel, the
+// second returns t0 + delta. Restored on cleanup.
+func withStubbedTime(t *testing.T, delta time.Duration) {
+	t.Helper()
+	orig := timeNowFn
+	calls := 0
+	t0 := time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC)
+	timeNowFn = func() time.Time {
+		defer func() { calls++ }()
+		if calls == 0 {
+			return t0
+		}
+		return t0.Add(delta)
+	}
+	t.Cleanup(func() { timeNowFn = orig })
+}
+
+// withCapturedStderr redirects commandStderr to the returned buffer and
+// restores it on cleanup so test assertions can match the dim "→ name
+// (Xs)" line emitted by showExeTime.
+func withCapturedStderr(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	restore := SetCommandOutput(io.Discard, &buf)
+	t.Cleanup(restore)
+	return &buf
+}
+
+func TestExecuteTask_showExeTime_emitsLine(t *testing.T) {
+	withStubbedTime(t, 1500*time.Millisecond)
+	buf := withCapturedStderr(t)
+
+	task := Task{
+		TaskProps: TaskProps{
+			Name:    "say-hi",
+			Options: &TaskOptions{ShowExeTime: true},
+		},
+		Type: Shell,
+		Cmd:  "exit 0",
+	}
+	if err := ExecuteTask(task); err != nil {
+		t.Fatalf("ExecuteTask: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "→ say-hi (1.5s)") {
+		t.Errorf("stderr %q missing '→ say-hi (1.5s)'", out)
+	}
+	if !strings.Contains(out, "\033[2m") || !strings.Contains(out, "\033[0m") {
+		t.Errorf("stderr %q missing dim ANSI styling", out)
+	}
+}
+
+func TestExecuteTask_showExeTime_fallsBackToTaskType(t *testing.T) {
+	withStubbedTime(t, 500*time.Millisecond)
+	buf := withCapturedStderr(t)
+
+	// No `name:` field — Label() falls back to the task type as-written.
+	// The Go constant `Shell` is lowercase ("shell"); a user writing
+	// `type: Shell` in YAML would see "Shell" here because Task.Type
+	// preserves the original case (ToLower() returns a normalized copy
+	// only for dispatch).
+	task := Task{
+		TaskProps: TaskProps{Options: &TaskOptions{ShowExeTime: true}},
+		Type:      Shell,
+		Cmd:       "exit 0",
+	}
+	_ = ExecuteTask(task)
+	if !strings.Contains(buf.String(), "→ shell (500ms)") {
+		t.Errorf("stderr %q missing '→ shell (500ms)'", buf.String())
+	}
+}
+
+func TestExecuteTask_showExeTime_firesOnFailureToo(t *testing.T) {
+	withStubbedTime(t, 2*time.Second)
+	buf := withCapturedStderr(t)
+
+	task := Task{
+		TaskProps: TaskProps{
+			Name:    "fails",
+			Options: &TaskOptions{ShowExeTime: true},
+		},
+		Type: Shell,
+		Cmd:  "exit 1",
+	}
+	if err := ExecuteTask(task); err == nil {
+		t.Fatal("expected error from `exit 1`")
+	}
+	if !strings.Contains(buf.String(), "→ fails (2.0s)") {
+		t.Errorf("stderr %q should still carry the exe-time line on failure", buf.String())
+	}
+}
+
+func TestExecuteTask_noOptionsLeavesOutputUntouched(t *testing.T) {
+	buf := withCapturedStderr(t)
+	task := Task{Type: Shell, Cmd: "exit 0"}
+	if err := ExecuteTask(task); err != nil {
+		t.Fatalf("ExecuteTask: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("default behavior should not emit anything on stderr, got %q", buf.String())
+	}
+}
+
+func TestFormatExeDuration(t *testing.T) {
+	cases := []struct {
+		in   time.Duration
+		want string
+	}{
+		{250 * time.Millisecond, "250ms"},
+		{1500 * time.Millisecond, "1.5s"},
+		{75 * time.Second, "1m15s"},
+		{2 * time.Hour, "2h00m"},
+	}
+	for _, c := range cases {
+		if got := formatExeDuration(c.in); got != c.want {
+			t.Errorf("formatExeDuration(%v) = %q, want %q", c.in, got, c.want)
+		}
 	}
 }
 

--- a/src/internal/lib/task_runner_test.go
+++ b/src/internal/lib/task_runner_test.go
@@ -148,8 +148,8 @@ func TestExecuteTask_showExeTime_emitsLine(t *testing.T) {
 	}
 
 	out := buf.String()
-	if !strings.Contains(out, "→ say-hi (1.5s)") {
-		t.Errorf("stderr %q missing '→ say-hi (1.5s)'", out)
+	if !strings.Contains(out, "say-hi complete in 1.5s") {
+		t.Errorf("stderr %q missing 'say-hi complete in 1.5s'", out)
 	}
 	if !strings.Contains(out, "\033[2m") || !strings.Contains(out, "\033[0m") {
 		t.Errorf("stderr %q missing dim ANSI styling", out)
@@ -171,8 +171,8 @@ func TestExecuteTask_showExeTime_fallsBackToTaskType(t *testing.T) {
 		Cmd:       "exit 0",
 	}
 	_ = ExecuteTask(task)
-	if !strings.Contains(buf.String(), "→ shell (500ms)") {
-		t.Errorf("stderr %q missing '→ shell (500ms)'", buf.String())
+	if !strings.Contains(buf.String(), "shell complete in 500ms") {
+		t.Errorf("stderr %q missing 'shell complete in 500ms'", buf.String())
 	}
 }
 
@@ -191,7 +191,7 @@ func TestExecuteTask_showExeTime_firesOnFailureToo(t *testing.T) {
 	if err := ExecuteTask(task); err == nil {
 		t.Fatal("expected error from `exit 1`")
 	}
-	if !strings.Contains(buf.String(), "→ fails (2.0s)") {
+	if !strings.Contains(buf.String(), "fails complete in 2.0s") {
 		t.Errorf("stderr %q should still carry the exe-time line on failure", buf.String())
 	}
 }

--- a/src/resources/app.properties
+++ b/src/resources/app.properties
@@ -1,2 +1,2 @@
-version=0.13.0-beta
+version=0.14.0-beta
 environment=development


### PR DESCRIPTION
## Summary

Resolves #54 — *Shared options: block on every task type*.

Adds a composable `options:` block on the base task definition (via `\$defs/taskOptions` in the schema) so cross-task fields don't have to be re-declared per task type. Every task type inherits the block; user-defined commands accept the same shape.

Initial field: **`showExeTime`** (bool). When true, raid prints a dim line to stderr after the task or command completes:

\`\`\`
→ task-name (1.2s)
\`\`\`

Fires on both success and failure. Task-level and command-level flags are independent — set both to time the command end-to-end **and** see per-task breakdowns.

\`\`\`yaml
commands:
  - name: build
    options:
      showExeTime: true       # one final line for the whole command
    tasks:
      - type: Shell
        name: server-build
        cmd: swift build
        options:
          showExeTime: true   # per-task line
\`\`\`

Smoke-tested locally:

\`\`\`
$ raid hi
hello from hi
→ Print (0ms)
→ sleep-task (116ms)
→ hi (116ms)
\`\`\`

## Implementation

- **Schema**: new \`taskOptions\` \`\$def\` referenced from \`taskCommon\` and from the \`commands\` entry. \`additionalProperties: false\` so future fields (\`quiet\`, \`timeout\`) don't land via typo.
- **Types**: \`TaskProps.Options\` and \`Command.Options\` (both \`*TaskOptions\`). Nil-safe; omitting the block leaves prior behavior unchanged.
- **Runtime**: \`ExecuteTask\` wraps the per-type dispatch with timing when set; \`runCommand\` wraps \`runCommandTasks\`. Timing uses a \`timeNowFn\` seam for deterministic tests. Output goes through \`commandStderr\` so MCP captures and CLI tty both behave correctly.
- \`Task.Label()\` returns \`Name\` when set, falling back to the raw task type so unnamed tasks still produce a meaningful line.
- \`formatExeDuration\` mirrors the recent-runs formatter in \`cmd/context\` so durations read consistently across raid's surfaces.

## Test plan

- [x] \`go test ./...\` — all packages green.
- [x] New tests:
  - \`TestExecuteTask_showExeTime_emitsLine\` / \`_fallsBackToTaskType\` / \`_firesOnFailureToo\` / \`_noOptionsLeavesOutputUntouched\`.
  - \`TestRunCommand_showExeTime_emitsLine\` / \`_off_byDefault\`.
  - \`TestValidateProfile_optionsAccepted_onEveryTaskType\` — locks the \`taskCommon\` inheritance across every task type plus the command-level block.
  - \`TestValidateProfile_optionsRejectsUnknownField\` — guards future fields landing silently via typo.
  - \`TestFormatExeDuration\` — bucket boundaries.
- [x] \`cd site && npm run build\` — no broken links. Static schema copy re-synced (embedded-vs-published test passes).
- [x] **Manual smoke**: profile with task-level and command-level \`options.showExeTime: true\` emits the expected three lines.

## Out of scope (per the issue)

- Additional option fields (\`quiet\`, \`timeout\`, …). The schema's \`additionalProperties: false\` makes adding them a straightforward additive change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)