### PR TITLE
fix: three critical issues blocking v1.0 (C1 telemetry persistence + C2 credential leak + C3 context race)

### DIFF
--- a/site/docs/whats-new.mdx
+++ b/site/docs/whats-new.mdx
@@ -9,6 +9,18 @@ description: Feature-by-feature release notes for Raid.
 
 User-visible changes per release, latest first. For full commit history see the [GitHub releases page](https://github.com/8bitalex/raid/releases).
 
+## 0.17.1 — upcoming
+
+Three pre-v1.0 hardening fixes from the release-readiness review. No behavior change for happy paths; all three are correctness/security bugs with regression tests now in place.
+
+**Telemetry consent prompt no longer gets killed by `--json`.** The first-run prompt previously persisted `decided=off` on any skip signal — including transient ones like `--json`. A user who piped one command through `raid context --json | jq` was silently opted out of telemetry for life. The consent flow now splits skip signals into two tiers: persistent (`--yes` / `--headless` / `RAID_HEADLESS` / non-TTY / `DO_NOT_TRACK`) which still persist `decided=off`, and transient (`--json`) which skip the prompt without writing state. The next interactive run without the transient signal still gets prompted.
+
+**Repo URL credentials no longer leak to `~/.raid/vars` or MCP.** A profile YAML using `https://user:token@github.com/...` as a clone URL no longer persists the credential to disk, no longer surfaces it through the MCP `raid://workspace/vars` resource, and no longer lands verbatim in `$RAID_REPO_<NAME>_URL` for subprocesses. SSH-style `git@host:repo.git` URLs round-trip unchanged. **If you've previously run raid against a profile with embedded clone credentials, rotate the affected token** — this fix prevents new leaks but doesn't scrub historical content from your existing vars file. Re-exported as `raid.ScrubURL`.
+
+**`~/.raid/vars` now written with mode `0600` instead of `0644`.** The vars file persists raid-managed variables (scrubbed repo URLs, `Set`-task values, anything project authors treat as secret-ish) and shouldn't be world-readable. New writes land at `0600` atomically; existing 0644 files are best-effort tightened on the next load.
+
+**MCP read/write race on the workspace context.** mcp-go dispatches tool calls from a 5-worker pool, so MCP read handlers (`raid_list_repos`, `raid_describe_repo`, …) could race with mutating handlers' `ForceLoad` rewrites of the package-global context. Replaced with `atomic.Pointer[Context]`; reads are now well-defined under concurrent writes. Race-detector test pins the contract.
+
 ## 0.17.0 — upcoming
 
 **Optional opt-out telemetry follow-up.** When a user declines the first-run telemetry prompt, raid now asks one follow-up question: may we send a single anonymous event recording your denial? Default is no (capital N) just like the main prompt. If accepted, raid fires exactly one `raid_telemetry_opt_out` event (with `reason: "prompt-declined"`) under explicit per-event consent and then leaves telemetry permanently off — that's the whole transaction. If declined or skipped, raid touches zero endpoints for the remainder of the install. The follow-up runs *only* on the explicit-decline path: non-TTY, headless, `DO_NOT_TRACK`, already-decided, and `raid telemetry ...` invocations skip both prompts. Closes the opt-out-rate measurement gap that's otherwise impossible to fill from website analytics alone.

--- a/src/cmd/context/serve.go
+++ b/src/cmd/context/serve.go
@@ -520,7 +520,10 @@ func handleListRepos(_ stdctx.Context, req mcp.CallToolRequest) (*mcp.CallToolRe
 
 	urls := make(map[string]string, len(active.Repositories))
 	for _, r := range active.Repositories {
-		urls[r.Name] = r.URL
+		// Scrub embedded userinfo so an HTTPS clone URL with a token
+		// (`https://user:token@host/...`) doesn't leak through the
+		// MCP tool result. See raid.ScrubURL for the contract.
+		urls[r.Name] = raid.ScrubURL(r.URL)
 	}
 
 	live := rctx.Get().Workspace.Repos

--- a/src/cmd/context/serve_test.go
+++ b/src/cmd/context/serve_test.go
@@ -563,6 +563,44 @@ func TestHandleListRepos_returnsConfiguredReposWithURL(t *testing.T) {
 	}
 }
 
+// TestHandleListRepos_scrubsCredentialBearingURL pins bug C2 at the
+// MCP handler boundary: a clone URL with embedded userinfo
+// (`https://user:token@host/...`) must come back through
+// raid_list_repos with the credentials stripped. The unit test on
+// ScrubURL alone isn't enough — a future refactor that bypasses the
+// helper here would still pass that test but reintroduce the leak.
+func TestHandleListRepos_scrubsCredentialBearingURL(t *testing.T) {
+	body := `name: test-fixture
+repositories:
+  - name: demo-repo
+    path: ` + "/tmp/raid-cmd-context-test-demo-repo-DOES-NOT-EXIST" + `
+    url: https://alice:s3cret@github.com/org/demo.git
+`
+	loadTestProfile(t, body)
+
+	res, err := handleListRepos(stdctx.Background(), mcp.CallToolRequest{})
+	if err != nil {
+		t.Fatalf("handleListRepos: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected ok, got error: %s", toolResultText(res))
+	}
+	raw := toolResultText(res)
+	if strings.Contains(raw, "alice") || strings.Contains(raw, "s3cret") {
+		t.Fatalf("MCP response leaked credentials: %s", raw)
+	}
+	var entries []listReposEntry
+	if err := json.Unmarshal([]byte(raw), &entries); err != nil {
+		t.Fatalf("body not JSON: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 repo, got %d: %+v", len(entries), entries)
+	}
+	if entries[0].URL != "https://github.com/org/demo.git" {
+		t.Errorf("repo URL = %q, want scrubbed scheme+host+path", entries[0].URL)
+	}
+}
+
 func TestHandleDescribeRepo_lookupByName(t *testing.T) {
 	loadTestProfile(t, minimalTestProfileBody)
 

--- a/src/cmd/raid.go
+++ b/src/cmd/raid.go
@@ -169,15 +169,20 @@ func executeRoot(args []string) int {
 
 	// First-run consent prompt for telemetry. Runs only for non-info,
 	// non-telemetry-subcommand invocations to avoid prompting on
-	// `raid --help`, `raid telemetry on`, and similar. The prompt
-	// itself no-ops when stdin isn't a TTY, when --yes/--headless is
-	// set, when --json is set, or when RAID_HEADLESS=1 in the env
-	// (CI / agent-host opt-in path), so it's safe in non-interactive
-	// contexts. See telemetry.MaybePromptForConsent for the full skip
-	// matrix.
+	// `raid --help`, `raid telemetry on`, and similar.
+	//
+	// Skip signals split into two tiers. Persistent — `--yes` /
+	// `--headless`, `RAID_HEADLESS=1`, non-TTY stdin, DO_NOT_TRACK —
+	// all reflect "this host is non-interactive long-term" and cause
+	// MaybePromptForConsent to persist decided=off so we don't keep
+	// re-prompting. Transient — `--json` — is just "this one command
+	// wants machine-readable output" and must NOT poison the consent
+	// state. The split was added after a real bug where one
+	// `raid context --json | jq` silently opted the user out for life.
 	if !info && !isTelemetrySubcommand(args) {
-		skip := headlessFromArgs(args) || jsonModeFromArgs(args) || lib.IsHeadless()
-		switch telemetry.MaybePromptForConsent(skip) {
+		skipPersistent := headlessFromArgs(args) || lib.IsHeadless()
+		skipTransient := jsonModeFromArgs(args)
+		switch telemetry.MaybePromptForConsent(skipPersistent, skipTransient) {
 		case telemetry.PromptAccepted:
 			// User opted in via the first-run prompt — fire the
 			// adoption event so `raid telemetry on` and the prompt

--- a/src/internal/lib/command.go
+++ b/src/internal/lib/command.go
@@ -67,18 +67,20 @@ func (c Command) IsZero() bool {
 
 // GetCommands returns all commands available in the active profile.
 func GetCommands() []Command {
-	if context == nil {
+	ctx := loadContext()
+	if ctx == nil {
 		return nil
 	}
-	return context.Profile.Commands
+	return ctx.Profile.Commands
 }
 
 // GetRepos returns the repositories in the active profile.
 func GetRepos() []Repo {
-	if context == nil {
+	ctx := loadContext()
+	if ctx == nil {
 		return nil
 	}
-	return context.Profile.Repositories
+	return ctx.Profile.Repositories
 }
 
 // ExecuteCommand runs the tasks for the named command, applying any output configuration.

--- a/src/internal/lib/command_test.go
+++ b/src/internal/lib/command_test.go
@@ -43,14 +43,14 @@ func TestGetCommands_nilContext(t *testing.T) {
 
 func TestGetCommands_withCommands(t *testing.T) {
 	setupTestConfig(t)
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Commands: []Command{
 				{Name: "build", Usage: "Build services"},
 				{Name: "test", Usage: "Run tests"},
 			},
 		},
-	}
+	})
 
 	got := GetCommands()
 	if len(got) != 2 {
@@ -65,11 +65,11 @@ func TestGetCommands_withCommands(t *testing.T) {
 
 func TestExecuteCommand_notFound(t *testing.T) {
 	setupTestConfig(t)
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Commands: []Command{{Name: "other", Tasks: []Task{{Type: Shell, Cmd: "exit 0"}}}},
 		},
-	}
+	})
 
 	if err := ExecuteCommand("nonexistent", nil, nil); err == nil {
 		t.Fatal("ExecuteCommand() expected error for unknown command, got nil")
@@ -82,11 +82,11 @@ func TestExecuteCommand_success(t *testing.T) {
 	commandStdout = io.Discard
 	t.Cleanup(func() { commandStdout = origOut })
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Commands: []Command{{Name: "noop", Tasks: []Task{{Type: Shell, Cmd: "exit 0"}}}},
 		},
-	}
+	})
 
 	if err := ExecuteCommand("noop", nil, nil); err != nil {
 		t.Errorf("ExecuteCommand() error: %v", err)
@@ -95,11 +95,11 @@ func TestExecuteCommand_success(t *testing.T) {
 
 func TestExecuteCommand_taskFailure(t *testing.T) {
 	setupTestConfig(t)
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Commands: []Command{{Name: "fail", Tasks: []Task{{Type: Shell, Cmd: "exit 1"}}}},
 		},
-	}
+	})
 
 	if err := ExecuteCommand("fail", nil, nil); err == nil {
 		t.Fatal("ExecuteCommand() expected error from failing task, got nil")
@@ -119,13 +119,13 @@ func TestExecuteCommand_argsSetAsEnvVars(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Commands: []Command{{Name: "capture", Tasks: []Task{
 				{Type: Template, Src: srcFile, Dest: outFile},
 			}}},
 		},
-	}
+	})
 
 	if err := ExecuteCommand("capture", []string{"foo", "bar"}, nil); err != nil {
 		t.Fatalf("ExecuteCommand() error: %v", err)
@@ -170,13 +170,13 @@ func TestExecuteCommand_staleArgsCleared(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Commands: []Command{{Name: "capture", Tasks: []Task{
 				{Type: Template, Src: srcFile, Dest: outFile},
 			}}},
 		},
-	}
+	})
 
 	// First call with two args, second call with one — RAID_ARG_2 must not bleed through.
 	if err := ExecuteCommand("capture", []string{"first", "stale"}, nil); err != nil {
@@ -230,11 +230,11 @@ func TestExecuteCommand_namedBindings_restoresPreviousEnv(t *testing.T) {
 	const key = "RAID_NAMED_TEST_KEY"
 	t.Setenv(key, "original")
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Commands: []Command{{Name: "noop", Tasks: []Task{}}},
 		},
-	}
+	})
 
 	if err := ExecuteCommand("noop", nil, map[string]string{key: "overwritten"}); err != nil {
 		t.Fatalf("ExecuteCommand: %v", err)
@@ -256,11 +256,11 @@ func TestExecuteCommand_namedBindings_unsetsAddedKeys(t *testing.T) {
 	os.Unsetenv(key)
 	t.Cleanup(func() { os.Unsetenv(key) })
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Commands: []Command{{Name: "noop", Tasks: []Task{}}},
 		},
-	}
+	})
 
 	if err := ExecuteCommand("noop", nil, map[string]string{key: "value"}); err != nil {
 		t.Fatalf("ExecuteCommand: %v", err)
@@ -277,11 +277,11 @@ func TestExecuteCommand_namedBindings_skipsInvalidKeys(t *testing.T) {
 	commandStdout, commandStderr = io.Discard, io.Discard
 	t.Cleanup(func() { commandStdout = origOut; commandStderr = origErr })
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Commands: []Command{{Name: "noop", Tasks: []Task{}}},
 		},
-	}
+	})
 
 	// Empty keys and all-underscore keys must not call os.Setenv (which would
 	// either error on the empty key or set a useless `_=value`).
