### PR TITLE
docs(site): refactor landing-page features section

### DIFF
--- a/site/src/components/HomepageFeatures/index.tsx
+++ b/site/src/components/HomepageFeatures/index.tsx
@@ -2,7 +2,7 @@ import type {ReactNode} from 'react';
 import clsx from 'clsx';
 import Heading from '@theme/Heading';
 import TerminalWindow from '@site/src/components/TerminalWindow';
-import { Rocket, BookOpen, Users, Layers } from 'lucide-react';
+import { Boxes, Rocket, BookOpen, Users, Layers, Bot } from 'lucide-react';
 import styles from './styles.module.css';
 
 type CodeSample = {
@@ -19,6 +19,35 @@ type FeatureItem = {
 };
 
 const FeatureList: FeatureItem[] = [
+  {
+    icon: <Boxes size={28} />,
+    title: 'Your whole stack, one YAML profile',
+    description: (
+      <>
+        A <strong>profile</strong> is a version-controlled YAML file that
+        describes your entire development environment: the repositories to
+        clone, how to set them up, the environments to switch between, and the
+        commands your team runs. Check it in once — every teammate and every
+        machine gets the same setup.
+      </>
+    ),
+    code: {
+      language: 'yaml',
+      title: 'profile.raid.yml',
+      content: `name: platform
+
+repositories:
+  - name: api
+    url: git@github.com:my-org/api.git
+    path: ~/dev/api
+  - name: frontend
+    url: git@github.com:my-org/frontend.git
+    path: ~/dev/frontend
+  - name: worker
+    url: git@github.com:my-org/worker.git
+    path: ~/dev/worker`,
+    },
+  },
   {
     icon: <Rocket size={28} />,
     title: 'One-command onboarding',
@@ -108,8 +137,9 @@ Done in 1m 18s`,
     description: (
       <>
         <code>raid env staging</code> writes the right <code>.env</code> files
-        into every repo and runs environment tasks across all of them at once.
-        Switch contexts in seconds, not minutes.
+        into every repo and runs environment tasks across all of them at once —
+        profile-level tasks and each repo&apos;s own. Switch contexts in
+        seconds, not minutes.
       </>
     ),
     code: {
@@ -126,8 +156,34 @@ Done in 1m 18s`,
       - type: Shell
         cmd: docker compose up -d
       - type: Wait
-        url: http://localhost:5432
+        url: localhost:5432
         timeout: 30s`,
+    },
+  },
+  {
+    icon: <Bot size={28} />,
+    title: 'Built for AI agents',
+    description: (
+      <>
+        Raid is a first-class <strong>MCP server</strong>: <code>raid context
+        serve</code> gives Claude, Cursor, or any MCP client live workspace
+        context and tools to run your team&apos;s commands — with per-command{' '}
+        <code>agent</code> safety metadata controlling what runs unattended.
+        Headless mode (<code>--yes</code>) and <code>--json</code> output make
+        every command scriptable.
+      </>
+    ),
+    code: {
+      language: 'json',
+      title: 'mcp.json',
+      content: `{
+  "mcpServers": {
+    "raid": {
+      "command": "raid",
+      "args": ["context", "serve"]
+    }
+  }
+}`,
     },
   },
 ];


### PR DESCRIPTION
## Summary

Refactors the landing page's features section to fix the most common feedback: visitors don't understand what Raid actually does. Site-only change (one component), no Go code, no version bump.

**Added:**
- **"Your whole stack, one YAML profile"** — new lead feature that states the core model up front (a version-controlled profile describing repos, setup, environments, and team commands), with a `repositories:` sample. Wording mirrors the docs overview page so the story stays consistent on click-through.
- **"Built for AI agents"** — new closing feature covering the MCP server (`raid context serve`), per-command `agent` safety metadata, headless `--yes` mode, and `--json` output. Uses the same `mcp.json` sample as the context docs.

**Updated:**
- **"Environment switching"** — the `Wait` sample probed Postgres via `url: http://localhost:5432`, which raid treats as an HTTP health check and would always fail; corrected to the TCP form `localhost:5432`. Copy now notes that switching runs both profile-level and repo-level env tasks (accurate as of 0.18.0).

**Kept unchanged:** One-command onboarding, Tribal knowledge codified, and Shared team commands — each still accurate with a distinct value proposition.

The section now reads as a narrative: what Raid is → day-one value → why it stays useful → team workflows → environments → agents.

## Test plan

- [x] `npm run build` in `site/` — clean build, no broken links
- [x] Served the production build and visually verified the rendered section (six features, alternating layout, all code samples render)
- [x] All code samples checked against the actual schema/docs (`repositories` profile shape, TCP `Wait` form, documented `mcp.json` config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQgj678MygsxSX51uHsksW

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQgj678MygsxSX51uHsksW)_