### PR TITLE
chore: drop -beta suffix from version (0.17.0-beta → 0.17.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ Most task runners are built to orchestrate a *single project*. Raid is built for
 
 ## Development Status
 
-Raid is currently in the **prototype stage**. Core functionality is still being explored and iterated on — expect frequent changes and incomplete features.
+Raid is in **active development toward v1.0**. Core functionality is stable and usable today — multi-repo profiles, environments, custom commands, eleven task types, the MCP server, opt-in telemetry, and headless mode all ship behind a documented contract. A small set of v1-milestone issues remains; expect additive changes and a few targeted refinements before the v1 tag.
 
-Feedback, issues, and contributions are welcome as the project takes shape.
+Feedback, issues, and contributions are welcome.
 
 ---
 
@@ -654,7 +654,7 @@ Yes. Raid's profile and repo schemas are published to [SchemaStore](https://www.
 
 ### Is Raid production-ready?
 
-Raid is currently in the **prototype stage**. Core functionality works and is usable today, but APIs and configuration may change as the project evolves. See [Development Status](#development-status).
+Raid is in **active development toward v1.0**. Core functionality is stable enough to use today; a handful of v1-milestone refinements still ship additively before the v1 tag. See [Development Status](#development-status).
 
 ### How is "Raid" pronounced, and where does the name come from?
 

--- a/site/static/.well-known/mcp/server-card.json
+++ b/site/static/.well-known/mcp/server-card.json
@@ -2,7 +2,7 @@
   "schemaVersion": "1.0",
   "serverInfo": {
     "name": "raid",
-    "version": "0.7.4-beta",
+    "version": "0.17.0",
     "description": "Distributed development environment orchestrator. Manages multi-repo workflows, environments, and tasks via an MCP stdio server."
   },
   "transport": [

--- a/src/resources/app.properties
+++ b/src/resources/app.properties
@@ -1,2 +1,2 @@
-version=0.17.0-beta
+version=0.17.0
 environment=development


### PR DESCRIPTION
## Summary

Raid has shipped enough feature surface under a documented contract that the "-beta" suffix no longer reflects the project's posture. Drop it and tighten the README "Development Status" + FAQ wording to match.

| Before | After |
|---|---|
| `version=0.17.0-beta` | `version=0.17.0` |
| "Raid is currently in the **prototype stage**." | "Raid is in **active development toward v1.0**." |

This is a version-string-only change. No behavior moves; no schemas, JSON shapes, or error codes change. The next release ships as `v0.17.0` instead of `v0.17.0-beta`.

## Test plan

- [x] `go test ./... -race` — all packages green; existing tests don't reference the `-beta` suffix
- [x] `cd site && npm run build` — docs green, no broken links
- [x] `baseVersion` in `src/cmd/raid.go` only strips `-preview` and is unaffected by the `-beta` removal
- [x] Goreleaser configs reference the version via `app.properties` — no `-beta` hardcoded
- [x] `whats-new.mdx` line 112 ("Initial public beta") is historical (describes 0.1.0) and intentionally left untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)