### PR TITLE
ci: pass POSTHOG_API_KEY through to release builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,3 +97,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}
+          # Injected via -X ldflag into src/internal/telemetry.APIKey by
+          # .goreleaser.yaml. Without this env wiring the ldflag resolves
+          # to the empty string and shipped binaries silently no-op every
+          # Capture call — telemetry would be dead code for release users.
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -79,3 +79,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}
+          # Injected via -X ldflag into src/internal/telemetry.APIKey by
+          # .goreleaser.preview.yaml. Without this env wiring the ldflag
+          # resolves to the empty string and preview binaries can't fire
+          # telemetry — keep parity with the stable channel so opted-in
+          # preview users contribute the same signal.
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}


### PR DESCRIPTION
## Summary

Caught during the v1.0 release-readiness check: both `.goreleaser.yaml` and `.goreleaser.preview.yaml` inject `POSTHOG_API_KEY` via `-X` ldflag into `src/internal/telemetry.APIKey` — but the deploy and preview workflows weren't passing the secret into the GoReleaser action's `env:` block.

Result before this PR: every released binary had `APIKey=\"\"` baked in, telemetry was silent dead code for everyone but dev builds (which never had a key anyway), and no opt-in user could fire events even if they tried. Confirmed live by checking the workflow files against the goreleaser configs.

Confirmed secret is set: `POSTHOG_API_KEY` is configured as a repo-level secret per your check.

## Change

Adds `POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}` to the GoReleaser step's `env:` block in both [.github/workflows/deploy.yml](.github/workflows/deploy.yml) (stable channel) and [.github/workflows/preview.yml](.github/workflows/preview.yml) (preview channel). Same shape as the existing `GITHUB_TOKEN` / `HOMEBREW_TOKEN` passthroughs.

## Validation

- The ldflag pattern in both goreleaser configs already uses `envOrDefault \"POSTHOG_API_KEY\" \"\"`, so missing-secret tolerance is preserved (dev / branch builds without the secret still produce a working empty-APIKey binary that no-ops telemetry).
- Existing `docs.yml` already wires the secret correctly — used as the reference pattern.
- No Go code changes; no test changes needed. The ldflag's effect is invisible to unit tests (they stub APIKey directly).

## Why this matters for v1.0

This needs to land before the v1.0.0 tag. Otherwise the first \"real\" telemetry-capable binary that ships will silently never send anything — opted-in users contribute zero signal, and the project gets a free \"opt-out rate looks 100%\" data point that's actually a CI bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)