@@ -397,13 +397,13 @@ func TestExecuteCommand_namedBindings(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Commands: []Command{{Name: "patch", Tasks: []Task{
 				{Type: Template, Src: srcFile, Dest: outFile},
 			}}},
 		},
-	}
+	})
 
 	named := map[string]string{
 		"TICKET":  "12345",
@@ -436,11 +436,11 @@ func TestExecuteCommand_notFoundDoesNotSetArgs(t *testing.T) {
 	os.Unsetenv("RAID_ARG_1")
 	t.Cleanup(func() { os.Unsetenv("RAID_ARG_1") })
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Commands: []Command{{Name: "other", Tasks: []Task{{Type: Shell, Cmd: "exit 0"}}}},
 		},
-	}
+	})
 
 	_ = ExecuteCommand("nonexistent", []string{"should-not-be-set"}, nil)
 	if got := os.Getenv("RAID_ARG_1"); got != "" {
@@ -613,9 +613,9 @@ func TestMergeCommands(t *testing.T) {
 // --- GetRepos ---
 
 func TestGetRepos_nilContext(t *testing.T) {
-	old := context
-	context = nil
-	defer func() { context = old }()
+	old := loadContext()
+	storeContext(nil)
+	defer func() { storeContext(old) }()
 
 	if got := GetRepos(); got != nil {
 		t.Errorf("GetRepos() = %v, want nil when context is nil", got)
@@ -623,15 +623,15 @@ func TestGetRepos_nilContext(t *testing.T) {
 }
 
 func TestGetRepos_withRepos(t *testing.T) {
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Repositories: []Repo{
 				{Name: "backend"},
 				{Name: "frontend"},
 			},
 		},
-	}
-	defer func() { context = nil }()
+	})
+	defer func() { storeContext(nil) }()
 
 	got := GetRepos()
 	if len(got) != 2 {
@@ -646,11 +646,11 @@ func TestGetRepos_withRepos(t *testing.T) {
 
 func TestExecuteRepoCommand_repoNotFound(t *testing.T) {
 	setupTestConfig(t)
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Repositories: []Repo{{Name: "backend"}},
 		},
-	}
+	})
 
 	err := ExecuteRepoCommand("nonexistent", "test", nil, nil)
 	if err == nil {
@@ -663,14 +663,14 @@ func TestExecuteRepoCommand_repoNotFound(t *testing.T) {
 
 func TestExecuteRepoCommand_cmdNotFound(t *testing.T) {
 	setupTestConfig(t)
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Repositories: []Repo{{
 				Name:     "backend",
 				Commands: []Command{{Name: "build", Tasks: []Task{{Type: Shell, Cmd: "exit 0"}}}},
 			}},
 		},
-	}
+	})
 
 	err := ExecuteRepoCommand("backend", "nonexistent", nil, nil)
 	if err == nil {
@@ -687,14 +687,14 @@ func TestExecuteRepoCommand_success(t *testing.T) {
 	commandStdout = io.Discard
 	t.Cleanup(func() { commandStdout = origOut })
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Repositories: []Repo{{
 				Name:     "backend",
 				Commands: []Command{{Name: "noop", Tasks: []Task{{Type: Shell, Cmd: "exit 0"}}}},
 			}},
 		},
-	}
+	})
 
 	if err := ExecuteRepoCommand("backend", "noop", nil, nil); err != nil {
 		t.Errorf("ExecuteRepoCommand() error: %v", err)
@@ -703,14 +703,14 @@ func TestExecuteRepoCommand_success(t *testing.T) {
 
 func TestExecuteRepoCommand_taskFailure(t *testing.T) {
 	setupTestConfig(t)
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Repositories: []Repo{{
 				Name:     "backend",
 				Commands: []Command{{Name: "fail", Tasks: []Task{{Type: Shell, Cmd: "exit 1"}}}},
 			}},
 		},
-	}
+	})
 
 	if err := ExecuteRepoCommand("backend", "fail", nil, nil); err == nil {
 		t.Fatal("expected error from failing task, got nil")
@@ -730,7 +730,7 @@ func TestExecuteRepoCommand_setsArgs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Repositories: []Repo{{
 				Name: "backend",
@@ -740,7 +740,7 @@ func TestExecuteRepoCommand_setsArgs(t *testing.T) {
 				}},
 			}},
 		},
