### PR TITLE
chore: replace Product Hunt badge with "Star on GitHub" CTA

### DIFF
--- a/site/src/pages/index.module.css
+++ b/site/src/pages/index.module.css
@@ -202,19 +202,16 @@
   justify-content: center;
 }
 
-.productHuntBadge {
+.ctaSecondary {
+  width: 220px;
+  justify-content: center;
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  width: 220px;
-  height: 3rem;
+  gap: 0.5rem;
 }
 
-.productHuntBadge img {
-  width: 100%;
-  height: auto;
-  max-height: 100%;
-  display: block;
+.ctaIcon {
+  flex-shrink: 0;
 }
 
 @media screen and (max-width: 480px) {
@@ -225,16 +222,6 @@
 
   .buttons > * {
     width: 100%;
-  }
-
-  .productHuntBadge {
-    height: auto;
-    justify-content: center;
-  }
-
-  .productHuntBadge img {
-    width: 100%;
-    height: auto;
   }
 }
 

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -122,14 +122,20 @@ function HomepageHeader() {
             Get Started
           </Link>
           <a
-            href="https://www.producthunt.com/products/raid?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-raid"
+            href="https://github.com/8bitAlex/raid"
             target="_blank"
             rel="noopener noreferrer"
-            className={styles.productHuntBadge}>
-            <img
-              alt="Raid - Open-source development workflow orchestrator | Product Hunt"
-              src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1128226&theme=neutral&t=1776801713624"
-            />
+            className={clsx('button button--secondary button--lg', styles.ctaSecondary)}>
+            <svg
+              aria-hidden="true"
+              focusable="false"
+              viewBox="0 0 16 16"
+              width="20"
+              height="20"
+              className={styles.ctaIcon}>
+              <path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+            </svg>
+            Star on GitHub
           </a>
         </div>
         <img


### PR DESCRIPTION
## Summary

- Drops the Product Hunt embed badge from the landing page (`site/src/pages/index.tsx`)
- Adds a "Star on GitHub" secondary button in its place, sized to match the existing "Get Started" primary CTA (220px, `button--lg`)
- Links to https://github.com/8bitAlex/raid
- Cleans up the now-unused `.productHuntBadge` styles in `index.module.css` and the mobile media-query block that was specific to them

## Why

The PH badge was for launch. Replacing it with a permanent CTA that drives ongoing repo stars (an actual signal for an OSS project) makes more sense for the steady state.

## Test plan

- [ ] `npm run start` in `site/`, landing page shows "Star on GitHub" next to "Get Started", same height/width
- [ ] Click navigates to https://github.com/8bitAlex/raid in a new tab
- [ ] Mobile (≤480px) — buttons stack and stretch like before

🤖 Generated with [Claude Code](https://claude.com/claude-code)