### PR TITLE
fix(test): portable MkdirAll-failure path for Windows

### DIFF
--- a/site/docs/whats-new.mdx
+++ b/site/docs/whats-new.mdx
@@ -9,6 +9,12 @@ description: Feature-by-feature release notes for Raid.
 
 User-visible changes per release, latest first. For full commit history see the [GitHub releases page](https://github.com/8bitalex/raid/releases).
 
+## 0.17.3 — upcoming
+
+Test-only hotfix. No behavior change to the shipped binary.
+
+**`TestWriteIDExclusive_mkdirFailure` now passes on Windows.** The test pinned `writeIDExclusive`'s "MkdirAll fails → error returned" contract by passing `/dev/null/impossible/path/id` — a path that only forces `MkdirAll` to fail on POSIX, where `/dev/null` is a char-device file the kernel refuses to descend into. On Windows there is no `/dev/null`, so `MkdirAll` happily created `C:\dev\null\impossible\path\` and the test failed with no returned error. Replaced with a portable file-as-parent-dir trick (write a regular file, then pass a path that treats it as a directory component) which fails `MkdirAll` on both POSIX (ENOTDIR) and Windows (ERROR_DIRECTORY).
+
 ## 0.17.2 — upcoming
 
 Eighteen High and Medium pre-v1.0 review fixes. No new features; behavior changes are surgical and called out individually below.

--- a/src/internal/telemetry/telemetry_test.go
+++ b/src/internal/telemetry/telemetry_test.go
@@ -1064,9 +1064,24 @@ func TestPurgeID_alreadyAbsent(t *testing.T) {
 
 func TestWriteIDExclusive_mkdirFailure(t *testing.T) {
 	setupTestEnv(t)
-	_, err := writeIDExclusive("/dev/null/impossible/path/id", "test-id")
+	// Force MkdirAll to fail in a portable way: create a regular file
+	// and pass a path that treats it as a directory component. On
+	// POSIX this yields ENOTDIR; on Windows it yields ERROR_DIRECTORY
+	// / "the directory name is invalid". Either way MkdirAll returns
+	// non-nil, which is the contract the test pins.
+	//
+	// The previous version passed `/dev/null/impossible/path/id`,
+	// which only fails on POSIX (where /dev/null is a char-device
+	// file). On Windows there is no /dev/null and MkdirAll happily
+	// creates the chain under the current drive, so the test failed.
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0600); err != nil {
+		t.Fatalf("setup blocker file: %v", err)
+	}
+	_, err := writeIDExclusive(filepath.Join(blocker, "impossible", "id"), "test-id")
 	if err == nil {
-		t.Fatal("writeIDExclusive() with impossible path should error")
+		t.Fatal("writeIDExclusive() with file-as-parent-dir path should error")
 	}
 }
 

--- a/src/resources/app.properties
+++ b/src/resources/app.properties
@@ -1,2 +1,2 @@
-version=0.17.2
+version=0.17.3
 environment=development


### PR DESCRIPTION
## Summary

Fixes the Windows CI failure on `TestWriteIDExclusive_mkdirFailure` (added in #98).

The test asserts that `writeIDExclusive` returns an error when its initial `os.MkdirAll(filepath.Dir(path), 0700)` cannot create the parent directory. The old version forced that failure by passing `/dev/null/impossible/path/id` — which relies on `/dev/null` being a POSIX char-device file that `MkdirAll` refuses to descend into. On Windows there is no `/dev/null`, so `MkdirAll` happily creates `C:\dev\null\impossible\path\` and the test fails with no returned error.

The fix uses a portable trick: create a regular file via `t.TempDir()` + `os.WriteFile`, then pass a path that treats that file as a directory component. Both POSIX (ENOTDIR) and Windows (ERROR_DIRECTORY / "the directory name is invalid") refuse to descend into a regular file, so `MkdirAll` returns non-nil on both platforms.

Test-only change — no production code touched.

## Test plan

- [x] `go test ./src/internal/telemetry/ -run TestWriteIDExclusive_mkdirFailure -race` passes locally
- [ ] Windows CI on this PR turns green

🤖 Generated with [Claude Code](https://claude.com/claude-code)