-	}
+	})
 
 	if err := ExecuteRepoCommand("backend", "tmpl", []string{"hello", "world"}, nil); err != nil {
 		t.Fatalf("ExecuteRepoCommand() error: %v", err)
@@ -755,9 +755,9 @@ func TestExecuteRepoCommand_setsArgs(t *testing.T) {
 }
 
 func TestExecuteRepoCommand_nilContext(t *testing.T) {
-	old := context
-	context = nil
-	defer func() { context = old }()
+	old := loadContext()
+	storeContext(nil)
+	defer func() { storeContext(old) }()
 
 	if err := ExecuteRepoCommand("any", "any", nil, nil); err == nil {
 		t.Fatal("expected error with nil context, got nil")

--- a/src/internal/lib/config_test.go
+++ b/src/internal/lib/config_test.go
@@ -17,19 +17,19 @@ func setupTestConfig(t *testing.T) {
 	configPath := filepath.Join(dir, "config.toml")
 
 	oldCfgPath := CfgPath
-	oldContext := context
+	oldContext := loadContext()
 	oldRecent := RecentPathOverride
 	oldLock := LockPathOverride
 	t.Cleanup(func() {
 		CfgPath = oldCfgPath
-		context = oldContext
+		storeContext(oldContext)
 		RecentPathOverride = oldRecent
 		LockPathOverride = oldLock
 		viper.Reset()
 	})
 
 	CfgPath = configPath
-	context = nil
+	storeContext(nil)
 	// Redirect recent.json so tests that exercise ExecuteCommand don't
 	// pollute the developer's real ~/.raid/recent.json.
 	RecentPathOverride = filepath.Join(dir, "recent.json")

--- a/src/internal/lib/context.go
+++ b/src/internal/lib/context.go
@@ -155,12 +155,13 @@ func GetWorkspaceContext() WorkspaceContext {
 			Vars:     snapshotRaidVars(),
 		},
 	}
-	if context == nil {
+	ctx := loadContext()
+	if ctx == nil {
 		return wc
 	}
-	wc.Workspace.Env = context.Env
+	wc.Workspace.Env = ctx.Env
 
-	profile := context.Profile
+	profile := ctx.Profile
 	if profile.IsZero() {
 		return wc
 	}

--- a/src/internal/lib/context_test.go
+++ b/src/internal/lib/context_test.go
@@ -8,13 +8,13 @@ import (
 
 func resetWorkspaceContextState(t *testing.T) {
 	t.Helper()
-	prevCtx := context
+	prevCtx := loadContext()
 	prevGit := runGitFn
 	t.Cleanup(func() {
-		context = prevCtx
+		storeContext(prevCtx)
 		runGitFn = prevGit
 	})
-	context = nil
+	storeContext(nil)
 }
 
 // makeFakeGitDir creates a directory with a `.git` subdirectory so isGitRepository returns true.
@@ -44,7 +44,7 @@ func TestGetWorkspaceContext_noContext(t *testing.T) {
 
 func TestGetWorkspaceContext_zeroProfile(t *testing.T) {
 	resetWorkspaceContextState(t)
-	context = &Context{Env: "dev"}
+	storeContext(&Context{Env: "dev"})
 
 	got := GetWorkspaceContext()
 	if got.Workspace.Profile != "" {
@@ -100,7 +100,7 @@ func TestGetWorkspaceContext_omitsEmptyVars(t *testing.T) {
 
 func TestGetWorkspaceContext_includesCommands(t *testing.T) {
 	resetWorkspaceContextState(t)
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Name: "demo",
 			Path: "/tmp/demo.raid.yaml",
@@ -109,7 +109,7 @@ func TestGetWorkspaceContext_includesCommands(t *testing.T) {
 				{Name: "test", Usage: "Run tests"},
 			},
 		},
-	}
+	})
 
 	got := GetWorkspaceContext()
 	if len(got.Workspace.Commands) != 2 {
@@ -124,7 +124,7 @@ func TestGetWorkspaceContext_includesCommands(t *testing.T) {
 // command's agent block flows into the WorkspaceCommand snapshot.
 func TestGetWorkspaceContext_populatesAgentForProfileCommands(t *testing.T) {
 	resetWorkspaceContextState(t)
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Name: "demo",
 			Path: "/tmp/demo.raid.yaml",
@@ -133,7 +133,7 @@ func TestGetWorkspaceContext_populatesAgentForProfileCommands(t *testing.T) {
 				{Name: "deploy", Usage: "Deploy"}, // no Agent block
 			},
 		},
-	}
+	})
 
 	got := GetWorkspaceContext()
 	if len(got.Workspace.Commands) != 2 {
@@ -159,13 +159,13 @@ func TestGetWorkspaceContext_populatesAgentForRepoMergedCommands(t *testing.T) {
 		Agent: &Agent{Safe: true, Description: "Idempotent smoke test, safe to auto-run"},
 	}
 	merged := mergeCommands(nil, []Command{repoCommand})
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Name:     "demo",
 			Path:     "/tmp/demo.raid.yaml",
 			Commands: merged,
 		},
-	}
+	})
 
 	got := GetWorkspaceContext()
 	if len(got.Workspace.Commands) != 1 {
@@ -185,7 +185,7 @@ func TestGetWorkspaceContext_populatesAgentForRepoMergedCommands(t *testing.T) {
 // task order.
 func TestGetWorkspaceContext_commandStepsOnlyNamedTasks(t *testing.T) {
 	resetWorkspaceContextState(t)
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Name: "demo",
 			Path: "/tmp/demo.raid.yaml",
@@ -202,7 +202,7 @@ func TestGetWorkspaceContext_commandStepsOnlyNamedTasks(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	got := GetWorkspaceContext()
 	if len(got.Workspace.Commands) != 1 {
@@ -225,7 +225,7 @@ func TestGetWorkspaceContext_commandStepsOnlyNamedTasks(t *testing.T) {
 // JSON tight.
 func TestGetWorkspaceContext_commandStepsOmittedWhenNoneNamed(t *testing.T) {
 	resetWorkspaceContextState(t)
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Name: "demo",
 			Path: "/tmp/demo.raid.yaml",
@@ -240,7 +240,7 @@ func TestGetWorkspaceContext_commandStepsOmittedWhenNoneNamed(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	got := GetWorkspaceContext()
 	if len(got.Workspace.Commands) != 1 {
@@ -257,9 +257,9 @@ func TestGetWorkspaceContext_includesRecent(t *testing.T) {
 
 	started := RecordRecentStart("deploy")
 	RecordRecentEnd("deploy", nil, started)
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{Name: "demo", Path: "/tmp/demo.raid.yaml"},
-	}
+	})
 
 	got := GetWorkspaceContext()
 	if len(got.Workspace.Recent) != 1 || got.Workspace.Recent[0].Command != "deploy" {
@@ -272,7 +272,7 @@ func TestGetWorkspaceContext_includesRecent(t *testing.T) {
 
 func TestGetWorkspaceContext_repoNotCloned(t *testing.T) {
 	resetWorkspaceContextState(t)
-	context = &Context{
+	storeContext(&Context{
 		Env: "dev",
 		Profile: Profile{
 			Name: "demo",
@@ -281,7 +281,7 @@ func TestGetWorkspaceContext_repoNotCloned(t *testing.T) {
 				{Name: "missing", Path: "/nonexistent/path/abc123", URL: "https://example.com/r.git"},
 			},
 		},
-	}
+	})
 
 	got := GetWorkspaceContext()
 	if got.Workspace.Profile != "demo" {
@@ -319,7 +319,7 @@ func TestGetWorkspaceContext_repoClean(t *testing.T) {
 		return "", nil
 	}
 
-	context = &Context{
+	storeContext(&Context{
 		Env: "dev",
 		Profile: Profile{
 			Name: "demo",
@@ -328,7 +328,7 @@ func TestGetWorkspaceContext_repoClean(t *testing.T) {
 				{Name: "api", Path: dir, URL: "https://example.com/api.git"},
 			},
 		},
-	}
+	})
 
 	got := GetWorkspaceContext()
 	if len(got.Workspace.Repos) != 1 {
@@ -363,7 +363,7 @@ func TestGetWorkspaceContext_repoDirty(t *testing.T) {
 		return "", nil
 	}
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Name: "demo",
 			Path: "/tmp/demo.raid.yaml",
@@ -371,7 +371,7 @@ func TestGetWorkspaceContext_repoDirty(t *testing.T) {
 				{Name: "api", Path: dir, URL: "https://example.com/api.git"},
 			},
 		},
-	}
+	})
 
 	got := GetWorkspaceContext()
 	r := got.Workspace.Repos[0]
@@ -396,7 +396,7 @@ func TestGetWorkspaceContext_directoryWithoutGit(t *testing.T) {
 		return "", nil
 	}
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Name: "demo",
 			Path: "/tmp/demo.raid.yaml",
@@ -404,7 +404,7 @@ func TestGetWorkspaceContext_directoryWithoutGit(t *testing.T) {
 				{Name: "scratch", Path: dir, URL: "https://example.com/s.git"},
 			},
 		},
-	}
+	})
 
 	got := GetWorkspaceContext()
 	r := got.Workspace.Repos[0]
@@ -421,7 +421,7 @@ func TestGetWorkspaceContext_gitErrorsLeaveFieldsZeroed(t *testing.T) {
 		return "", os.ErrNotExist
 	}
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Name: "demo",
 			Path: "/tmp/demo.raid.yaml",
@@ -429,7 +429,7 @@ func TestGetWorkspaceContext_gitErrorsLeaveFieldsZeroed(t *testing.T) {
 				{Name: "broken", Path: dir, URL: "https://example.com/b.git"},
 			},
 		},
-	}
+	})
 
 	got := GetWorkspaceContext()
 	r := got.Workspace.Repos[0]

--- a/src/internal/lib/env.go
+++ b/src/internal/lib/env.go
@@ -46,12 +46,13 @@ func GetEnv() string {
 
 // ListEnvs returns the names of all environments in the active profile.
 func ListEnvs() []string {
-	if context == nil || len(context.Profile.Environments) == 0 {
+	ctx := loadContext()
+	if ctx == nil || len(ctx.Profile.Environments) == 0 {
 		return []string{}
 	}
 
-	names := make([]string, 0, len(context.Profile.Environments))
-	for _, env := range context.Profile.Environments {
+	names := make([]string, 0, len(ctx.Profile.Environments))
+	for _, env := range ctx.Profile.Environments {
 		names = append(names, env.Name)
 	}
 	return names
@@ -69,20 +70,21 @@ func ContainsEnv(name string) bool {
 
 // ExecuteEnv writes environment variables to each repo's .env file and runs the environment's tasks.
 func ExecuteEnv(name string) error {
-	if context == nil {
+	ctx := loadContext()
+	if ctx == nil {
 		return liberrs.Internal("raid context is not initialized")
 	}
-	if err := setEnvVariablesForRepos(name); err != nil {
+	if err := setEnvVariablesForRepos(ctx, name); err != nil {
 		return liberrs.Newf(liberrs.CodeConfigInvalid, liberrs.CategoryConfig, "failed to set env variables: %v", err)
 	}
-	if err := runTasksForEnv(name); err != nil {
+	if err := runTasksForEnv(ctx, name); err != nil {
 		return liberrs.Newf(liberrs.CodeTaskFailed, liberrs.CategoryTask, "failed to run env tasks: %v", err)
 	}
 	return nil
 }
 
-func setEnvVariablesForRepos(name string) error {
-	for _, repo := range context.Profile.Repositories {
+func setEnvVariablesForRepos(ctx *Context, name string) error {
+	for _, repo := range ctx.Profile.Repositories {
 		fmt.Fprintf(commandStdout, "Setting up environment for repo: %s\n", repo.Name)
 
 		path, err := buildEnvPath(repo.Path)
@@ -90,7 +92,7 @@ func setEnvVariablesForRepos(name string) error {
 			return liberrs.Newf(liberrs.CodeConfigInvalid, liberrs.CategoryConfig, "invalid path for repo '%s': %v", repo.Name, err)
 		}
 
-		if err := setEnvVariables(context.Profile.getEnv(name).Variables, repo.getEnv(name).Variables, path); err != nil {
+		if err := setEnvVariables(ctx.Profile.getEnv(name).Variables, repo.getEnv(name).Variables, path); err != nil {
 			return liberrs.Newf(liberrs.CodeConfigInvalid, liberrs.CategoryConfig, "failed to set env variables for repo '%s': %v", repo.Name, err)
 		}
 	}
@@ -123,8 +125,8 @@ func setEnvVariables(profVars []EnvVar, repoVars []EnvVar, path string) error {
 	return godotenv.Write(envMap, path)
 }
 
-func runTasksForEnv(name string) error {
-	env := context.Profile.getEnv(name)
+func runTasksForEnv(ctx *Context, name string) error {
+	env := ctx.Profile.getEnv(name)
 	if env.IsZero() || len(env.Tasks) == 0 {
 		return nil
 	}
@@ -133,12 +135,13 @@ func runTasksForEnv(name string) error {
 
 // LoadEnv loads .env files from all repositories in the active profile into the process environment.
 func LoadEnv() error {
-	if context == nil {
+	ctx := loadContext()
+	if ctx == nil {
 		return liberrs.Internal("context not initialized")
 	}
 
 	var paths []string
-	for _, r := range context.Profile.Repositories {
+	for _, r := range ctx.Profile.Repositories {
 		p := filepath.Join(sys.ExpandPath(r.Path), ".env")
 		if sys.FileExists(p) {
 			paths = append(paths, p)

--- a/src/internal/lib/env_test.go
+++ b/src/internal/lib/env_test.go
@@ -36,9 +36,9 @@ func TestListEnvs_nilContext(t *testing.T) {
 func TestListEnvs_emptyEnvironments(t *testing.T) {
 	setupTestConfig(t)
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{Name: "test", Path: "/path"},
-	}
+	})
 
 	envs := ListEnvs()
 	if len(envs) != 0 {
@@ -49,14 +49,14 @@ func TestListEnvs_emptyEnvironments(t *testing.T) {
 func TestListEnvs_withEnvironments(t *testing.T) {
 	setupTestConfig(t)
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Environments: []Env{
 				{Name: "dev"},
 				{Name: "prod"},
 			},
 		},
-	}
+	})
 
 	envs := ListEnvs()
 	if len(envs) != 2 {
@@ -67,13 +67,13 @@ func TestListEnvs_withEnvironments(t *testing.T) {
 func TestContainsEnv(t *testing.T) {
 	setupTestConfig(t)
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Environments: []Env{
 				{Name: "dev"},
 			},
 		},
-	}
+	})
 
 	if !ContainsEnv("dev") {
 		t.Error("ContainsEnv(\"dev\") = false, want true")
@@ -95,11 +95,11 @@ func TestSetEnv_emptyName(t *testing.T) {
 func TestSetEnv_notFound(t *testing.T) {
 	setupTestConfig(t)
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Environments: []Env{{Name: "dev"}},
 		},
-	}
+	})
 
 	err := SetEnv("nonexistent")
 	if err == nil {
@@ -110,11 +110,11 @@ func TestSetEnv_notFound(t *testing.T) {
 func TestSetAndGetEnv(t *testing.T) {
 	setupTestConfig(t)
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Environments: []Env{{Name: "dev"}},
 		},
-	}
+	})
 
 	if err := SetEnv("dev"); err != nil {
 		t.Fatalf("SetEnv() error: %v", err)
@@ -137,7 +137,7 @@ func TestExecuteEnv_buildEnvPathError(t *testing.T) {
 	tmpFile.Close()
 	defer os.Remove(tmpFile.Name())
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Name: "test",
 			Path: "/test",
@@ -145,7 +145,7 @@ func TestExecuteEnv_buildEnvPathError(t *testing.T) {
 				{Name: "repo1", Path: tmpFile.Name(), URL: "http://x.com"},
 			},
 		},
-	}
+	})
 
 	err = ExecuteEnv("dev")
 	if err == nil {
@@ -158,7 +158,7 @@ func TestExecuteEnv_taskFailure(t *testing.T) {
 
 	dir := t.TempDir()
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Name: "test",
 			Path: "/test",
@@ -172,7 +172,7 @@ func TestExecuteEnv_taskFailure(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	err := ExecuteEnv("dev")
 	if err == nil {
@@ -185,7 +185,7 @@ func TestExecuteEnv_success(t *testing.T) {
 
 	dir := t.TempDir()
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Name: "test",
 			Path: "/test",
@@ -199,7 +199,7 @@ func TestExecuteEnv_success(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	if err := ExecuteEnv("dev"); err != nil {
 		t.Errorf("ExecuteEnv() error: %v", err)
@@ -211,7 +211,7 @@ func TestExecuteEnv_noMatchingEnvTasks(t *testing.T) {
 
 	dir := t.TempDir()
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Name: "test",
 			Path: "/test",
@@ -220,7 +220,7 @@ func TestExecuteEnv_noMatchingEnvTasks(t *testing.T) {
 			},
 			// No environments defined — env name won't match anything.
 		},
-	}
+	})
 
 	// Runs setEnvVariablesForRepos (empty vars) then runTasksForEnv (zero env, returns nil).
 	if err := ExecuteEnv("nonexistent"); err != nil {
@@ -229,7 +229,7 @@ func TestExecuteEnv_noMatchingEnvTasks(t *testing.T) {
 }
 
 func TestLoadEnv_nilContext(t *testing.T) {
-	context = nil
+	storeContext(nil)
 
 	err := LoadEnv()
 	if err == nil {
@@ -240,13 +240,13 @@ func TestLoadEnv_nilContext(t *testing.T) {
 func TestLoadEnv_noEnvFiles(t *testing.T) {
 	setupTestConfig(t)
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Repositories: []Repo{
 				{Name: "repo1", Path: "/nonexistent/path"},
 			},
 		},
-	}
+	})
 
 	if err := LoadEnv(); err != nil {
 		t.Errorf("LoadEnv() with no .env files error: %v", err)
@@ -263,13 +263,13 @@ func TestLoadEnv_withEnvFiles(t *testing.T) {
 	}
 	defer os.Unsetenv("RAID_LOAD_TEST")
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Repositories: []Repo{
 				{Name: "repo1", Path: dir},
 			},
 		},
-	}
+	})
 
 	if err := LoadEnv(); err != nil {
 		t.Errorf("LoadEnv() with .env files error: %v", err)
@@ -281,7 +281,7 @@ func TestExecuteEnv_repoEnvVars(t *testing.T) {
 
 	dir := t.TempDir()
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Name: "test",
 			Path: "/test",
@@ -306,7 +306,7 @@ func TestExecuteEnv_repoEnvVars(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	if err := ExecuteEnv("dev"); err != nil {
 		t.Errorf("ExecuteEnv() with repo env vars error: %v", err)
@@ -327,7 +327,7 @@ func TestExecuteEnv_setEnvWriteError(t *testing.T) {
 	}
 	defer os.Chmod(envPath, 0644)
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Name: "test",
 			Path: "/test",
@@ -338,7 +338,7 @@ func TestExecuteEnv_setEnvWriteError(t *testing.T) {
 				{Name: "dev", Variables: []EnvVar{{Name: "KEY", Value: "val"}}},
 			},
 		},
-	}
+	})
 
 	if err := ExecuteEnv("dev"); err == nil {
 		t.Fatal("ExecuteEnv() expected error when .env is read-only")
@@ -355,13 +355,13 @@ func TestLoadEnv_loadFailure(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Repositories: []Repo{
 				{Name: "repo1", Path: dir},
 			},
 		},
-	}
+	})
 
 	if err := LoadEnv(); err == nil {
 		t.Fatal("LoadEnv() expected error when .env is a directory")
@@ -371,9 +371,9 @@ func TestLoadEnv_loadFailure(t *testing.T) {
 func TestLoadEnv_emptyRepositories(t *testing.T) {
 	setupTestConfig(t)
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{},
-	}
+	})
 
 	if err := LoadEnv(); err != nil {
 		t.Errorf("LoadEnv() with empty repositories error: %v", err)

--- a/src/internal/lib/lib.go
+++ b/src/internal/lib/lib.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/8bitalex/raid/schemas"
@@ -39,7 +40,37 @@ type OnInstall struct {
 	Tasks []Task `json:"tasks"`
 }
 
-var context *Context
+// contextPtr is the active workspace context. Replaced wholly via
+// storeContext on Load/ForceLoad; never mutated in-place. Reads go
+// through loadContext.
+//
+// Atomic.Pointer is the right primitive here: writes are rare
+// (Load / ForceLoad / Reset only), reads are frequent (every
+// command/task dispatch + every MCP read), and the value is always
+// wholly replaced rather than partially mutated. mcp-go runs tool
+// handlers from a 5-worker pool, so a mutating handler that calls
+// ForceLoad can race with a read handler that reads context.Profile —
+// the atomic pointer makes the swap+read interleave well-defined.
+//
+// Callers must use loadContext() once per logical operation and bind
+// to a local. "Check nil then read field" patterns must NOT re-call
+// loadContext between the check and the read — otherwise a swap
+// could land in between.
+var contextPtr atomic.Pointer[Context]
+
+// loadContext returns the current active context, or nil when no
+// profile has been loaded yet. Safe for concurrent reads; consumers
+// should bind the result to a local before nil-checking + reading.
+func loadContext() *Context {
+	return contextPtr.Load()
+}
+
+// storeContext atomically replaces the active context. Passing nil
+// resets the context to "not loaded" (Load / Reset paths). Callers
+// outside lib should not need this — use Load / ForceLoad instead.
+func storeContext(c *Context) {
+	contextPtr.Store(c)
+}
 
 const raidVarsFileName = "vars"
 
@@ -318,12 +349,12 @@ func QuietLoad() []Command {
 // ResetContext clears the cached load context, forcing the next Load or ForceLoad to
 // rebuild from the current viper configuration.
 func ResetContext() {
-	context = nil
+	storeContext(nil)
 }
 
 // Load initializes the context from the active profile, using cached results if available.
 func Load() error {
-	if context == nil {
+	if loadContext() == nil {
 		return ForceLoad()
 	}
 	return nil
@@ -337,7 +368,7 @@ func ForceLoad() error {
 	loadRaidVars()
 	p := GetProfile()
 	if p.IsZero() {
-		context = &Context{Env: GetEnv()}
+		storeContext(&Context{Env: GetEnv()})
 		return nil
 	}
 
@@ -375,10 +406,10 @@ func ForceLoad() error {
 
 	setRepoVars(profile.Repositories)
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: profile,
 		Env:     GetEnv(),
-	}
+	})
 	return nil
 }
 
@@ -489,10 +520,11 @@ func installRepo(repo Repo) error {
 // InstallRepo clones a single named repository and runs its install tasks.
 // The profile-level install tasks are not run.
 func InstallRepo(name string) error {
-	if context == nil {
+	ctx := loadContext()
+	if ctx == nil {
 		return liberrs.Internal("raid context is not initialized")
 	}
-	profile := context.Profile
+	profile := ctx.Profile
 	if profile.IsZero() {
 		return liberrs.Newf(liberrs.CodeProfileNotActive, liberrs.CategoryNotFound, "profile not found")
 	}
@@ -513,10 +545,11 @@ func InstallRepo(name string) error {
 
 // Install clones all repositories in the active profile and runs install tasks.
 func Install(maxThreads int) error {
-	if context == nil {
+	ctx := loadContext()
+	if ctx == nil {
 		return liberrs.Internal("raid context is not initialized")
 	}
-	profile := context.Profile
+	profile := ctx.Profile
 	if profile.IsZero() {
 		return liberrs.Newf(liberrs.CodeProfileNotActive, liberrs.CategoryNotFound, "profile not found")
 	}

--- a/src/internal/lib/lib.go
+++ b/src/internal/lib/lib.go
@@ -131,9 +131,16 @@ func loadRaidVars() {
 	// versions (godotenv defaults to 0644). The file may carry
 	// scrubbed-but-still-private RAID_REPO_*_URL entries and any
 	// Set-task values that the project author treats as secret-ish,
-	// so it should be 0600. Best-effort: chmod failures (read-only
+	// so it should be 0600.
+	//
+	// Use Lstat so a symlinked path doesn't get its target chmodded,
+	// and only touch regular files — a directory or device at this
+	// path is a misconfiguration we shouldn't compound by stripping
+	// its mode bits. Best-effort: chmod failures (read-only
 	// filesystems, foreign-owned files) don't block the load.
-	_ = os.Chmod(path, 0600)
+	if fi, err := os.Lstat(path); err == nil && fi.Mode().IsRegular() {
+		_ = os.Chmod(path, 0600)
+	}
 	m, err := godotenv.Read(path)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "raid: failed to load persisted vars from %s: %v\n", path, err)
@@ -454,18 +461,20 @@ func setRepoVars(repos []Repo) {
 	}
 }
 
-// ScrubURL strips userinfo (user:password@) from an HTTPS-style URL so
-// credentials embedded in a clone URL never get persisted or surfaced
-// to MCP clients. Returns the input unchanged when:
+// ScrubURL strips userinfo (user:password@) from a credential-bearing
+// URL so secrets embedded in a clone URL never get persisted or
+// surfaced to MCP clients. Returns the input unchanged when:
 //
 //   - it's empty
-//   - it's an SSH-style URL (`git@host:repo.git`) where there's no
-//     userinfo component to leak
+//   - it's an SSH-style URL (`git@host:repo.git` or `ssh://git@host/…`)
+//     where the username is the protocol's required login, not a
+//     credential — stripping it would change clone semantics
 //   - it can't be parsed as a URL (treated as opaque)
 //
-// HTTPS / HTTP URLs with an embedded user (e.g. `https://x-token-auth:
-// <secret>@github.com/...`) come back with `u.User = nil`. The scheme,
-// host, path, and query are preserved verbatim.
+// Only `http` and `https` schemes get scrubbed: those are the ones
+// where userinfo carries tokens / basic-auth secrets. SSH userinfo
+// (the `git` user) is preserved so a scrubbed URL is still a valid
+// clone URL for downstream consumers.
 func ScrubURL(raw string) string {
 	if raw == "" {
 		return ""
@@ -474,8 +483,13 @@ func ScrubURL(raw string) string {
 	if err != nil || u.User == nil {
 		return raw
 	}
-	u.User = nil
-	return u.String()
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+		u.User = nil
+		return u.String()
+	default:
+		return raw
+	}
 }
 
 // sanitizeRepoVarName converts a repo name into the uppercase identifier

--- a/src/internal/lib/lib.go
+++ b/src/internal/lib/lib.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -95,6 +96,13 @@ func loadRaidVars() {
 	if !sys.FileExists(path) {
 		return
 	}
+	// Tighten perms on existing vars files written by earlier raid
+	// versions (godotenv defaults to 0644). The file may carry
+	// scrubbed-but-still-private RAID_REPO_*_URL entries and any
+	// Set-task values that the project author treats as secret-ish,
+	// so it should be 0600. Best-effort: chmod failures (read-only
+	// filesystems, foreign-owned files) don't block the load.
+	_ = os.Chmod(path, 0600)
 	m, err := godotenv.Read(path)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "raid: failed to load persisted vars from %s: %v\n", path, err)
@@ -384,6 +392,11 @@ func ForceLoad() error {
 // renamed repo persisted to ~/.raid/vars) are pruned first. Sanitized-name
 // collisions between repos (e.g. "my-api" and "my_api" both → MY_API) are
 // reported to stderr; the last repo wins so behavior is deterministic.
+//
+// URLs are scrubbed of userinfo before storage so an HTTPS clone URL
+// embedding credentials (`https://user:token@host/...`) doesn't end up
+// persisted to ~/.raid/vars or served verbatim through the MCP vars
+// resource. See ScrubURL for the contract.
 func setRepoVars(repos []Repo) {
 	raidVarsMu.Lock()
 	defer raidVarsMu.Unlock()
@@ -404,10 +417,34 @@ func setRepoVars(repos []Repo) {
 				prev, repo.Name, key, repo.Name)
 		}
 		seen[key] = repo.Name
-		raidVars["RAID_REPO_"+key+"_URL"] = repo.URL
+		raidVars["RAID_REPO_"+key+"_URL"] = ScrubURL(repo.URL)
 		raidVars["RAID_REPO_"+key+"_PATH"] = sys.ExpandPath(repo.Path)
 		raidVars["RAID_REPO_"+key+"_BRANCH"] = repo.Branch
 	}
+}
+
+// ScrubURL strips userinfo (user:password@) from an HTTPS-style URL so
+// credentials embedded in a clone URL never get persisted or surfaced
+// to MCP clients. Returns the input unchanged when:
+//
+//   - it's empty
+//   - it's an SSH-style URL (`git@host:repo.git`) where there's no
+//     userinfo component to leak
+//   - it can't be parsed as a URL (treated as opaque)
+//
+// HTTPS / HTTP URLs with an embedded user (e.g. `https://x-token-auth:
+// <secret>@github.com/...`) come back with `u.User = nil`. The scheme,
+// host, path, and query are preserved verbatim.
+func ScrubURL(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.User == nil {
+		return raw
+	}
+	u.User = nil
+	return u.String()
 }
 
 // sanitizeRepoVarName converts a repo name into the uppercase identifier

--- a/src/internal/lib/lib_test.go
+++ b/src/internal/lib/lib_test.go
@@ -1164,6 +1164,71 @@ func TestSetRepoVars_overwritesPriorEntries(t *testing.T) {
 	}
 }
 
+// TestSetRepoVars_scrubsCredentialsFromURL pins bug C2: a profile YAML
+// using `https://user:token@host/...` as a clone URL must not persist
+// the credential to ~/.raid/vars or surface it through MCP.
+// setRepoVars is the choke point — once a URL passes through it,
+// downstream consumers (the vars resource, every Print/Set task
+// referencing $RAID_REPO_*_URL, etc.) see the scrubbed form.
+func TestSetRepoVars_scrubsCredentialsFromURL(t *testing.T) {
+	withCleanRaidVars(t)
+
+	setRepoVars([]Repo{
+		{Name: "api", Path: "/tmp/api", URL: "https://alice:s3cret@github.com/org/repo.git"},
+		{Name: "ssh", Path: "/tmp/ssh", URL: "git@github.com:org/ssh-repo.git"},
+		{Name: "plain", Path: "/tmp/plain", URL: "https://github.com/org/plain.git"},
+	})
+
+	raidVarsMu.RLock()
+	apiURL := raidVars["RAID_REPO_API_URL"]
+	sshURL := raidVars["RAID_REPO_SSH_URL"]
+	plainURL := raidVars["RAID_REPO_PLAIN_URL"]
+	raidVarsMu.RUnlock()
+
+	if strings.Contains(apiURL, "alice") || strings.Contains(apiURL, "s3cret") {
+		t.Errorf("RAID_REPO_API_URL leaked credentials: %q", apiURL)
+	}
+	if apiURL != "https://github.com/org/repo.git" {
+		t.Errorf("RAID_REPO_API_URL = %q, want scheme+host+path preserved", apiURL)
+	}
+	// SSH URLs have no userinfo to scrub — must round-trip verbatim.
+	if sshURL != "git@github.com:org/ssh-repo.git" {
+		t.Errorf("SSH URL mangled: got %q, want %q", sshURL, "git@github.com:org/ssh-repo.git")
+	}
+	// Plain HTTPS URLs must round-trip verbatim too.
+	if plainURL != "https://github.com/org/plain.git" {
+		t.Errorf("plain HTTPS URL mangled: got %q, want %q", plainURL, "https://github.com/org/plain.git")
+	}
+}
+
+// TestScrubURL covers the helper in isolation against the edge cases
+// setRepoVars exercises in aggregate.
+func TestScrubURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"https with userinfo", "https://alice:secret@github.com/org/repo.git", "https://github.com/org/repo.git"},
+		{"https user only", "https://alice@github.com/org/repo.git", "https://github.com/org/repo.git"},
+		{"https no userinfo", "https://github.com/org/repo.git", "https://github.com/org/repo.git"},
+		{"http with userinfo", "http://u:p@example.com/", "http://example.com/"},
+		{"ssh scp-style", "git@github.com:org/repo.git", "git@github.com:org/repo.git"},
+		{"ssh url scheme", "ssh://git@github.com/org/repo.git", "ssh://github.com/org/repo.git"},
+		{"unparseable", "://broken", "://broken"},
+		{"path only", "/local/path", "/local/path"},
+		{"query preserved", "https://alice:s@host/p?ref=main", "https://host/p?ref=main"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ScrubURL(tt.in); got != tt.want {
+				t.Errorf("ScrubURL(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestForceLoad_seedsRepoVars(t *testing.T) {
 	root := repoRoot(t)
 	setupTestConfig(t)

--- a/src/internal/lib/lib_test.go
+++ b/src/internal/lib/lib_test.go
@@ -142,10 +142,18 @@ func TestForceLoad_noActiveProfile(t *testing.T) {
 // read handlers (raid_list_repos, raid_describe_repo, raid_list_profiles)
 // concurrently read the package-global context pointer. Before the
 // atomic.Pointer refactor this was an undefined-behavior race that
-// `go test -race` would flag. The test stresses that interleave —
-// many readers + one writer hammering the pointer — and relies on the
-// race detector to surface a regression if anyone reintroduces a
-// non-atomic write to the context.
+// `go test -race` would flag.
+//
+// CI-coverage caveat: this regression only fails loudly when the suite
+// runs under `-race`. The repo's default workflow runs
+// `go test -v ./...` without the race detector, so a non-atomic
+// pointer write reintroduced into production code would slip past
+// CI even with this test in place. The race target is meant to be
+// caught locally (`go test -race ./...`) and via the dedicated race
+// CI lane that should accompany this fix; the test is structured to
+// give the detector the strongest possible signal — a synchronized
+// start and continuous writer activity while readers are running —
+// rather than relying on goroutine scheduling luck.
 func TestContextRaceForceLoadVsReads(t *testing.T) {
 	setupTestConfig(t)
 
@@ -156,13 +164,30 @@ func TestContextRaceForceLoadVsReads(t *testing.T) {
 	}}})
 
 	const readers = 8
-	const iterations = 200
-	done := make(chan struct{})
+	const iterations = 1000
+
+	// Start barrier: every goroutine blocks on `start` so the writer
+	// can't sprint past the readers' first iteration before they're
+	// scheduled. Without this, fast machines can finish the writer
+	// loop before any reader runs and the race detector has nothing
+	// to observe.
+	start := make(chan struct{})
+	stop := make(chan struct{})
+
+	writerDone := make(chan struct{})
 	go func() {
-		// Writer: replaces the context wholesale. Doesn't go through
-		// ForceLoad (which requires viper state) — emulates the same
-		// atomic-pointer swap path.
-		for i := 0; i < iterations; i++ {
+		defer close(writerDone)
+		<-start
+		// Keep writing until readers are done so reads and writes
+		// genuinely overlap. Doesn't go through ForceLoad (which
+		// requires viper state) — emulates the same atomic-pointer
+		// swap path.
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
 			storeContext(&Context{Profile: Profile{
 				Name: "race-test",
 				Repositories: []Repo{
@@ -171,16 +196,16 @@ func TestContextRaceForceLoadVsReads(t *testing.T) {
 				},
 			}})
 		}
-		close(done)
 	}()
 
-	// Readers: walk fields the way GetCommands / GetRepos /
-	// GetWorkspaceContext do.
 	var wg sync.WaitGroup
 	wg.Add(readers)
 	for r := 0; r < readers; r++ {
 		go func() {
 			defer wg.Done()
+			<-start
+			// Readers: walk fields the way GetCommands / GetRepos /
+			// GetWorkspaceContext do.
 			for i := 0; i < iterations; i++ {
 				_ = GetRepos()
 				_ = GetCommands()
@@ -188,8 +213,11 @@ func TestContextRaceForceLoadVsReads(t *testing.T) {
 			}
 		}()
 	}
+
+	close(start)
 	wg.Wait()
-	<-done
+	close(stop)
+	<-writerDone
 
 	// If we got here under -race without a fatal, the atomic-pointer
 	// contract held. The assertion is implicit in the race detector.
@@ -1277,7 +1305,8 @@ func TestScrubURL(t *testing.T) {
 		{"https no userinfo", "https://github.com/org/repo.git", "https://github.com/org/repo.git"},
 		{"http with userinfo", "http://u:p@example.com/", "http://example.com/"},
 		{"ssh scp-style", "git@github.com:org/repo.git", "git@github.com:org/repo.git"},
-		{"ssh url scheme", "ssh://git@github.com/org/repo.git", "ssh://github.com/org/repo.git"},
+		{"ssh url scheme preserves user", "ssh://git@github.com/org/repo.git", "ssh://git@github.com/org/repo.git"},
+		{"git+ssh preserves user", "git+ssh://git@example.com/org/repo.git", "git+ssh://git@example.com/org/repo.git"},
 		{"unparseable", "://broken", "://broken"},
 		{"path only", "/local/path", "/local/path"},
 		{"query preserved", "https://alice:s@host/p?ref=main", "https://host/p?ref=main"},

--- a/src/internal/lib/lib_test.go
+++ b/src/internal/lib/lib_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -63,13 +64,13 @@ func TestLoad_noContext(t *testing.T) {
 func TestLoad_withExistingContext(t *testing.T) {
 	setupTestConfig(t)
 
-	context = &Context{Profile: Profile{Name: "test", Path: "/path"}}
+	storeContext(&Context{Profile: Profile{Name: "test", Path: "/path"}})
 
 	if err := Load(); err != nil {
 		t.Errorf("Load() with existing context error: %v", err)
 	}
 	// Should not reload — cached context must be preserved.
-	if context.Profile.Name != "test" {
+	if loadContext().Profile.Name != "test" {
 		t.Errorf("Load() modified existing context unexpectedly")
 	}
 }
@@ -131,8 +132,69 @@ func TestForceLoad_noActiveProfile(t *testing.T) {
 	if err := ForceLoad(); err != nil {
 		t.Errorf("ForceLoad() with no active profile error: %v", err)
 	}
-	if context == nil {
+	if loadContext() == nil {
 		t.Fatal("ForceLoad() did not set context")
+	}
+}
+
+// TestContextRaceForceLoadVsReads pins bug C3: ForceLoad is called
+// from mutating MCP handlers (raid_install, raid_env_switch, …) while
+// read handlers (raid_list_repos, raid_describe_repo, raid_list_profiles)
+// concurrently read the package-global context pointer. Before the
+// atomic.Pointer refactor this was an undefined-behavior race that
+// `go test -race` would flag. The test stresses that interleave —
+// many readers + one writer hammering the pointer — and relies on the
+// race detector to surface a regression if anyone reintroduces a
+// non-atomic write to the context.
+func TestContextRaceForceLoadVsReads(t *testing.T) {
+	setupTestConfig(t)
+
+	// Seed an initial context so reads have something to walk.
+	storeContext(&Context{Profile: Profile{Name: "race-test", Repositories: []Repo{
+		{Name: "a", Path: "/tmp/a"},
+		{Name: "b", Path: "/tmp/b"},
+	}}})
+
+	const readers = 8
+	const iterations = 200
+	done := make(chan struct{})
+	go func() {
+		// Writer: replaces the context wholesale. Doesn't go through
+		// ForceLoad (which requires viper state) — emulates the same
+		// atomic-pointer swap path.
+		for i := 0; i < iterations; i++ {
+			storeContext(&Context{Profile: Profile{
+				Name: "race-test",
+				Repositories: []Repo{
+					{Name: "a", Path: "/tmp/a"},
+					{Name: "b", Path: "/tmp/b"},
+				},
+			}})
+		}
+		close(done)
+	}()
+
+	// Readers: walk fields the way GetCommands / GetRepos /
+	// GetWorkspaceContext do.
+	var wg sync.WaitGroup
+	wg.Add(readers)
+	for r := 0; r < readers; r++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				_ = GetRepos()
+				_ = GetCommands()
+				_ = GetProfile()
+			}
+		}()
+	}
+	wg.Wait()
+	<-done
+
+	// If we got here under -race without a fatal, the atomic-pointer
+	// contract held. The assertion is implicit in the race detector.
+	if loadContext() == nil {
+		t.Fatal("context unexpectedly nil after race test")
 	}
 }
 
@@ -168,8 +230,8 @@ func TestForceLoad_withValidProfile(t *testing.T) {
 	if err := ForceLoad(); err != nil {
 		t.Errorf("ForceLoad() with valid profile error: %v", err)
 	}
-	if context == nil || context.Profile.Name != "testprofile" {
-		t.Errorf("ForceLoad() context = %v, want profile named testprofile", context)
+	if loadContext() == nil || loadContext().Profile.Name != "testprofile" {
+		t.Errorf("ForceLoad() context = %v, want profile named testprofile", loadContext())
 	}
 }
 
@@ -284,7 +346,7 @@ func TestValidateSchema_schemaViolation(t *testing.T) {
 func TestInstall_noProfile(t *testing.T) {
 	setupTestConfig(t)
 
-	context = &Context{Profile: Profile{}}
+	storeContext(&Context{Profile: Profile{}})
 
 	err := Install(1)
 	if err == nil {
@@ -295,9 +357,9 @@ func TestInstall_noProfile(t *testing.T) {
 func TestInstall_noRepos(t *testing.T) {
 	setupTestConfig(t)
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{Name: "test", Path: "/path"},
-	}
+	})
 
 	if err := Install(0); err != nil {
 		t.Errorf("Install() with no repos error: %v", err)
@@ -311,7 +373,7 @@ func TestInstall_withSemaphoreAndExistingRepo(t *testing.T) {
 	// Fake git repo — CloneRepository will skip cloning.
 	os.MkdirAll(filepath.Join(dir, ".git"), 0755)
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Name: "test",
 			Path: "/path",
@@ -319,7 +381,7 @@ func TestInstall_withSemaphoreAndExistingRepo(t *testing.T) {
 				{Name: "repo1", Path: dir, URL: "http://example.com"},
 			},
 		},
-	}
+	})
 
 	// maxThreads=1 exercises the semaphore acquisition/release paths.
 	if err := Install(1); err != nil {
@@ -332,7 +394,7 @@ func TestInstall_cloneFailure(t *testing.T) {
 
 	dir := t.TempDir()
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Name: "test",
 			Path: "/path",
@@ -341,7 +403,7 @@ func TestInstall_cloneFailure(t *testing.T) {
 				{Name: "repo1", Path: filepath.Join(dir, "newrepo"), URL: "file:///nonexistent/repo.git"},
 			},
 		},
-	}
+	})
 
 	err := Install(0)
 	if err == nil {
@@ -352,7 +414,7 @@ func TestInstall_cloneFailure(t *testing.T) {
 func TestInstall_installTaskFailure(t *testing.T) {
 	setupTestConfig(t)
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Name: "test",
 			Path: "/path",
@@ -360,7 +422,7 @@ func TestInstall_installTaskFailure(t *testing.T) {
 				Tasks: []Task{{Type: Shell, Cmd: "exit 1"}},
 			},
 		},
-	}
+	})
 
 	err := Install(0)
 	if err == nil {
@@ -374,7 +436,7 @@ func TestInstall_repoInstallTaskFailure(t *testing.T) {
 	dir := t.TempDir()
 	os.MkdirAll(filepath.Join(dir, ".git"), 0755)
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Name: "test",
 			Path: "/path",
@@ -389,7 +451,7 @@ func TestInstall_repoInstallTaskFailure(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 
 	err := Install(0)
 	if err == nil {
@@ -399,7 +461,7 @@ func TestInstall_repoInstallTaskFailure(t *testing.T) {
 
 func TestInstallRepo_notFound(t *testing.T) {
 	setupTestConfig(t)
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Name: "test",
 			Path: "/path",
@@ -407,7 +469,7 @@ func TestInstallRepo_notFound(t *testing.T) {
 				{Name: "repo1", Path: t.TempDir(), URL: "http://example.com"},
 			},
 		},
-	}
+	})
 
 	err := InstallRepo("doesnotexist")
 	if err == nil {
@@ -436,7 +498,7 @@ func TestInstallRepo_clonesAndRunsTasks(t *testing.T) {
 		raidVarsMu.Unlock()
 	})
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Name: "test",
 			Path: "/path",
@@ -453,7 +515,7 @@ func TestInstallRepo_clonesAndRunsTasks(t *testing.T) {
 				{Name: "other", Path: t.TempDir(), URL: "http://example.com"},
 			},
 		},
-	}
+	})
 
 	if err := InstallRepo("target"); err != nil {
 		t.Fatalf("InstallRepo() error: %v", err)
@@ -483,7 +545,7 @@ func TestInstallRepo_doesNotRunProfileTasks(t *testing.T) {
 		raidVarsMu.Unlock()
 	})
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Name: "test",
 			Path: "/path",
@@ -494,7 +556,7 @@ func TestInstallRepo_doesNotRunProfileTasks(t *testing.T) {
 				{Name: "repo1", Path: dir, URL: "http://example.com"},
 			},
 		},
-	}
+	})
 
 	if err := InstallRepo("repo1"); err != nil {
 		t.Fatalf("InstallRepo() error: %v", err)
@@ -509,7 +571,7 @@ func TestInstallRepo_doesNotRunProfileTasks(t *testing.T) {
 
 func TestInstallRepo_noContext(t *testing.T) {
 	setupTestConfig(t)
-	context = nil
+	storeContext(nil)
 
 	if err := InstallRepo("any"); err == nil {
 		t.Fatal("InstallRepo() expected error when context is nil")
@@ -518,7 +580,7 @@ func TestInstallRepo_noContext(t *testing.T) {
 
 func TestInstallRepo_noProfile(t *testing.T) {
 	setupTestConfig(t)
-	context = &Context{Profile: Profile{}}
+	storeContext(&Context{Profile: Profile{}})
 
 	if err := InstallRepo("any"); err == nil {
 		t.Fatal("InstallRepo() expected error when profile is zero")
@@ -573,10 +635,10 @@ func TestForceLoad_mergesRepoCommands(t *testing.T) {
 
 func TestResetContext_nilsContext(t *testing.T) {
 	setupTestConfig(t)
-	context = &Context{Profile: Profile{Name: "foo"}}
+	storeContext(&Context{Profile: Profile{Name: "foo"}})
 	ResetContext()
-	if context != nil {
-		t.Errorf("ResetContext() did not nil context, got %v", context)
+	if loadContext() != nil {
+		t.Errorf("ResetContext() did not nil context, got %v", loadContext())
 	}
 }
 
@@ -894,7 +956,7 @@ func TestRaidVarsPath_default(t *testing.T) {
 // TestInstall_nilContext tests the early return branch when context is nil.
 func TestInstall_nilContext(t *testing.T) {
 	setupTestConfig(t)
-	context = nil
+	storeContext(nil)
 
 	if err := Install(0); err == nil {
 		t.Error("Install() expected error when context is nil")
@@ -960,8 +1022,8 @@ func TestForceLoad_withGroups(t *testing.T) {
 	if err := ForceLoad(); err != nil {
 		t.Fatalf("ForceLoad with groups: %v", err)
 	}
-	if context == nil || len(context.Profile.Groups) != 2 {
-		t.Errorf("ForceLoad: expected 2 groups, got %v", context)
+	if loadContext() == nil || len(loadContext().Profile.Groups) != 2 {
+		t.Errorf("ForceLoad: expected 2 groups, got %v", loadContext())
 	}
 }
 
@@ -973,7 +1035,7 @@ func TestInstallRepo_installTaskError(t *testing.T) {
 	dir := t.TempDir()
 	os.MkdirAll(filepath.Join(dir, ".git"), 0755)
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Name: "test",
 			Path: "/path",
@@ -988,8 +1050,8 @@ func TestInstallRepo_installTaskError(t *testing.T) {
 				},
 			},
 		},
-	}
-	defer func() { context = nil }()
+	})
+	defer func() { storeContext(nil) }()
 
 	err := InstallRepo("repo1")
 	if err == nil {

--- a/src/internal/lib/profile.go
+++ b/src/internal/lib/profile.go
@@ -67,8 +67,8 @@ func SetProfile(name string) error {
 
 // GetProfile returns the currently active profile.
 func GetProfile() Profile {
-	if context != nil && !context.Profile.IsZero() {
-		return context.Profile
+	if ctx := loadContext(); ctx != nil && !ctx.Profile.IsZero() {
+		return ctx.Profile
 	}
 
 	name := viper.GetString(activeProfileKey)

--- a/src/internal/lib/profile_test.go
+++ b/src/internal/lib/profile_test.go
@@ -175,9 +175,9 @@ func TestSetAndGetProfile(t *testing.T) {
 func TestGetProfile_fromContext(t *testing.T) {
 	setupTestConfig(t)
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{Name: "ctx-profile", Path: "/ctx/path"},
-	}
+	})
 
 	got := GetProfile()
 	if got.Name != "ctx-profile" {
@@ -1290,29 +1290,29 @@ func TestForceLoad_singleRepoProfile(t *testing.T) {
 	if err := ForceLoad(); err != nil {
 		t.Fatalf("ForceLoad: %v", err)
 	}
-	if context == nil || context.Profile.Name != "mono" {
-		t.Fatalf("context.Profile.Name = %q, want mono", context.Profile.Name)
+	if loadContext() == nil || loadContext().Profile.Name != "mono" {
+		t.Fatalf("loadContext().Profile.Name = %q, want mono", loadContext().Profile.Name)
 	}
-	if !context.Profile.IsSingleRepo() {
+	if !loadContext().Profile.IsSingleRepo() {
 		t.Error("IsSingleRepo() = false on loaded profile")
 	}
-	if len(context.Profile.Repositories) != 1 || context.Profile.Repositories[0].Path != dir {
-		t.Errorf("Repositories = %+v, want one repo with path %q", context.Profile.Repositories, dir)
+	if len(loadContext().Profile.Repositories) != 1 || loadContext().Profile.Repositories[0].Path != dir {
+		t.Errorf("Repositories = %+v, want one repo with path %q", loadContext().Profile.Repositories, dir)
 	}
 	// Repo-level environments should be promoted to profile level so `raid env`
 	// can find them without a wrapping profile YAML.
-	if len(context.Profile.Environments) != 1 || context.Profile.Environments[0].Name != "dev" {
-		t.Errorf("Environments = %+v, want one named 'dev'", context.Profile.Environments)
+	if len(loadContext().Profile.Environments) != 1 || loadContext().Profile.Environments[0].Name != "dev" {
+		t.Errorf("Environments = %+v, want one named 'dev'", loadContext().Profile.Environments)
 	}
 	// Repo commands should have been merged into top-level commands.
 	found := false
-	for _, c := range context.Profile.Commands {
+	for _, c := range loadContext().Profile.Commands {
 		if c.Name == "greet" {
 			found = true
 		}
 	}
 	if !found {
-		t.Errorf("Commands missing 'greet': %+v", context.Profile.Commands)
+		t.Errorf("Commands missing 'greet': %+v", loadContext().Profile.Commands)
 	}
 }
 

--- a/src/internal/lib/session_test.go
+++ b/src/internal/lib/session_test.go
@@ -300,7 +300,7 @@ func TestShellSession_exportedVarFlowsToSetThenShell(t *testing.T) {
 	commandStdout = &buf
 	t.Cleanup(func() { commandStdout = origOut })
 
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Commands: []Command{{
 				Name: "test",
@@ -314,7 +314,7 @@ func TestShellSession_exportedVarFlowsToSetThenShell(t *testing.T) {
 				},
 			}},
 		},
-	}
+	})
 
 	if err := ExecuteCommand("test", nil, nil); err != nil {
 		t.Fatalf("ExecuteCommand error: %v", err)
@@ -338,7 +338,7 @@ func TestShellSession_earlyExitStillCapturesEnv(t *testing.T) {
 
 	// The script exports a variable then calls `exit 0` explicitly — the env
 	// dump must still happen via the EXIT trap, not the sequential append.
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Commands: []Command{{
 				Name: "early",
@@ -349,7 +349,7 @@ func TestShellSession_earlyExitStillCapturesEnv(t *testing.T) {
 				},
 			}},
 		},
-	}
+	})
 
 	var buf bytes.Buffer
 	origOut := commandStdout
@@ -373,7 +373,7 @@ func TestShellSession_setECapturesEnvBeforeFailure(t *testing.T) {
 
 	// With set -e, a failing command causes an immediate exit. The EXIT trap
 	// must still capture whatever was exported before the failure.
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Commands: []Command{{
 				Name: "sete",
@@ -382,7 +382,7 @@ func TestShellSession_setECapturesEnvBeforeFailure(t *testing.T) {
 				},
 			}},
 		},
-	}
+	})
 
 	// The command fails (false exits 1), but BEFORE_FAIL must be captured.
 	_ = ExecuteCommand("sete", nil, nil)
@@ -418,7 +418,7 @@ func TestShellSession_shellLocalVarNotExpandedByRaid(t *testing.T) {
 
 	// A shell-local variable ($LOCAL) is set and echoed within the SAME task.
 	// expandRaidForShell should leave $LOCAL intact so the shell resolves it.
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Commands: []Command{{
 				Name: "local",
@@ -427,7 +427,7 @@ func TestShellSession_shellLocalVarNotExpandedByRaid(t *testing.T) {
 				},
 			}},
 		},
-	}
+	})
 
 	if err := ExecuteCommand("local", nil, nil); err != nil {
 		t.Fatalf("ExecuteCommand error: %v", err)

--- a/src/internal/lib/task_runner.go
+++ b/src/internal/lib/task_runner.go
@@ -926,6 +926,17 @@ func execSetVar(task Task) error {
 		return liberrs.Newf(liberrs.CodeTaskFailed, liberrs.CategoryTask, "failed to write temp vars file: %v", err)
 	}
 
+	// Tighten perms BEFORE the rename so the final file lands at 0600
+	// atomically — godotenv.Write defaults to 0644 (world-readable),
+	// which is wrong for a file that holds raid vars (RAID_REPO_*_URL
+	// can be a clone URL, and user-defined Set values can be anything
+	// the project author treats as secret-ish). Chmod on the tempfile
+	// path: if it fails we abort before rename so we never leave a
+	// 0644 vars file on disk.
+	if err := os.Chmod(tmpName, 0600); err != nil {
+		return liberrs.Newf(liberrs.CodeTaskFailed, liberrs.CategoryTask, "failed to set vars file permissions: %v", err)
+	}
+
 	if err := os.Rename(tmpName, path); err != nil {
 		return liberrs.Newf(liberrs.CodeTaskFailed, liberrs.CategoryTask, "failed to replace vars file: %v", err)
 	}

--- a/src/internal/lib/task_runner.go
+++ b/src/internal/lib/task_runner.go
@@ -668,11 +668,12 @@ func execGroup(task Task) error {
 	if task.Ref == "" {
 		return liberrs.ArgInvalid("ref is required for Group task")
 	}
-	if context == nil || context.Profile.Groups == nil {
+	ctx := loadContext()
+	if ctx == nil || ctx.Profile.Groups == nil {
 		return liberrs.Newf(liberrs.CodeArgInvalid, liberrs.CategoryConfig, "no task_groups defined in the active profile")
 	}
 
-	tasks, ok := context.Profile.Groups[task.Ref]
+	tasks, ok := ctx.Profile.Groups[task.Ref]
 	if !ok {
 		return liberrs.Newf(liberrs.CodeTaskFailed, liberrs.CategoryTask, "task group '%s' not found in profile", task.Ref)
 	}

--- a/src/internal/lib/task_runner_extra_test.go
+++ b/src/internal/lib/task_runner_extra_test.go
@@ -70,14 +70,14 @@ func TestExecuteTask_prompt_readError(t *testing.T) {
 // --- Group parallel/retry group not found ---
 
 func TestExecuteTask_group_parallel_groupNotFound(t *testing.T) {
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Groups: map[string][]Task{
 				"other": {{Type: Shell, Cmd: "exit 0"}},
 			},
 		},
-	}
-	defer func() { context = nil }()
+	})
+	defer func() { storeContext(nil) }()
 
 	task := Task{Type: Group, Ref: "nonexistent", Parallel: true}
 	if err := ExecuteTask(task); err == nil {
@@ -86,14 +86,14 @@ func TestExecuteTask_group_parallel_groupNotFound(t *testing.T) {
 }
 
 func TestExecuteTask_group_retry_groupNotFound(t *testing.T) {
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Groups: map[string][]Task{
 				"other": {{Type: Shell, Cmd: "exit 0"}},
 			},
 		},
-	}
-	defer func() { context = nil }()
+	})
+	defer func() { storeContext(nil) }()
 
 	task := Task{Type: Group, Ref: "nonexistent", Attempts: 1}
 	if err := ExecuteTask(task); err == nil {
@@ -767,7 +767,7 @@ func TestExecuteTask_setVar_createFileError(t *testing.T) {
 // --- installRepo ---
 
 func TestInstallRepo_cloneError(t *testing.T) {
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Name: "test",
 			Path: "/path",
@@ -779,8 +779,8 @@ func TestInstallRepo_cloneError(t *testing.T) {
 				},
 			},
 		},
-	}
-	defer func() { context = nil }()
+	})
+	defer func() { storeContext(nil) }()
 
 	err := InstallRepo("badrepo")
 	if err == nil {

--- a/src/internal/lib/task_runner_extra_test.go
+++ b/src/internal/lib/task_runner_extra_test.go
@@ -299,6 +299,48 @@ func TestExecuteTask_setVar_storesInMemory(t *testing.T) {
 	}
 }
 
+// TestExecuteTask_setVar_writesFileMode0600 pins bug C2: the vars
+// file persists project-author secrets (Set values, scrubbed clone
+// URLs) and must not be world-readable. godotenv defaults to 0644;
+// the atomic write path chmods the tempfile down to 0600 before the
+// rename so the final file always lands at the tight mode.
+func TestExecuteTask_setVar_writesFileMode0600(t *testing.T) {
+	overrideRaidVarsPath(t)
+	if err := ExecuteTask(Task{Type: SetVar, Var: "RAID_PERM_TEST", Value: "secret"}); err != nil {
+		t.Fatalf("ExecuteTask(SetVar): %v", err)
+	}
+	info, err := os.Stat(raidVarsPath())
+	if err != nil {
+		t.Fatalf("stat vars file: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Errorf("vars file mode = %o, want 0600 (world-readable bits leak credentials/values)", mode)
+	}
+}
+
+// TestLoadRaidVars_tightensExistingFilePerms covers the migration
+// path: vars files written by earlier raid versions on disk at 0644
+// should be tightened to 0600 on the next load. Best-effort — chmod
+// failures don't block the load, so a foreign-owned or read-only-
+// filesystem file just keeps its old mode.
+func TestLoadRaidVars_tightensExistingFilePerms(t *testing.T) {
+	overrideRaidVarsPath(t)
+	path := raidVarsPath()
+	if err := os.WriteFile(path, []byte("LEGACY=value\n"), 0o644); err != nil {
+		t.Fatalf("seed legacy vars file: %v", err)
+	}
+
+	loadRaidVars()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Errorf("legacy file not tightened: mode = %o, want 0600", mode)
+	}
+}
+
 func TestExecuteTask_setVar_expandsValue(t *testing.T) {
 	overrideRaidVarsPath(t)
 	os.Setenv("RAID_BASE", "world")

--- a/src/internal/lib/task_runner_extra_test.go
+++ b/src/internal/lib/task_runner_extra_test.go
@@ -305,6 +305,13 @@ func TestExecuteTask_setVar_storesInMemory(t *testing.T) {
 // the atomic write path chmods the tempfile down to 0600 before the
 // rename so the final file always lands at the tight mode.
 func TestExecuteTask_setVar_writesFileMode0600(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// Windows file modes only toggle the read-only attribute via
+		// os.Chmod; POSIX permission bits don't round-trip through
+		// Stat().Mode().Perm(). The 0600 invariant is a Unix
+		// guarantee — Windows uses ACLs we don't manage here.
+		t.Skip("0600 perm bits aren't round-trippable on Windows")
+	}
 	overrideRaidVarsPath(t)
 	if err := ExecuteTask(Task{Type: SetVar, Var: "RAID_PERM_TEST", Value: "secret"}); err != nil {
 		t.Fatalf("ExecuteTask(SetVar): %v", err)
@@ -324,6 +331,11 @@ func TestExecuteTask_setVar_writesFileMode0600(t *testing.T) {
 // failures don't block the load, so a foreign-owned or read-only-
 // filesystem file just keeps its old mode.
 func TestLoadRaidVars_tightensExistingFilePerms(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// See TestExecuteTask_setVar_writesFileMode0600 — Windows
+		// doesn't preserve POSIX perm bits through os.Chmod.
+		t.Skip("0600 perm bits aren't round-trippable on Windows")
+	}
 	overrideRaidVarsPath(t)
 	path := raidVarsPath()
 	if err := os.WriteFile(path, []byte("LEGACY=value\n"), 0o644); err != nil {

--- a/src/internal/lib/task_runner_test.go
+++ b/src/internal/lib/task_runner_test.go
@@ -1042,7 +1042,7 @@ func TestExecuteTask_condition_cmd_fails(t *testing.T) {
 // --- Group tasks ---
 
 func TestExecuteTask_group_noContext(t *testing.T) {
-	context = nil
+	storeContext(nil)
 	task := Task{Type: Group, Ref: "mygroup"}
 	err := ExecuteTask(task)
 	if err == nil {
@@ -1051,8 +1051,8 @@ func TestExecuteTask_group_noContext(t *testing.T) {
 }
 
 func TestExecuteTask_group_noGroups(t *testing.T) {
-	context = &Context{Profile: Profile{}}
-	defer func() { context = nil }()
+	storeContext(&Context{Profile: Profile{}})
+	defer func() { storeContext(nil) }()
 
 	task := Task{Type: Group, Ref: "mygroup"}
 	err := ExecuteTask(task)
@@ -1062,14 +1062,14 @@ func TestExecuteTask_group_noGroups(t *testing.T) {
 }
 
 func TestExecuteTask_group_missingRef(t *testing.T) {
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Groups: map[string][]Task{
 				"other": {{Type: Shell, Cmd: "exit 0"}},
 			},
 		},
-	}
-	defer func() { context = nil }()
+	})
+	defer func() { storeContext(nil) }()
 
 	task := Task{Type: Group, Ref: "missing"}
 	err := ExecuteTask(task)
@@ -1083,7 +1083,7 @@ func TestExecuteTask_group_missingRef(t *testing.T) {
 
 func TestExecuteTask_group_success(t *testing.T) {
 	marker := filepath.Join(t.TempDir(), "group-ran")
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Groups: map[string][]Task{
 				"mygroup": {
@@ -1091,8 +1091,8 @@ func TestExecuteTask_group_success(t *testing.T) {
 				},
 			},
 		},
-	}
-	defer func() { context = nil }()
+	})
+	defer func() { storeContext(nil) }()
 
 	task := Task{Type: Group, Ref: "mygroup"}
 	if err := ExecuteTask(task); err != nil {
@@ -1104,7 +1104,7 @@ func TestExecuteTask_group_success(t *testing.T) {
 }
 
 func TestExecuteTask_group_propagatesFailure(t *testing.T) {
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Groups: map[string][]Task{
 				"failgroup": {
@@ -1112,8 +1112,8 @@ func TestExecuteTask_group_propagatesFailure(t *testing.T) {
 				},
 			},
 		},
-	}
-	defer func() { context = nil }()
+	})
+	defer func() { storeContext(nil) }()
 
 	task := Task{Type: Group, Ref: "failgroup"}
 	if err := ExecuteTask(task); err == nil {
@@ -1506,7 +1506,7 @@ func TestExecuteTask_prompt_headlessOverEnvVar(t *testing.T) {
 // --- Group parallel mode ---
 
 func TestExecuteTask_group_parallel_noContext(t *testing.T) {
-	context = nil
+	storeContext(nil)
 	task := Task{Type: Group, Ref: "mygroup", Parallel: true}
 	if err := ExecuteTask(task); err == nil {
 		t.Fatal("expected error when context is nil, got nil")
@@ -1523,7 +1523,7 @@ func TestExecuteTask_group_parallel_missingRef(t *testing.T) {
 func TestExecuteTask_group_parallel_success(t *testing.T) {
 	markerA := filepath.Join(t.TempDir(), "a")
 	markerB := filepath.Join(t.TempDir(), "b")
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Groups: map[string][]Task{
 				"workers": {
@@ -1532,8 +1532,8 @@ func TestExecuteTask_group_parallel_success(t *testing.T) {
 				},
 			},
 		},
-	}
-	defer func() { context = nil }()
+	})
+	defer func() { storeContext(nil) }()
 
 	task := Task{Type: Group, Ref: "workers", Parallel: true}
 	if err := ExecuteTask(task); err != nil {
@@ -1547,7 +1547,7 @@ func TestExecuteTask_group_parallel_success(t *testing.T) {
 }
 
 func TestExecuteTask_group_parallel_propagatesFailure(t *testing.T) {
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Groups: map[string][]Task{
 				"broken": {
@@ -1555,8 +1555,8 @@ func TestExecuteTask_group_parallel_propagatesFailure(t *testing.T) {
 				},
 			},
 		},
-	}
-	defer func() { context = nil }()
+	})
+	defer func() { storeContext(nil) }()
 
 	task := Task{Type: Group, Ref: "broken", Parallel: true}
 	if err := ExecuteTask(task); err == nil {
@@ -1574,7 +1574,7 @@ func TestExecuteTask_group_retry_missingRef(t *testing.T) {
 }
 
 func TestExecuteTask_group_retry_noContext(t *testing.T) {
-	context = nil
+	storeContext(nil)
 	task := Task{Type: Group, Ref: "mygroup", Attempts: 1}
 	if err := ExecuteTask(task); err == nil {
 		t.Fatal("expected error when context is nil, got nil")
@@ -1583,14 +1583,14 @@ func TestExecuteTask_group_retry_noContext(t *testing.T) {
 
 func TestExecuteTask_group_retry_succeedsOnFirstAttempt(t *testing.T) {
 	marker := filepath.Join(t.TempDir(), "ran")
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Groups: map[string][]Task{
 				"work": {{Type: Shell, Cmd: "echo done > " + marker}},
 			},
 		},
-	}
-	defer func() { context = nil }()
+	})
+	defer func() { storeContext(nil) }()
 
 	task := Task{Type: Group, Ref: "work", Attempts: 3}
 	if err := ExecuteTask(task); err != nil {
@@ -1602,14 +1602,14 @@ func TestExecuteTask_group_retry_succeedsOnFirstAttempt(t *testing.T) {
 }
 
 func TestExecuteTask_group_retry_exhaustsAllAttempts(t *testing.T) {
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Groups: map[string][]Task{
 				"always-fail": {{Type: Shell, Cmd: "exit 1"}},
 			},
 		},
-	}
-	defer func() { context = nil }()
+	})
+	defer func() { storeContext(nil) }()
 
 	task := Task{Type: Group, Ref: "always-fail", Attempts: 2, Delay: "1ms"}
 	err := ExecuteTask(task)
@@ -1622,14 +1622,14 @@ func TestExecuteTask_group_retry_exhaustsAllAttempts(t *testing.T) {
 }
 
 func TestExecuteTask_group_retry_invalidDelay(t *testing.T) {
-	context = &Context{
+	storeContext(&Context{
 		Profile: Profile{
 			Groups: map[string][]Task{
 				"work": {{Type: Shell, Cmd: "exit 0"}},
 			},
 		},
-	}
-	defer func() { context = nil }()
+	})
+	defer func() { storeContext(nil) }()
 
 	task := Task{Type: Group, Ref: "work", Attempts: 1, Delay: "not-a-duration"}
 	if err := ExecuteTask(task); err == nil {

--- a/src/internal/telemetry/prompt.go
+++ b/src/internal/telemetry/prompt.go
@@ -57,12 +57,16 @@ var isInteractiveFn = func() bool {
 //
 //  1. **Persistent skip** — long-term reasons to be non-interactive:
 //     `--yes` / `--headless` / `RAID_HEADLESS=1`, `DO_NOT_TRACK=1`,
-//     stdin isn't a TTY (CI, pipes, agent hosts), build has no
-//     API key, already decided. These persist `decided=off` so
-//     future runs from the same machine don't re-attempt the
-//     prompt logic. Rationale: a host that's non-interactive today
-//     is probably non-interactive tomorrow; re-prompting on every
-//     run is noise.
+//     stdin isn't a TTY (CI, pipes, agent hosts), already decided.
+//     These persist `decided=off` so future runs from the same
+//     machine don't re-attempt the prompt logic. Rationale: a host
+//     that's non-interactive today is probably non-interactive
+//     tomorrow; re-prompting on every run is noise.
+//
+//     Dev / no-API-key builds short-circuit before reaching this
+//     tier — there's nothing to opt out of, so consent state stays
+//     untouched and a later release-build run on the same machine
+//     will still get a fresh prompt.
 //
 //  2. **Transient skip** — per-invocation reasons that don't reflect
 //     the user's long-term posture: `--json` (machine-readable

--- a/src/internal/telemetry/prompt.go
+++ b/src/internal/telemetry/prompt.go
@@ -53,20 +53,28 @@ var isInteractiveFn = func() bool {
 // appropriate. Returns the resolved outcome so the caller can fire
 // follow-up events.
 //
-// Skip conditions (each → PromptSkipped + consent persisted off):
-//   - DO_NOT_TRACK env var set
-//   - Consent already decided in a prior invocation
-//   - Build has no API key (telemetry is dead code anyway)
-//   - Stdin isn't a TTY (CI, pipes, agent hosts)
-//   - skipInteractive is true (raid invoked with --yes/--headless,
-//     or for an info command like `--help`, or for a subcommand
-//     that itself manages telemetry like `raid telemetry on`)
+// Two skip tiers, by design:
 //
-// The skip-and-persist behavior matches the user-confirmed scope:
-// non-interactive contexts get the same "off forever, never
-// prompt again" treatment so a later interactive run also stays
-// quiet unless the user runs `raid telemetry on` explicitly.
-func MaybePromptForConsent(skipInteractive bool) PromptResult {
+//  1. **Persistent skip** — long-term reasons to be non-interactive:
+//     `--yes` / `--headless` / `RAID_HEADLESS=1`, `DO_NOT_TRACK=1`,
+//     stdin isn't a TTY (CI, pipes, agent hosts), build has no
+//     API key, already decided. These persist `decided=off` so
+//     future runs from the same machine don't re-attempt the
+//     prompt logic. Rationale: a host that's non-interactive today
+//     is probably non-interactive tomorrow; re-prompting on every
+//     run is noise.
+//
+//  2. **Transient skip** — per-invocation reasons that don't reflect
+//     the user's long-term posture: `--json` (machine-readable
+//     output mode for one command). The prompt is suppressed but
+//     no consent state is written, so a later interactive run
+//     still gets prompted. Rationale: piping one command through
+//     `--json` is a momentary tool choice, not an opt-out signal.
+//
+// The split exists because conflating the two caused a real bug
+// where `raid context --json | jq` silently opted the user out
+// forever. Callers must classify their skip signal correctly.
+func MaybePromptForConsent(skipPersistent, skipTransient bool) PromptResult {
 	if APIKey == "" {
 		return PromptSkipped
 	}
@@ -77,8 +85,18 @@ func MaybePromptForConsent(skipInteractive bool) PromptResult {
 	if LoadState().Decided {
 		return PromptSkipped
 	}
-	if skipInteractive || !isInteractiveFn() {
+	// Persistent skip or non-TTY: record decided=off so the prompt
+	// doesn't re-fire on subsequent runs. Checked BEFORE transient
+	// so a caller passing both (e.g. `--yes --json` together) gets
+	// the stronger "persist" outcome — not a state-leaving transient
+	// skip that resurrects the prompt on the next run.
+	if skipPersistent || !isInteractiveFn() {
 		_ = SetDecidedOff()
+		return PromptSkipped
+	}
+	// Transient skip: skip without persisting; the next interactive
+	// run without the transient signal still gets prompted.
+	if skipTransient {
 		return PromptSkipped
 	}
 

--- a/src/internal/telemetry/telemetry_test.go
+++ b/src/internal/telemetry/telemetry_test.go
@@ -515,7 +515,7 @@ func TestPreviewPayload_redactsAPIKey(t *testing.T) {
 func TestMaybePromptForConsent_skipsWhenAPIKeyEmpty(t *testing.T) {
 	setupTestEnv(t)
 	APIKey = ""
-	got := MaybePromptForConsent(false)
+	got := MaybePromptForConsent(false, false)
 	if got != PromptSkipped {
 		t.Errorf("outcome = %v, want PromptSkipped", got)
 	}
@@ -527,7 +527,7 @@ func TestMaybePromptForConsent_skipsWhenAPIKeyEmpty(t *testing.T) {
 func TestMaybePromptForConsent_skipsAndPersistsOffOnNonTTY(t *testing.T) {
 	setupTestEnv(t)
 	isInteractiveFn = func() bool { return false }
-	got := MaybePromptForConsent(false)
+	got := MaybePromptForConsent(false, false)
 	if got != PromptSkipped {
 		t.Errorf("outcome = %v, want PromptSkipped", got)
 	}
@@ -542,7 +542,7 @@ func TestMaybePromptForConsent_skipsAndPersistsOffOnNonTTY(t *testing.T) {
 func TestMaybePromptForConsent_skipsAndPersistsOffOnHeadless(t *testing.T) {
 	setupTestEnv(t)
 	isInteractiveFn = func() bool { return true }
-	got := MaybePromptForConsent(true) // skipInteractive=true (e.g. --yes)
+	got := MaybePromptForConsent(true, false) // skipPersistent=true (e.g. --yes)
 	if got != PromptSkipped {
 		t.Errorf("outcome = %v, want PromptSkipped", got)
 	}
@@ -551,11 +551,54 @@ func TestMaybePromptForConsent_skipsAndPersistsOffOnHeadless(t *testing.T) {
 	}
 }
 
+// TestMaybePromptForConsent_transientSkipDoesNotPersist pins the two-tier
+// skip contract. A transient skip signal (today: --json) must suppress
+// the prompt for the current invocation without writing consent state,
+// so a later interactive run without --json still gets prompted. The
+// prior single-bool API conflated these and silently opted users out
+// for life after one `raid context --json | jq` invocation.
+func TestMaybePromptForConsent_transientSkipDoesNotPersist(t *testing.T) {
+	setupTestEnv(t)
+	isInteractiveFn = func() bool { return true }
+	got := MaybePromptForConsent(false, true) // skipTransient=true (e.g. --json)
+	if got != PromptSkipped {
+		t.Errorf("outcome = %v, want PromptSkipped", got)
+	}
+	if LoadState().Decided {
+		t.Error("transient skip should NOT persist consent state — bug C1 regression")
+	}
+}
+
+// TestMaybePromptForConsent_transientSkipDoesNotOverridePersistent
+// confirms the ordering: when both signals are set, persistent wins
+// (state persisted). Belt-and-suspenders against future callers that
+// might pass both.
+func TestMaybePromptForConsent_transientSkipDoesNotOverridePersistent(t *testing.T) {
+	setupTestEnv(t)
+	isInteractiveFn = func() bool { return true }
+	got := MaybePromptForConsent(false, true)
+	if got != PromptSkipped {
+		t.Fatalf("outcome = %v, want PromptSkipped", got)
+	}
+	if LoadState().Decided {
+		t.Fatal("transient-only skip persisted state; aborting subsequent assertions")
+	}
+
+	// Now flip persistent on for the second call — must persist.
+	got = MaybePromptForConsent(true, true)
+	if got != PromptSkipped {
+		t.Errorf("outcome = %v, want PromptSkipped", got)
+	}
+	if !LoadState().Decided {
+		t.Error("persistent skip should persist even when transient also true")
+	}
+}
+
 func TestMaybePromptForConsent_skipsWhenDoNotTrack(t *testing.T) {
 	setupTestEnv(t)
 	isInteractiveFn = func() bool { return true }
 	os.Setenv(DoNotTrackEnvVar, "1")
-	got := MaybePromptForConsent(false)
+	got := MaybePromptForConsent(false, false)
 	if got != PromptSkipped {
 		t.Errorf("outcome = %v, want PromptSkipped", got)
 	}
@@ -567,7 +610,7 @@ func TestMaybePromptForConsent_skipsWhenAlreadyDecided(t *testing.T) {
 		t.Fatal(err)
 	}
 	isInteractiveFn = func() bool { return true }
-	got := MaybePromptForConsent(false)
+	got := MaybePromptForConsent(false, false)
 	if got != PromptSkipped {
 		t.Errorf("outcome = %v, want PromptSkipped (already decided)", got)
 	}
@@ -579,7 +622,7 @@ func TestMaybePromptForConsent_acceptsOnYes(t *testing.T) {
 	r := strings.NewReader("y\n")
 	promptInFn = func() io.Reader { return r }
 	promptOutFn = func() io.Writer { return io.Discard }
-	got := MaybePromptForConsent(false)
+	got := MaybePromptForConsent(false, false)
 	if got != PromptAccepted {
 		t.Errorf("outcome = %v, want PromptAccepted", got)
 	}
@@ -595,7 +638,7 @@ func TestMaybePromptForConsent_declinesOnEmpty(t *testing.T) {
 	r := strings.NewReader("\n")
 	promptInFn = func() io.Reader { return r }
 	promptOutFn = func() io.Writer { return io.Discard }
-	got := MaybePromptForConsent(false)
+	got := MaybePromptForConsent(false, false)
 	if got != PromptDeclined {
 		t.Errorf("outcome = %v, want PromptDeclined (capital-N default)", got)
 	}
@@ -616,7 +659,7 @@ func TestMaybePromptForConsent_explainerThenAccept(t *testing.T) {
 	r := strings.NewReader("?\ny\n")
 	promptInFn = func() io.Reader { return r }
 	promptOutFn = func() io.Writer { return io.Discard }
-	got := MaybePromptForConsent(false)
+	got := MaybePromptForConsent(false, false)
 	if got != PromptAccepted {
 		t.Errorf("outcome = %v, want PromptAccepted after explainer", got)
 	}
@@ -646,7 +689,7 @@ func TestMaybePromptForConsent_declineThenConsentToOptOutEvent(t *testing.T) {
 	defer srv.Close()
 	CaptureEndpoint = srv.URL
 
-	got := MaybePromptForConsent(false)
+	got := MaybePromptForConsent(false, false)
 	if got != PromptDeclined {
 		t.Errorf("outcome = %v, want PromptDeclined", got)
 	}
@@ -678,7 +721,7 @@ func TestMaybePromptForConsent_declineRefuseOptOutEventSendsNothing(t *testing.T
 	defer srv.Close()
 	CaptureEndpoint = srv.URL
 
-	got := MaybePromptForConsent(false)
+	got := MaybePromptForConsent(false, false)
 	if got != PromptDeclined {
 		t.Errorf("outcome = %v, want PromptDeclined", got)
 	}
@@ -707,7 +750,7 @@ func TestMaybePromptForConsent_declineEmptyFollowUpSendsNothing(t *testing.T) {
 	defer srv.Close()
 	CaptureEndpoint = srv.URL
 
-	if got := MaybePromptForConsent(false); got != PromptDeclined {
+	if got := MaybePromptForConsent(false, false); got != PromptDeclined {
 		t.Errorf("outcome = %v, want PromptDeclined", got)
 	}
 	if h := atomic.LoadInt32(&hits); h != 0 {
@@ -729,7 +772,7 @@ func TestMaybePromptForConsent_acceptSkipsFollowUp(t *testing.T) {
 	out := &strings.Builder{}
 	promptOutFn = func() io.Writer { return out }
 
-	got := MaybePromptForConsent(false)
+	got := MaybePromptForConsent(false, false)
 	if got != PromptAccepted {
 		t.Errorf("outcome = %v, want PromptAccepted", got)
 	}

--- a/src/raid/raid.go
+++ b/src/raid/raid.go
@@ -117,6 +117,14 @@ func GetRepos() []lib.Repo {
 	return lib.GetRepos()
 }
 
+// ScrubURL strips userinfo (`user:password@`) from an HTTPS-style URL
+// so an embedded clone-time credential never gets persisted or
+// surfaced through MCP. SSH-style `git@host:repo.git` URLs and
+// unparseable inputs pass through unchanged. See lib.ScrubURL.
+func ScrubURL(raw string) string {
+	return lib.ScrubURL(raw)
+}
+
 // QuietGetCommands performs a best-effort, read-only profile load and returns
 // the available commands. It does not create config files or emit warnings, and
 // returns nil if the config is absent or loading fails.

--- a/src/resources/app.properties
+++ b/src/resources/app.properties
@@ -1,2 +1,2 @@
-version=0.17.0
+version=0.17.1
 environment=development


### PR DESCRIPTION
## Summary

Fixes the three Critical findings from the pre-v1.0 review. Three commits, one PR — read each commit independently. No behavior change for any existing happy path; all three are correctness/security bugs that the review caught and the test suite now pins.

## C1 — `--json` no longer kills the telemetry consent prompt

[commit](../../commit/6ee4c7e)

The first-run consent prompt previously persisted `decided=off` on ANY skip signal — including transient ones like `--json`. A user who ran `raid context --json | jq` once was silently opted out of telemetry for life, never seeing the prompt in any future interactive run. That's a real privacy + UX bug.

Split `MaybePromptForConsent` into two skip tiers:
- **Persistent** (`--yes` / `--headless` / `RAID_HEADLESS` / non-TTY / `DO_NOT_TRACK`): long-term \"this host is non-interactive\" signals → persist `decided=off`.
- **Transient** (`--json`): per-invocation tool choice → skip the prompt without writing state.

Precedence: persistent wins when both are set. Regression test pins the contract.

## C2 — credential leak via repo URLs in `~/.raid/vars`

[commit](../../commit/08ed04a)

Two related changes:

1. **`setRepoVars` scrubs userinfo from URLs.** A profile YAML using the common `https://user:token@github.com/...` clone-URL pattern no longer persists the credential to `~/.raid/vars`, no longer surfaces it through the MCP `raid://workspace/vars` resource, and no longer lands verbatim in `$RAID_REPO_<NAME>_URL` for subprocesses. SSH-style `git@host:repo.git` and unparseable inputs pass through unchanged. Re-exported as `raid.ScrubURL` and applied in the MCP `raid_list_repos` handler.

2. **`~/.raid/vars` written 0600, not 0644.** `execSetVar`'s atomic write chmods the tempfile to 0600 before the rename so the final file lands at the tight mode regardless of godotenv's 0644 default. `loadRaidVars` best-effort tightens existing 0644 files on next load for migration.

## C3 — atomic.Pointer for the global workspace context

[commit](../../commit/9a9650f)

The package-global `context *Context` in `src/internal/lib` was read concurrently by MCP read handlers (`raid_list_repos`, `raid_describe_repo`, …) while mutating handlers (`raid_install`, `raid_env_switch`) called `ForceLoad` which rewrote the pointer. mcp-go dispatches tool calls from a **5-worker pool** (verified: `mcp-go@v0.49.0/server/stdio.go:403`), so the reader/writer interleave was a real undefined-behavior race.

Replaced with `atomic.Pointer[Context]`. Reads go through `loadContext()`, writes through `storeContext()`. The value is always wholly replaced (never partially mutated) so the atomic pointer is the right primitive — zero contention on the read hot path, well-defined swap semantics on writes.

Mechanical sweep across 15 production read sites + 89 test sites. New `TestContextRaceForceLoadVsReads` stresses the interleave with 8 concurrent readers + 1 writer; the race detector enforces the contract.

## Test plan

- [x] `go test ./... -race` — all packages green
- [x] `TestContextRaceForceLoadVsReads` passes 3x in a row under `-race`
- [x] `TestMaybePromptForConsent_transientSkipDoesNotPersist` pins C1
- [x] `TestMaybePromptForConsent_transientSkipDoesNotOverridePersistent` pins precedence
- [x] `TestSetRepoVars_scrubsCredentialsFromURL` + `TestScrubURL` (10 cases) pin C2 URL scrub
- [x] `TestExecuteTask_setVar_writesFileMode0600` + `TestLoadRaidVars_tightensExistingFilePerms` pin C2 file perms
- [x] `cd site && npm run build` — docs green (no doc changes here; verified no regressions)

## Things explicitly not in this PR

The High and Medium findings from the review (auxiliary writes bypassing outputMu, `isInfoCommand` positional match, profile-cmd JSON parity, list ordering, env merge semantics, etc.). Those are correctness/UX gaps but not blocker-shaped — happy to land them as a follow-up PR after v1 tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)