### PR TITLE
feat: follow-up prompt to record telemetry denial

### DIFF
--- a/site/docs/telemetry.mdx
+++ b/site/docs/telemetry.mdx
@@ -9,7 +9,7 @@ description: What raid's opt-in anonymous CLI telemetry collects, what it never 
 
 raid ships an **opt-in, anonymous** CLI telemetry pipeline so the team can prioritize features against real usage signal — which task types matter, which commands fail, which features go unused — without ever capturing what you actually run.
 
-**Off by default.** A fresh install never sends anything to the telemetry endpoint until you explicitly run `raid telemetry on` (or accept the first-run prompt). When opted out, raid makes zero telemetry / PostHog requests, and there's an integration test that pins this contract. (raid still performs an unrelated GitHub release-version check on normal invocations regardless of telemetry state — that request is independent of this pipeline.)
+**Off by default.** A fresh install never sends anything to the telemetry endpoint until you explicitly run `raid telemetry on` (or accept the first-run prompt). The one narrow exception is the [follow-up question](#follow-up-may-we-record-the-denial): if you decline the first-run prompt and then explicitly answer yes to the follow-up, raid sends exactly one anonymous `raid_telemetry_opt_out` event and then stays off forever. Answering no to the follow-up (or skipping it for any reason) means raid still sends nothing. When opted out, raid makes zero further telemetry / PostHog requests, and there's an integration test that pins this contract. (raid still performs an unrelated GitHub release-version check on normal invocations regardless of telemetry state — that request is independent of this pipeline.)
 
 ## What raid collects
 

--- a/site/docs/telemetry.mdx
+++ b/site/docs/telemetry.mdx
@@ -19,7 +19,7 @@ raid ships an **opt-in, anonymous** CLI telemetry pipeline so the team can prior
 | `raid_command_executed` | `command_name`, `task_count`, `task_types[]`, `duration_ms`, `success` |
 | `raid_command_failed` | `command_name`, `error_code` (from the [errors table](references/errors)), `duration_ms` |
 | `raid_task_executed` | `task_type`, `duration_ms`, `success` — **sampled** at ~10% to bound volume |
-| `raid_telemetry_opt_out` | `reason` (optional free-text from `raid telemetry off --why "..."`) |
+| `raid_telemetry_opt_out` | `reason` — either `"prompt-declined"` (set automatically when you accept the [follow-up question](#follow-up-may-we-record-the-denial)) or the free-text string from `raid telemetry off --why "..."`. Optional; absent when neither path was used. |
 
 **Every event also carries:** `distinct_id` (anonymous UUIDv4 from `~/.config/raid/telemetry-id`), `raid_version`, `os` (e.g. `darwin`/`linux`/`windows`), `arch` (e.g. `arm64`/`amd64`).
 
@@ -48,6 +48,23 @@ See: https://raidcli.dev/docs/telemetry
 ```
 
 Default is **no** (capital `N`). `[?]` shows the long-form disclosure inline and re-asks.
+
+### Follow-up: may we record the denial?
+
+If you decline the first prompt, raid asks one follow-up question:
+
+```
+Telemetry is off. May raid send a single anonymous event recording your decision?
+This is the only event raid would ever send; it helps the project measure how
+many users opt out vs. opt in. Same anonymity guarantees as above.
+
+  [y] yes, send once       [N] no, send nothing at all
+> 
+```
+
+Default is **no** again. Answering yes fires exactly one `raid_telemetry_opt_out` event (with `reason: "prompt-declined"`) and then leaves telemetry permanently off — that's the whole transaction. Answering no (or hitting Enter) skips the network entirely; raid touches zero endpoints for the remainder of the install.
+
+The follow-up exists because opt-out rate is the most useful single signal for the project: without it, we can't tell whether a quiet user has opted out actively or just never finished setup. It's also why the follow-up exists *only* on the explicit-decline path — when you skip the first prompt for any other reason (non-TTY, headless, `DO_NOT_TRACK`, etc.), raid never asks anything further.
 
 **Non-interactive contexts skip the prompt entirely and leave telemetry off.** Specifically, raid does not prompt when:
 

--- a/site/docs/whats-new.mdx
+++ b/site/docs/whats-new.mdx
@@ -11,6 +11,8 @@ User-visible changes per release, latest first. For full commit history see the 
 
 ## 0.17.0 — upcoming
 
+**Optional opt-out telemetry follow-up.** When a user declines the first-run telemetry prompt, raid now asks one follow-up question: may we send a single anonymous event recording your denial? Default is no (capital N) just like the main prompt. If accepted, raid fires exactly one `raid_telemetry_opt_out` event (with `reason: "prompt-declined"`) under explicit per-event consent and then leaves telemetry permanently off — that's the whole transaction. If declined or skipped, raid touches zero endpoints for the remainder of the install. The follow-up runs *only* on the explicit-decline path: non-TTY, headless, `DO_NOT_TRACK`, already-decided, and `raid telemetry ...` invocations skip both prompts. Closes the opt-out-rate measurement gap that's otherwise impossible to fill from website analytics alone.
+
 **Per-task output prefixing in concurrent runs.** Tasks with `concurrent: true` now have their stdout/stderr lines prefixed with `[task-name]` and rendered in a deterministic per-task color, so interleaved output stays attributable. Prefixing is automatically suppressed on non-TTY sinks (pipes, file redirects, CI logs, and the MCP server's capture buffer), so machine-readable output is byte-identical to today. `NO_COLOR=1` strips just the color; `--no-prefix` / `RAID_NO_PREFIX=1` strips both. Partial trailing lines without a final newline are flushed with their prefix when the task exits, so output is never silently lost. See [raid → Output prefixing in concurrent runs](/docs/usage/raid#output-prefixing-in-concurrent-runs). Closes [#77](https://github.com/8bitAlex/raid/issues/77).
 
 ## 0.16.0 — upcoming

--- a/src/internal/telemetry/prompt.go
+++ b/src/internal/telemetry/prompt.go
@@ -98,10 +98,50 @@ func MaybePromptForConsent(skipInteractive bool) PromptResult {
 			fmt.Fprint(promptOutFn(), explainerText())
 			continue
 		default:
+			// User declined the main prompt. Ask one follow-up: may
+			// we send a single anonymous "denial recorded" event so
+			// the project can measure opt-out rates? Default is no.
+			// If they say yes we fire under per-event consent
+			// BEFORE flipping the state off (technically the bypass
+			// path doesn't require the order, but firing first
+			// matches the `raid telemetry off` pattern and makes
+			// the intent obvious to future readers).
+			if askOptOutEventConsent(reader) {
+				CaptureOptOutConsented("prompt-declined")
+			}
 			_ = SetEnabled(false)
 			return PromptDeclined
 		}
 	}
+}
+
+// askOptOutEventConsent renders the follow-up prompt and returns
+// true iff the user explicitly accepts. Default is no (capital N)
+// so a stray enter keeps the strict opt-out posture. Exists as a
+// separate function so the prompt text + truthy-answer matching
+// have a single test surface.
+func askOptOutEventConsent(reader *bufio.Reader) bool {
+	fmt.Fprint(promptOutFn(), optOutFollowUpText())
+	line, err := reader.ReadString('\n')
+	if err != nil && line == "" {
+		return false
+	}
+	switch strings.TrimSpace(strings.ToLower(line)) {
+	case "y", "yes":
+		return true
+	}
+	return false
+}
+
+func optOutFollowUpText() string {
+	return "" +
+		"\n" +
+		"Telemetry is off. May raid send a single anonymous event recording your decision?\n" +
+		"This is the only event raid would ever send; it helps the project measure how\n" +
+		"many users opt out vs. opt in. Same anonymity guarantees as above.\n" +
+		"\n" +
+		"  [y] yes, send once       [N] no, send nothing at all\n" +
+		"> "
 }
 
 // readPromptAnswer renders the prompt and reads a single line of

--- a/src/internal/telemetry/telemetry.go
+++ b/src/internal/telemetry/telemetry.go
@@ -98,6 +98,35 @@ func Capture(name string, properties map[string]any) {
 	}()
 }
 
+// CaptureOptOutConsented fires the opt-out event under explicit
+// per-event consent — used by the first-run prompt when a user
+// declines telemetry generally but agrees to send a single
+// anonymous "denial recorded" event. Bypasses the standard
+// IsActive() gate (which would short-circuit because consent has
+// just been set to off, or is still undecided) but still respects
+// the two hard kill-switches: a build with no APIKey and a
+// DO_NOT_TRACK env var. Synchronous so the event has its best
+// chance to land before raid exits.
+//
+// Callers MUST ensure the user has explicitly consented to this
+// specific event — never call this for any other purpose, and
+// never extend it to a general "bypass" capture path. The whole
+// trust model of telemetry rests on consent being explicit at the
+// event level when state-level consent isn't true.
+func CaptureOptOutConsented(reason string) {
+	if APIKey == "" {
+		return
+	}
+	if isDoNotTrack() {
+		return
+	}
+	id := loadOrCreateID()
+	if id == "" {
+		return
+	}
+	send(Event{Name: EventTelemetryOptOut, Properties: enrichProperties(id, OptOutProps(reason))})
+}
+
 // CaptureSync is Capture's blocking variant. Used by `raid telemetry
 // off` so the opt-out event is attempted synchronously before the
 // process exits — we want to give the event the best chance to land

--- a/src/internal/telemetry/telemetry.go
+++ b/src/internal/telemetry/telemetry.go
@@ -17,11 +17,18 @@
 //
 // The package is read-only side-effect-free for users who never opt
 // in via prompt or `raid telemetry on`: no goroutines spawned, no
-// HTTP calls. The one exception is the consent-decision marker —
-// MaybePromptForConsent persists a "decided=off" entry to viper when
-// the prompt is skipped (DO_NOT_TRACK, non-TTY, headless) so we don't
-// re-prompt on the next interactive run. No anonymous ID is created
-// or written until the user explicitly opts in.
+// HTTP calls. Two narrow exceptions exist:
+//   - MaybePromptForConsent persists a "decided=off" entry to viper
+//     when the prompt is skipped (DO_NOT_TRACK, non-TTY, headless) so
+//     we don't re-prompt on the next interactive run. No anonymous ID
+//     or network traffic results.
+//   - CaptureOptOutConsented, used only by the first-run follow-up
+//     prompt when a declining user explicitly consents to record their
+//     decision, creates an anonymous ID and sends exactly one
+//     `raid_telemetry_opt_out` event before leaving telemetry off
+//     forever. This is per-event consent, never state-level.
+// Outside of those two paths, no anonymous ID is created or written
+// until the user explicitly opts in.
 package telemetry
 
 import (

--- a/src/internal/telemetry/telemetry_test.go
+++ b/src/internal/telemetry/telemetry_test.go
@@ -622,6 +622,194 @@ func TestMaybePromptForConsent_explainerThenAccept(t *testing.T) {
 	}
 }
 
+// --- Follow-up opt-out event consent ---
+
+// TestMaybePromptForConsent_declineThenConsentToOptOutEvent covers
+// the happy path of the follow-up prompt: user declines telemetry
+// generally, then opts into sending a single anonymous
+// "denial recorded" event so the project can measure opt-out
+// rates. The event must land via the bypass path
+// (CaptureOptOutConsented) because the standard IsActive() gate is
+// false at that moment.
+func TestMaybePromptForConsent_declineThenConsentToOptOutEvent(t *testing.T) {
+	setupTestEnv(t)
+	isInteractiveFn = func() bool { return true }
+	// "n" declines the first prompt; "y" accepts the follow-up.
+	r := strings.NewReader("n\ny\n")
+	promptInFn = func() io.Reader { return r }
+	promptOutFn = func() io.Writer { return io.Discard }
+
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+	}))
+	defer srv.Close()
+	CaptureEndpoint = srv.URL
+
+	got := MaybePromptForConsent(false)
+	if got != PromptDeclined {
+		t.Errorf("outcome = %v, want PromptDeclined", got)
+	}
+	st := LoadState()
+	if !st.Decided || st.Enabled {
+		t.Errorf("state = %+v, want decided=true enabled=false after decline", st)
+	}
+	if h := atomic.LoadInt32(&hits); h != 1 {
+		t.Errorf("opt-out event delivered %d times, want 1", h)
+	}
+}
+
+// TestMaybePromptForConsent_declineRefuseOptOutEventSendsNothing
+// covers the conservative default — declining the main prompt and
+// then declining the follow-up must send zero events. This is the
+// trust-preserving path: a user who chose "no" twice should leave
+// the binary in a state that has touched the network zero times.
+func TestMaybePromptForConsent_declineRefuseOptOutEventSendsNothing(t *testing.T) {
+	setupTestEnv(t)
+	isInteractiveFn = func() bool { return true }
+	r := strings.NewReader("n\nn\n")
+	promptInFn = func() io.Reader { return r }
+	promptOutFn = func() io.Writer { return io.Discard }
+
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+	}))
+	defer srv.Close()
+	CaptureEndpoint = srv.URL
+
+	got := MaybePromptForConsent(false)
+	if got != PromptDeclined {
+		t.Errorf("outcome = %v, want PromptDeclined", got)
+	}
+	if h := atomic.LoadInt32(&hits); h != 0 {
+		t.Errorf("refusing follow-up sent %d events, want 0", h)
+	}
+}
+
+// TestMaybePromptForConsent_declineEmptyFollowUpSendsNothing pins
+// the capital-N default on the follow-up: hitting Enter at the
+// second prompt is "no". A stray Enter (or a piped script that
+// answers the main prompt but leaves stdin closed) must never
+// flip into the "send event" path.
+func TestMaybePromptForConsent_declineEmptyFollowUpSendsNothing(t *testing.T) {
+	setupTestEnv(t)
+	isInteractiveFn = func() bool { return true }
+	// "\n" declines the main prompt; the follow-up reads EOF.
+	r := strings.NewReader("\n")
+	promptInFn = func() io.Reader { return r }
+	promptOutFn = func() io.Writer { return io.Discard }
+
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+	}))
+	defer srv.Close()
+	CaptureEndpoint = srv.URL
+
+	if got := MaybePromptForConsent(false); got != PromptDeclined {
+		t.Errorf("outcome = %v, want PromptDeclined", got)
+	}
+	if h := atomic.LoadInt32(&hits); h != 0 {
+		t.Errorf("EOF follow-up sent %d events, want 0", h)
+	}
+}
+
+// TestMaybePromptForConsent_acceptSkipsFollowUp asserts the
+// follow-up prompt does not fire when the user opted in — there's
+// no "denial" to record, and an extra prompt would be confusing.
+func TestMaybePromptForConsent_acceptSkipsFollowUp(t *testing.T) {
+	setupTestEnv(t)
+	isInteractiveFn = func() bool { return true }
+	// "y" accepts. If the follow-up wrongly fired, the second line
+	// would be the input — but the test reader has only one line,
+	// so the missing line proves the follow-up was skipped.
+	r := strings.NewReader("y\n")
+	promptInFn = func() io.Reader { return r }
+	out := &strings.Builder{}
+	promptOutFn = func() io.Writer { return out }
+
+	got := MaybePromptForConsent(false)
+	if got != PromptAccepted {
+		t.Errorf("outcome = %v, want PromptAccepted", got)
+	}
+	if strings.Contains(out.String(), "recording your decision") {
+		t.Errorf("follow-up prompt text leaked into output: %q", out.String())
+	}
+}
+
+// --- CaptureOptOutConsented ---
+
+// TestCaptureOptOutConsented_bypassesInactive — the whole point of
+// this entry point. Consent is undecided / disabled (IsActive ==
+// false), but an explicit per-event consent path must still send.
+func TestCaptureOptOutConsented_bypassesInactive(t *testing.T) {
+	setupTestEnv(t)
+	var hits int32
+	var body []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		body, _ = io.ReadAll(r.Body)
+	}))
+	defer srv.Close()
+	CaptureEndpoint = srv.URL
+
+	if IsActive() {
+		t.Fatal("test precondition: IsActive should be false on fresh setup")
+	}
+	CaptureOptOutConsented("prompt-declined")
+	if h := atomic.LoadInt32(&hits); h != 1 {
+		t.Fatalf("delivered %d events, want 1", h)
+	}
+	// Confirm the event carries the opt-out shape — name + reason.
+	if !strings.Contains(string(body), EventTelemetryOptOut) {
+		t.Errorf("body missing event name %q: %s", EventTelemetryOptOut, body)
+	}
+	if !strings.Contains(string(body), `"reason":"prompt-declined"`) {
+		t.Errorf("body missing reason: %s", body)
+	}
+}
+
+// TestCaptureOptOutConsented_respectsAPIKeyEmpty — even with
+// explicit consent, a build without an API key has no destination
+// and must no-op. Otherwise dev builds would surface a confusing
+// "no endpoint" path.
+func TestCaptureOptOutConsented_respectsAPIKeyEmpty(t *testing.T) {
+	setupTestEnv(t)
+	APIKey = ""
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+	}))
+	defer srv.Close()
+	CaptureEndpoint = srv.URL
+
+	CaptureOptOutConsented("prompt-declined")
+	if h := atomic.LoadInt32(&hits); h != 0 {
+		t.Errorf("delivered %d events with empty API key, want 0", h)
+	}
+}
+
+// TestCaptureOptOutConsented_respectsDoNotTrack — the hard
+// kill-switch must override the per-event consent path. A user
+// who set DO_NOT_TRACK=1 has expressed a global "never" that
+// trumps any one-off consent we might collect afterward.
+func TestCaptureOptOutConsented_respectsDoNotTrack(t *testing.T) {
+	setupTestEnv(t)
+	os.Setenv(DoNotTrackEnvVar, "1")
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+	}))
+	defer srv.Close()
+	CaptureEndpoint = srv.URL
+
+	CaptureOptOutConsented("prompt-declined")
+	if h := atomic.LoadInt32(&hits); h != 0 {
+		t.Errorf("delivered %d events with DO_NOT_TRACK=1, want 0", h)
+	}
+}
+
 // --- Consent state ---
 
 func TestSetEnabled_persistsBothKeys(t *testing.T) {

--- a/src/internal/telemetry/telemetry_test.go
+++ b/src/internal/telemetry/telemetry_test.go
@@ -721,9 +721,9 @@ func TestMaybePromptForConsent_declineEmptyFollowUpSendsNothing(t *testing.T) {
 func TestMaybePromptForConsent_acceptSkipsFollowUp(t *testing.T) {
 	setupTestEnv(t)
 	isInteractiveFn = func() bool { return true }
-	// "y" accepts. If the follow-up wrongly fired, the second line
-	// would be the input — but the test reader has only one line,
-	// so the missing line proves the follow-up was skipped.
+	// "y" accepts. The assertion below pins behavior by checking the
+	// prompt output never contains the follow-up question text — if
+	// the follow-up wrongly fired, that string would appear in `out`.
 	r := strings.NewReader("y\n")
 	promptInFn = func() io.Reader { return r }
 	out := &strings.Builder{}


### PR DESCRIPTION
## Summary

When a user declines the first-run telemetry prompt, raid now asks one follow-up: may we send a single anonymous event recording your denial? Default is no (capital N), just like the main prompt.

```
raid would like to send anonymous usage telemetry to help prioritize features.
…
  [y] yes, send telemetry      [N] no, leave it off       [?] what's collected
> n

Telemetry is off. May raid send a single anonymous event recording your decision?
This is the only event raid would ever send; it helps the project measure how
many users opt out vs. opt in. Same anonymity guarantees as above.

  [y] yes, send once       [N] no, send nothing at all
> 
```

If accepted, raid fires exactly one `raid_telemetry_opt_out` event (with `reason: "prompt-declined"`) under explicit per-event consent and then leaves telemetry permanently off. If declined or skipped, raid makes zero network calls for the remainder of the install.

**Why this matters.** Opt-out rate is the most useful single data point for prioritization that's otherwise impossible to recover from website analytics alone — without it, we can't tell whether a quiet user opted out actively or just never finished setup.

## Implementation

- New `CaptureOptOutConsented(reason string)` in [telemetry.go](src/internal/telemetry/telemetry.go) bypasses the `IsActive()` gate (which is false the moment after a decline because the state hasn't been written yet) but still respects the two hard kill-switches: a build with no `APIKey` and `DO_NOT_TRACK`. The function comment scopes its use strictly to the prompt-decline path — the trust model rests on per-event consent being explicit.
- Follow-up wired into [prompt.go](src/internal/telemetry/prompt.go) on the explicit-decline branch of `MaybePromptForConsent`. All skip paths (non-TTY, headless, `DO_NOT_TRACK`, already-decided, `raid telemetry ...` invocations) continue to ask nothing further.
- The `EOF` case (stray Enter, closed stdin after the main prompt) defaults to no — verified by a dedicated test.

## Test plan

- [x] `go test ./... -race` — all packages green
- [x] `TestMaybePromptForConsent_declineThenConsentToOptOutEvent` — happy path: decline + yes → exactly one event delivered + state persisted off
- [x] `TestMaybePromptForConsent_declineRefuseOptOutEventSendsNothing` — decline + no → zero events
- [x] `TestMaybePromptForConsent_declineEmptyFollowUpSendsNothing` — decline + EOF → zero events
- [x] `TestMaybePromptForConsent_acceptSkipsFollowUp` — accept main → no follow-up prompt rendered
- [x] `TestCaptureOptOutConsented_bypassesInactive` — fires when `IsActive() == false`, payload includes event name + reason
- [x] `TestCaptureOptOutConsented_respectsAPIKeyEmpty` — no-op when `APIKey == ""`
- [x] `TestCaptureOptOutConsented_respectsDoNotTrack` — no-op when `DO_NOT_TRACK=1`
- [x] `askOptOutEventConsent` and `optOutFollowUpText` at 100% line coverage
- [x] `cd site && npm run build` — no broken anchors

## Docs

- [Telemetry → Follow-up: may we record the denial?](site/docs/telemetry.mdx) — new subsection under First-run consent explaining the question, the strict opt-out posture, and why the follow-up exists only on the explicit-decline path
- [Telemetry → events table](site/docs/telemetry.mdx) — `raid_telemetry_opt_out`'s `reason` field now documents both the `"prompt-declined"` value and the `--why "..."` free-text value
- [what's-new → 0.17.0 — upcoming](site/docs/whats-new.mdx) — entry above the existing per-task prefix one

🤖 Generated with [Claude Code](https://claude.com/claude-code)